### PR TITLE
Lakeshore data acquisition autostart

### DIFF
--- a/agents/lakeshore240/LS240_agent.py
+++ b/agents/lakeshore240/LS240_agent.py
@@ -39,16 +39,17 @@ class LS240_Agent:
 
     # Task functions.
     def init_lakeshore_task(self, session, params=None):
-        """Perform first time setup of the Lakeshore 240 Module.
+        """init_lakeshore_task(params=None)
 
-        Parameters
-        ----------
-        params : dict
-            Parameters dictionary for passing parameters to task. Supports the
-            following keys:
+        Perform first time setup of the Lakeshore 240 Module.
 
-            - 'auto_acquire' (bool, optional: Default is False. Starts data
-              acquisition after initialization if True.
+        Args:
+            params (dict): Parameters dictionary for passing parameters to
+                task.
+
+        Parameters:
+            auto_acquire (bool, optional): Default is False. Starts data
+                acquisition after initialization if True.
 
         """
 

--- a/agents/lakeshore372/LS372_agent.py
+++ b/agents/lakeshore372/LS372_agent.py
@@ -8,13 +8,14 @@ from ocs import ocs_agent, site_config, client_t
 from socs.Lakeshore.Lakeshore372 import LS372
 
 class LS372_Agent:
-    """
-        Agent to connect to a single Lakeshore 372 device.
-        
-        Params:
-            name: Application Session
-            ip:  ip address of agent
-            fake_data: generates random numbers without connecting to LS if True.
+    """Agent to connect to a single Lakeshore 372 device.
+
+    Args:
+        name (ApplicationSession): ApplicationSession for the Agent.
+        ip (str): IP Address for the 372 device.
+        fake_data (bool, optional): generates random numbers without connecting
+            to LS if True.
+
     """
     def __init__(self, agent, name, ip, fake_data=False):
         self.lock = threading.Semaphore()
@@ -39,7 +40,6 @@ class LS372_Agent:
                                  agg_params=agg_params,
                                  buffer_time=1)
 
-
     def try_set_job(self, job_name):
         print(self.job, job_name)
         with self.lock:
@@ -54,18 +54,20 @@ class LS372_Agent:
             self.job = None
 
     def init_lakeshore_task(self, session, params=None):
-        """Perform first time setup of Lakeshore 372 communication.
+        """init_lakeshore_task(params=None)
 
-        Parameters
-        ----------
-        params : dict
-            Parameters dictionary for passing parameters to task. Supports the
-            following keys:
+        Perform first time setup of the Lakeshore 372 communication.
 
