### PR TITLE
Ls240 simulator

### DIFF
--- a/agents/lakeshore240/LS240_agent.py
+++ b/agents/lakeshore240/LS240_agent.py
@@ -221,9 +221,9 @@ class LS240_Agent:
                 }
 
                 for chan in self.module.channels:
-                    chan_string = "channel_{}".format(chan.channel_num)
-                    data['data'][chan_string + '_T'] = chan.get_reading(unit='K')
-                    data['data'][chan_string + '_V'] = chan.get_reading(unit='S')
+                    chan_string = "Channel {}".format(chan.channel_num)
+                    data['data'][chan_string + ' T'] = chan.get_reading(unit='K')
+                    data['data'][chan_string + ' V'] = chan.get_reading(unit='S')
 
                 self.agent.publish_to_feed('temperatures', data)
 

--- a/agents/lakeshore240/LS240_agent.py
+++ b/agents/lakeshore240/LS240_agent.py
@@ -1,28 +1,23 @@
-from ocs import ocs_agent, site_config, client_t
+from ocs import ocs_agent, site_config
 from socs.Lakeshore.Lakeshore240 import Module
-import random
 import time
-import threading
 import os
 from ocs.ocs_twisted import TimeoutLock
 from typing import Optional
 
 
-from autobahn.wamp.exception import ApplicationError
-
 class LS240_Agent:
 
-    def __init__(self, agent,
-                 port="/dev/ttyUSB0"):
+    def __init__(self, agent, port="/dev/ttyUSB0", f_sample=2.5):
 
-        self.agent = agent
+        self.agent: ocs_agent.OCSAgent = agent
         self.log = agent.log
         self.lock = TimeoutLock()
 
         self.port = port
         self.module: Optional[Module] = None
 
-        # self.thermometers = ['Channel {}'.format(i + 1) for i in range(num_channels)]
+        self.f_sample = f_sample
 
         self.initialized = False
         self.take_data = False