-            - 'auto_acquire' (bool, optional): Default is False. Starts data
-              acquisition after initialization if True.
+        Args:
+            params (dict): Parameters dictionary for passing parameters to
+                task.
+
+        Parameters:
+            auto_acquire (bool, optional): Default is False. Starts data
+                acquisition after initialization if True.
 
         """
+
         if params is None:
             params = {}
 

--- a/agents/lakeshore372/LS372_agent.py
+++ b/agents/lakeshore372/LS372_agent.py
@@ -1,4 +1,5 @@
 import random
+import argparse
 import time, threading
 import numpy as np
 import ocs
@@ -451,9 +452,13 @@ class LS372_Agent:
         self.set_job_done()
         return True, "Set {} display to {}, output to {}".format(heater, display, output)
 
-if __name__ == '__main__':
-    # Get the default ocs argument parser.
-    parser = site_config.add_arguments()
+def make_parser(parser=None):
+    """Build the argument parser for the Agent. Allows sphinx to automatically
+    build documentation based on this function.
+
+    """
+    if parser is None:
+        parser = argparse.ArgumentParser()
 
     # Add options specific to this agent.
     pgroup = parser.add_argument_group('Agent Options')
@@ -464,6 +469,14 @@ if __name__ == '__main__':
                         help='Set non-zero to fake data, without hardware.')
     pgroup.add_argument('--auto-acquire', type=bool, default=True,
                         help='Automatically start data acquisition on startup')
+
+    return parser
+
+if __name__ == '__main__':
+    # Get the default ocs argument parser.
+    site_parser = site_config.add_arguments()
+
+    parser = make_parser(site_parser)
 
     # Parse comand line.
     args = parser.parse_args()

--- a/docs/lakeshore240.rst
+++ b/docs/lakeshore240.rst
@@ -27,7 +27,7 @@ automatically when the 240s are connected to the computer.
 To install the drivers clone the ls240_drivers repository and run ``make`` to
 build the drivers::
 
-    $ git clone <drivers URL>
+    $ git clone https://github.com/simonsobs/ls240-drivers.git
     $ make
 
 Update the udev rules file, ``50-ls240.rules``, adding an entry for your

--- a/docs/lakeshore240.rst
+++ b/docs/lakeshore240.rst
@@ -56,10 +56,6 @@ configuration block::
 Each device requires configuration under 'agent-instances'. See the OCS site
 configs documentation for more details.
 
-Optional arguments::
-   'arguments': [['--fake-data', 1],
-                 ['--auto-acquire', False]]},
-
 Docker Configuration
 --------------------
 

--- a/docs/lakeshore240.rst
+++ b/docs/lakeshore240.rst
@@ -6,6 +6,59 @@
 Lakeshore 240
 =============
 
+The Lakeshore 240 is a 4-lead meausrement device used for readout of ROXes and
+Diodes at 1K and above.
+
+Driver Setup
+------------
+The Lakeshore 240 requires USB drivers to be compiled for your machine. A
+private repository, `ls240_drivers`, with the required drivers is available on
+the Simons Observatory Github. This repository provides some other helpful
+tools, including a set of udev rules for setting the device address
+automatically when the 240s are connected to the computer.
+
+.. note::
+    The 240 drivers are compiled for the specific kernel you are running at
+    installation. If your kernel is updated the drivers will no longer work.
+    The DKMS module provided by the `ls24_drivers` repository attempts to solve
+    this problem, but does not currently appear to work. Please report any
+    difficulty with the drivers to Brian.
+
+To install the drivers clone the ls240_drivers repository and run ``make`` to
+build the drivers::
+
+    $ git clone <drivers URL>
+    $ make
+
+Update the udev rules file, ``50-ls240.rules``, adding an entry for your
+devices' serial numbers, then run::
+
+    $ make install_udev
+
+If your devices were plugged in already you will need to unplug and replug them
+for the udev rules to properly recognize the devices and set the path and
+permissions appropriately. Once you complete this step they will be recongized
+on reboots, and the udev rules will not need to be reinstalled unless you add a
+new device.
+
+OCS Configuration
+-----------------
+
+To configure your Lakeshore 240 for use with OCS you need to add a
+Lakeshore240Agent block to your ocs configuration file. Here is an example
+configuration block::
+
+  {'agent-class': 'Lakeshore240Agent',
+   'instance-id': 'LSA22Z2',
+   'arguments': [['--serial-number', 'LSA22Z2'],
+                     ['--num-channels', 8]]},
+
+Each device requires configuration under 'agent-instances'. See the OCS site
+configs documentation for more details.
+
+Docker Configuration
+--------------------
+
 The Lakeshore 240 Agent can (and probably should) be configured to run in a
 Docker container. An example configuration is::
 

--- a/docs/lakeshore240.rst
+++ b/docs/lakeshore240.rst
@@ -51,10 +51,14 @@ configuration block::
   {'agent-class': 'Lakeshore240Agent',
    'instance-id': 'LSA22Z2',
    'arguments': [['--serial-number', 'LSA22Z2'],
-                     ['--num-channels', 8]]},
+                 ['--num-channels', 8]]},
 
 Each device requires configuration under 'agent-instances'. See the OCS site
 configs documentation for more details.
+
+Optional arguments::
+   'arguments': [['--fake-data', 1],
+                 ['--auto-acquire', False]]},
 
 Docker Configuration
 --------------------

--- a/docs/lakeshore372.rst
+++ b/docs/lakeshore372.rst
@@ -84,8 +84,14 @@ That should get you started with direct communication. The API is fairly full
 featured. For any feature requests for functionality that might be missing,
 please file a Github issue.
 
-API
----
+Agent API
+---------
+
+.. autoclass:: agents.lakeshore372.LS372_agent.LS372_Agent
+    :members: init_lakeshore_task
+
+Driver API
+----------
 
 For the API all methods should start with one of the following:
 

--- a/docs/lakeshore372.rst
+++ b/docs/lakeshore372.rst
@@ -8,106 +8,67 @@ Lakeshore 372
 
 The Lakeshore 372 (LS372) units are used for 100 mK and 1K thermometer readout.
 Basic functionality to interface and control an LS372 is provided by the
-``ocs.Lakeshore.Lakeshore372.py`` module.
+``socs.Lakeshore.Lakeshore372.py`` module.
 
-LS372 OCS Quickstart
---------------------
-To quickly get started acquiring data from a Lakeshore 372 with OCS perform the
-following starting in the ocs directory (each in a separate terminal):
-
-* Start the crossbar server::
-
-    $ cd example/
-    $ make run_crossbar
-
-* Configure the aggregator data frame and file durations.
-
-In ``agents/aggregator/aggregator_agent.py`` there is a method called
-``start_aggregate``, this contains the following lines::
-
-    time_per_frame = 60 * 10 # [s]
-    time_per_file  = 60 * 60  # [s]
-
-``time_per_frame`` indicates how often a Frame is flushed from memory to disk in
-the 3g file. The current amount is every 10 minutes. ``time_per_file`` indicates
-how often the file is closed out and a new one started. Currently this is every
-hour. Since we do not currently have a live monitoring system in place this is
-likely longer than you would like for the purposes of monitoring the data. You
-will not be able to open the g3 file until the file is closed, so you likely
-want to set both the frame and file duration to something short. The trade off
-here is we will generate many files.
-
-* Start the data aggregator agent::
-
-    $ cd agents/aggregator/
-    $ python3 aggregator_agent.py
-
-* Configure the LS372 agent by putting the correct IP address in
-  ``agents/thermometry/LS372_agent.py``::
-
-    therm = LS372_Agent("LS372A", "10.10.10.2" , fake_data=False)
-
-* Start the LS372 Agent::
-
-    $ cd agents/thermometry/
-    $ python3 LS372_agent.py
-
-* Run the ``therm_and_agg_ctrl.py`` client. This will collect 30 seconds of data.
-* You can change this in the client either by extending the ``sleep_time`` or by replacing the loop and data acquisiton and aggregator stop commands with a small sleep time, for instance, replacing::
-
-    sleep_time = 10
-    for i in range(sleep_time):
-        print('sleeping for {:d} more seconds'.format(sleep_time - i))
-        yield client_t.dsleep(1)
-
-
-    print("Stopping Data Acquisition")
-    yield get_data.stop()
-    yield get_data.wait()
-
-    print("Stopping Data Aggregator")
-    yield aggregate.stop()
-    yield aggregate.wait()
-
-with::
-
-    yield client_t.dsleep(.1)
-
-This will cause the client to run the data acquisition and close. You will see
-the data collected printed to the terminal ``LS372_agent.py`` is running. Data
-is saved to ``ocs/agents/aggregator/data/``.
-
-Sampling rate can be adjusted by changing the sleep time in ``LS372_agent.py``
-on line 91::
-
-    active_channel = self.module.get_active_channel()
-    data[active_channel.name] = (time.time(), self.module.get_temp(unit='S', chan=active_channel.channel_num))
-    time.sleep(.01)
-
-Opening a 3g File
+OCS Configuration
 -----------------
-This quick script will open the passed in 3g file::
 
-    from spt3g import core
-    import sys
+To configure your Lakeshore 372 for use with OCS you need to add a
+Lakeshore372Agent block to your ocs configuration file. Here is an example
+configuration block::
 
-    frames = [fr for fr in core.G3File(sys.argv[1])]
+  {'agent-class': 'Lakeshore372Agent',
+   'instance-id': 'LSA22YG',
+   'arguments': [['--serial-number', 'LSA22YG'],
+                 ['--ip-address', '10.10.10.2']]},
 
-Save it (say as ``open.py``) and run with::
+Each device requires configuration under 'agent-instances'. See the OCS site
+configs documentation for more details.
 
-    python3 open.py <filename>
+Optional arguments::
+   'arguments': [['--fake-data', 1],
+                 ['--auto-acquire', False]]},
 
-Data is then accessible in each frame, for instance::
+Docker Configuration
+--------------------
 
-    frames[0]['TODs'].keys()
+The Lakeshore 372 Agent should be configured to run in a Docker container. An
+example configuration is::
 
-This displays the channels recorded (should be only active ones) and then you
-can access the data with ``frames[0]['TODs']['Channel 01']`` for instance.
+  ocs-LSA22YE:
+    image: grumpy.physics.yale.edu/ocs-lakeshore372-agent:latest
+    hostname: ocs-docker
+    volumes:
+      - ${OCS_CONFIG_DIR}:/config:ro
+    command:
+      - "--instance-id=LSA22YE"
+
+To view the 372 temperatures data feed in the live monitor an accompanying
+data-feed server will need to be run. An example of this configuration is::
+
+  sisock-LSA22YE:
+    image: grumpy.physics.yale.edu/sisock-data-feed-server:latest
+    environment:
+        TARGET: LSA22YE # match to instance-id of agent to monitor, used for data feed subscription
+        NAME: 'LSA22YE' # will appear in sisock a front of field name
+        DESCRIPTION: "LS372 with two ROXes for calibration."
+        FEED: "temperatures"
+    logging:
+      options:
+        max-size: "20m"
+        max-file: "10"
+
+For additional configuration see the sisock data-feed-server documentation.
+
+.. note::
+    The serial numbers here will need to be updated for your device.
+
 
 Direct Communication
 --------------------
 Direct communication with the Lakeshore can be achieved without OCS, using the
-``Lakeshore372.py`` module in ``ocs/ocs/Lakeshore/``. From that directory, you can run a script like::
+``Lakeshore372.py`` module in ``socs/socs/Lakeshore/``. From that directory,
+you can run a script like::
 
     from Lakeshore372 import LS372
 
@@ -120,8 +81,8 @@ resistance measured on the currently active channel with::
     ls.get_active_channel().get_resistance_reading()
 
 That should get you started with direct communication. The API is fairly full
-featured. Development on the Heater class is currently underway and has a
-development branch on GitHub.
+featured. For any feature requests for functionality that might be missing,
+please file a Github issue.
 
 API
 ---

--- a/docs/lakeshore372.rst
+++ b/docs/lakeshore372.rst
@@ -10,6 +10,11 @@ The Lakeshore 372 (LS372) units are used for 100 mK and 1K thermometer readout.
 Basic functionality to interface and control an LS372 is provided by the
 ``socs.Lakeshore.Lakeshore372.py`` module.
 
+.. argparse::
+    :filename: ../agents/lakeshore372/LS372_agent.py
+    :func: make_parser
+    :prog: python3 LS372_agent.py
+
 OCS Configuration
 -----------------
 
@@ -24,10 +29,6 @@ configuration block::
 
 Each device requires configuration under 'agent-instances'. See the OCS site
 configs documentation for more details.
-
-Optional arguments::
-   'arguments': [['--fake-data', 1],
-                 ['--auto-acquire', False]]},
 
 Docker Configuration
 --------------------


### PR DESCRIPTION
This adds automatically starting data acquisition to both the 240 and 372 agents. By default they will initialize and start data acquisition on startup. Users can disable this behavior if they want with a flag or argument configured in their ocs config file.

I've tested with both Lakeshore models at Yale. This likely has some conflicts with the changes in #9, so merging should be handled carefully.

Also adds documentation for both Agents, as well as instructions for first time setup of the 240s, detailing driver installations an pitfalls there.