@@ -51,6 +46,10 @@ class LS240_Agent:
                 acquisition after initialization if True.
 
         """
+        if params is None:
+            params = {}
+
+        auto_acquire = params.get('auto_acquire', False)
 
         if self.initialized:
             return True, "Already Initialized Module"
@@ -70,7 +69,7 @@ class LS240_Agent:
         self.initialized = True
 
         # Start data acquisition if requested
-        if params.get('auto_acquire', False):
+        if auto_acquire:
             self.agent.start('acq')
 
         return True, 'Lakeshore module initialized.'
@@ -174,7 +173,11 @@ class LS240_Agent:
         if params is None:
             params = {}
 
-        f_sample = params.get('sampling_frequency', 2.5)
+        f_sample = params.get('sampling_frequency')
+        # If f_sample is None, use value passed to Agent init
+        if f_sample is None:
+            f_sample = self.f_sample
+
         sleep_time = 1/f_sample - 0.01
 
         with self.lock.acquire_timeout(0, job='acq') as acquired:
@@ -199,9 +202,9 @@ class LS240_Agent:
                     data['data'][chan_string + '_T'] = chan.get_reading(unit='K')
                     data['data'][chan_string + '_V'] = chan.get_reading(unit='S')
 
-                time.sleep(sleep_time)
-
                 self.agent.publish_to_feed('temperatures', data)
+
+                time.sleep(sleep_time)
 
             self.agent.feeds['temperatures'].flush_buffer()
 
@@ -217,19 +220,29 @@ class LS240_Agent:
         else:
             return False, 'acq is not currently running'
 
-if __name__ == '__main__':
+
+def main():
     parser = site_config.add_arguments()
 
     # Add options specific to this agent.
     pgroup = parser.add_argument_group('Agent Options')
     pgroup.add_argument('--serial-number')
     pgroup.add_argument('--port')
-    pgroup.add_argument('--num-channels', default='2')
     pgroup.add_argument('--mode')
-    pgroup.add_argument('--fake-data', default='0')
+    pgroup.add_argument('--sampling-frequency')
 
-    # Parse command line.
+    #Not used anymore, but we don't it to break the agent if these args are passed
+    pgroup.add_argument('--fake-data')
+    pgroup.add_argument('--num-channels')
+
     args = parser.parse_args()
+    if args.fake_data is not None:
+        print("WARNING: the --fake-data parameter is deprecated, please remove"
+              "your site-config file")
+
+    if args.num_channels is not None:
+        print("WARNING: the --num-channels parameter is deprecated, please remove"
+              "your site-config file")
 
     # Automatically acquire data if requested (default)
     init_params=False
@@ -241,17 +254,10 @@ if __name__ == '__main__':
     # Interpret options in the context of site_config.
     site_config.reparse_args(args, 'Lakeshore240Agent')
 
-    num_channels = int(args.num_channels)
-    fake_data = int(args.fake_data)
-
-    # Finds usb-port for device
-    # This should work for devices with the cp210x driver
-
+    device_port = None
     if args.port is not None:
         device_port = args.port
-    else:
-
-        device_port = ""
+    else:  # Tries to find correct USB port automatically
 
         # This exists if udev rules are setup properly for the 240s
         if os.path.exists('/dev/{}'.format(args.serial_number)):
@@ -265,10 +271,19 @@ if __name__ == '__main__':
                     print("Found port {}".format(device_port))
                     break
 
-    if device_port:
-        agent, runner = ocs_agent.init_site_agent(args)
+    if device_port is None:
+        print("Could not find device port for {}".format(args.serial_number))
+        return
 
-        therm = LS240_Agent(agent, port=device_port)
+    agent, runner = ocs_agent.init_site_agent(args)
+
+    kwargs = {
+        'port': device_port
+    }
+    if args.sampling_frequency is not None:
+        kwargs['f_sample'] = float(args.sampling_frequency)
+
+    therm = LS240_Agent(agent, **kwargs)
 
         agent.register_task('init_lakeshore', therm.init_lakeshore_task,
                             startup=init_params)
@@ -276,7 +291,9 @@ if __name__ == '__main__':
         agent.register_task('upload_cal_curve', therm.upload_cal_curve)
         agent.register_process('acq', therm.start_acq, therm.stop_acq)
 
-        runner.run(agent, auto_reconnect=True)
+    runner.run(agent, auto_reconnect=True)
 
-    else:
-        print("Could not find device with sn {}".format(args.serial_number))
+
+if __name__ == '__main__':
+    main()
+

--- a/docs/lakeshore240.rst
+++ b/docs/lakeshore240.rst
@@ -71,6 +71,27 @@ The following tasks are registered for the LS240 agent.
 .. autoclass:: agents.lakeshore240.LS240_agent.LS240_Agent
     :members: init_lakeshore, set_values, upload_cal_curve, acq
 
+Out of the box, the Lakeshore 240 channels are not enabled or configured
+to correctly measure thermometers. To enable, you can use the ``set_values`` task
+of the LS240 agent to configure a particular channel. Below is an example of a
+client script that uses the ``ocs.matched_client`` functionality to
+set channel 1 of a lakeshore module to read a diode::
+
+    from ocs.matched_client import MatchedClient
+
+    ls_client = MatchedClient("LSA24MA", args=[])
+
+    diode_params = {
+        'sensor': 1,
+        'autorange': 1,
+        'units': 3,
+        'enabled': 1,
+    }
+
+    ls_client.set_values.start(channel=1, name="CHWP_01", **diode_params)
+    ls_client.set_values.wait()
+
+
 Docker Configuration
 --------------------
 
@@ -95,3 +116,31 @@ The serial number will need to be updated in your configuration. The hostname
 should also match your configured host in your OCS configuration file. The
 site-hub and site-http need to point to your crossbar server, as described in
 the OCS documentation.
+
+
+Lakeshore240 Simulator
+-------------------------
+
+.. argparse::
+    :filename: ../socs/simulators/ls240_simulator.py
+    :func: make_parser
+    :prog: python3 ls240_simulator
+
+
+The Lakeshore240 Simulator is a tool that you can use to emulate a Lakeshore 240
+in order to test and debug agent functionality if you don't have a real device.
+It opens a socket port and interprets commands and queries in a similar manner
+to the real device. Not all lakeshore 240 commands actually do something currently,
+but you can set and read channel variables (even though they don't change anything)
+and read data from channels, which will currently return white noise centered around
+zero.
+
+Running ``python3 ls240_simulator.py`` will start the simulator and it will
+wait for a connection. To connect to it, you can use the same Lakeshore240.py
+module that is used to connect to the real device, but by providing
+``port=`tcp::/<address>:<port>'`` instead of the device port.
+For instance, if you run ``python3 ls240_simulator.py -p 1000``, you can connect
+by providing the Lakeshore240 module with ``port="tcp://localhost:1000"``.
+You can specify the port for a LS240 agent in the site-file or through the command line.
+Talking to the simulator from an agent inside a docker container hasn't yet been
+tried.

--- a/docs/lakeshore240.rst
+++ b/docs/lakeshore240.rst
@@ -9,6 +9,16 @@ Lakeshore 240
 The Lakeshore 240 is a 4-lead meausrement device used for readout of ROXes and
 Diodes at 1K and above.
 
+.. argparse::
+    :filename: ../agents/lakeshore240/LS240_agent.py
+    :func: make_parser
+    :prog: python3 LS240_agent.py
+
+
+    These options can be included in the site-config entry for the agent,
+    or can be specified manually from the command line.
+
+
 Driver Setup
 ------------
 The Lakeshore 240 requires USB drivers to be compiled for your machine. A
@@ -55,6 +65,11 @@ configuration block::
 
 Each device requires configuration under 'agent-instances'. See the OCS site
 configs documentation for more details.
+
+The following tasks are registered for the LS240 agent.
+
+.. autoclass:: agents.lakeshore240.LS240_agent.LS240_Agent
+    :members: init_lakeshore, set_values, upload_cal_curve, acq
 
 Docker Configuration
 --------------------

--- a/socs/Lakeshore/Lakeshore240.py
+++ b/socs/Lakeshore/Lakeshore240.py
@@ -91,7 +91,8 @@ class Module:
             Return response (within timeout) if message is a query.
         """
         if self.simulator:
-            self.com.send(msg.encode())
+            message_string = "{};".format(msg)
+            self.com.send(message_string.encode())
             resp = ''
             if '?' in msg:
                 resp = self.com.recv(BUFF_SIZE).decode()

--- a/socs/simulators/ls240_simulator.py
+++ b/socs/simulators/ls240_simulator.py
@@ -1,0 +1,262 @@
+import socket
+import argparse
+import numpy as np
+import logging
+import sys
+
+BUFF_SIZE = 1024
+
+class Lakeshore240_Simulator:
+
+    def __init__(self, port, num_channels=8, sn="LSSIM"):
+        self.log = logging.getLogger()
+
+        self.port = port
+        self.sn = sn
+        self.modname = "SIM_MODULE"
+
+        self.num_channels = num_channels
+        self.channels = [ChannelSim(i+1, "Channel {}".format(i+1))
+                         for i in range(self.num_channels)]
+
+        self.cmds = {
+            "*IDN?": self.get_idn,
+            "CRDG?": lambda x: self.get_reading(*x, unit='C'),
+            "FRDG?": lambda x: self.get_reading(*x, unit='F'),
+            "KRDG?": lambda x: self.get_reading(*x, unit='K'),
+            "SRDG?": lambda x: self.get_reading(*x, unit='S'),
+            "MODNAME": self.set_modname,
+            "MODNAME?": self.get_modname,
+            "INNAME": self.set_channel_name,
+            "INNAME?": self.get_channel_name,
+            "INTYPE": self.set_channel_intype,
+            "INTYPE?": self.get_channel_intype,
+            "SET_VALUE": self.set_channel_value
+        }
+
+    def set_modname(self, name):
+        self.modname = name
+
+    def get_modname(self):
+        return self.modname
+
+    def set_channel_value(self, chan, value):
+        chan_index = int(chan) - 1
+        if not 0 <= chan_index < self.num_channels:
+            self.log.warning(f"chan num must be between 1 and {self.num_channels}")
+            return
+
+        self.channels[chan_index].set_value(value)
+
+    def get_channel_intype(self, chan):
+        chan_index = int(chan) - 1
+        if not 0 <= chan_index < self.num_channels:
+            self.log.warning(f"chan num must be between 1 and {self.num_channels}")
+            return
+
+        return self.channels[chan_index].get_intype()
+
+    def set_channel_intype(self, chan, *args):
+        chan_index = int(chan) - 1
+        if not 0 <= chan_index < self.num_channels:
+            self.log.warning(f"chan num must be between 1 and {self.num_channels}")
+            return
+
+        args = map(int, args)
+        self.channels[chan_index].set_intype(*args)
+
+    def get_channel_name(self, chan):
+        if not 0 < int(chan) <= self.num_channels:
+            self.log.warning(f"chan num must be between 1 and {self.num_channels}")
+            return
+
+        return self.channels[int(chan)-1].name
+
+    def set_channel_name(self, chan, name):
+        if not 0 < int(chan) <= self.num_channels:
+            self.log.warning(f"chan num must be between 1 and {self.num_channels}")
+            return
+
+        self.channels[int(chan)-1].name = name
+
+    def run(self):
+
+        sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+
+        # Checks self.port plus the next ten to see if they're open
+        for p in range(self.port, self.port+10):
+            try:
+                self.log.info(f"Trying to listen on port {p}")
+                sock.bind(('localhost', p))
+                break
+            except OSError as e:
+                if e.errno == 48:
+                    self.log.warning(f"Address {p} is already in use")
+                else:
+                    raise(e)
+        else:
+            print(f"Could not connect to ports in {range(self.port, self.port+5)}")
+
+        sock.listen(1)
+        self.log.info('waiting for a connection....')
+        conn, client_address = sock.accept()
+        self.log.info(f"Made connection with {client_address}")
+        with conn:
+
+            # Main data loop
+            while True:
+                data = conn.recv(BUFF_SIZE)
+
+                if not data:
+                    self.log.info("Connection closed by client")
+                    break
+
+
+                # Only takes first command in case multiple commands are s
+                cmds = data.decode().split(';')
+
+                for c in cmds:
+                    cmd_list = c.strip().split(' ')
+
+                    if len(cmd_list) == 1:
+                        cmd, args = cmd_list[0], []
+                    else:
+                        cmd, args = cmd_list[0], cmd_list[1].split(',')
+                    self.log.debug(f"{cmd} {args}")
+
+                    try:
+                        cmd_fn = self.cmds.get(cmd)
+                        if cmd_fn is None:
+                            self.log.warning(f"Command {cmd} is not registered")
+                            continue
+
+                        resp = cmd_fn(*args)
+
+                    except TypeError as e:
+                        self.log.error(f"Command error: {e}")
+                        continue
+
+                    if resp is not None:
+                        conn.send(resp.encode())
+
+    def get_idn(self):
+        return ','.join([
+            "Lakeshore",
+            "LSSIM_{}P".format(self.num_channels),
+            self.sn,
+            'v0.0.0'
+        ])
+
+    def get_reading(self, channel_num, unit='S'):
+        chan_index = int(channel_num) - 1
+        if not 0 <= chan_index < self.num_channels:
+            self.log.warning(f"chan num must be between 1 and {self.num_channels}")
+            return
+
+        return self.channels[chan_index].get_reading(unit=unit)
+
+
+class ChannelSim:
+    def __init__(self, channel_num, name):
+        self.log = logging.getLogger()
+
+        self.channel_num = channel_num
+        self.name = name
+
+        self.sensor_type = 1
+        self.autorange = 0
+        self.range = 0
+        self.current_reversal = 0
+        self.units = 3
+        self.enabled = 0
+        self.value = 100
+
+    def get_intype(self):
+        return ','.join([
+            str(self.sensor_type),
+            str(self.autorange),
+            str(self.range),
+            str(self.current_reversal),
+            str(self.units),
+            str(self.enabled),
+        ])
+
+    def set_intype(self, sensor_type, autorange, rng, current_reversal, units, enabled):
+        if sensor_type in [1,2,3]:
+            self.log.debug(f"Setting sensor type to {sensor_type}")
+            self.sensor_type = sensor_type
+
+        if autorange in [0,1]:
+            self.autorange = autorange
+
+        if (self.sensor_type in [1,2] and rng in [0]) or \
+            (self.sensor_type == 3 and rng in range(9)):
+            self.range = rng
+
+        if self.sensor_type in [2,3] and current_reversal in [0,1]:
+            self.log.debug(f"Setting chan {self.channel_num} "
+                           f"current_reversal to {current_reversal}")
+            self.current_reversal = current_reversal
+
+        if units in [1,2,3,4]:
+            self.log.debug(f"Setting chan {self.channel_num} units to {units}")
+            self.units = units
+
+        if enabled in [0,1]:
+            self.log.debug(f"Setting chan {self.channel_num} enabled to {enabled}")
+            self.enabled = enabled
+
+    def set_value(self, value):
+        self.log.debug(f"Setting value to {value}")
+        self.value = float(value)
+
+    def get_reading(self, unit='S'):
+        if not self.enabled:
+            rv = 0
+        else:
+            rv = np.random.normal(self.value)
+
+        return str(rv)
+
+
+
+if __name__ == '__main__':
+    parser = argparse.ArgumentParser()
+    parser.add_argument('--port', type=int, default=1094)
+    parser.add_argument('--num-channels', type=int, default=8)
+    parser.add_argument('--sn', type=str, default='LS_SIM')
+    parser.add_argument('--log-file', type=str, default='log.txt')
+    parser.add_argument('--log-level',
+                        choices=['debug', 'info', 'warning', 'error'],
+                        default='info')
+
+
+    args = parser.parse_args()
+
+
+    log_level = {
+        'debug': logging.DEBUG,
+        'info': logging.INFO,
+        'warning': logging.WARNING,
+        'error': logging.ERROR
+    }[args.log_level]
+
+    format_string = '%(asctime)-15s [%(levelname)s]:  %(message)s'
+
+
+    logging.basicConfig(level=log_level, filename=args.log_file, format=format_string)
+
+    formatter = logging.Formatter(format_string)
+
+    log = logging.getLogger()
+
+    consoleHandler = logging.StreamHandler()
+    consoleHandler.setFormatter(formatter)
+
+    log.addHandler(consoleHandler)
+
+    ls = Lakeshore240_Simulator(args.port,
+                                num_channels=args.num_channels,
+                                sn=args.sn)
+
+    ls.run()


### PR DESCRIPTION
This PR adds a lakeshore240 simulator to socs/simulators, which emulates a lakeshore 240 device and can be controlled with the Lakeshore240.py module. To use it, you can run `python3 ls240_simulator.py` optionally specifying a port for it to use. When connecting the the  Lakeshore Module code, instead of giving the Module the usb port in the init function you can give it an address like `tcp://localhost:1094`, which will connect to a simulator running on port 1094. The simulator is not fully fleshed out yet, but most of the Lakeshore240 commands that we use have been implemented, with the exception of using calibration curves. Right now if you try to get data from it it'll just return white noise around a value that you can specify.

Now that we have this I took all of the fake_data functionality out of the LS240 agent, since it is kind of a pain to maintain both the fake and real functionality for each operation. I figured this would be ok since the fake_data_agent is now doing everything that I needed the fake_data option to test.

I also added a few command line arguments to the LS240 agent, such as `--port` which allows you to specify the port to connect to directly, which is necessary if you want to use the simulator. Also, if you set the `--mode` arg to `init` it will automatically initialize the device on startup, and if you set it to `acq` it will automatically initialize the device and start the data acquisition process. 

I'm planning on updating the documentation for the agent this weekend, but I figured I would start the PR so that you can start reviewing it whenever.