### PR TITLE
Replaced job locking with TimeoutLock

### DIFF
--- a/agents/lakeshore372/LS372_agent.py
+++ b/agents/lakeshore372/LS372_agent.py
@@ -332,7 +332,6 @@ class LS372_Agent:
 
             # Make sure we aren't servoing too high in temperature.
             if params["temperature"] > 1:
-                self.set_job_done()
                 return False, f'Servo temperature is set above 1K. Aborting.'
 
             self.module.sample_heater.set_setpoint(params["temperature"])
@@ -376,7 +375,6 @@ class LS372_Agent:
                 session.add_message(f'Setpoint Difference: ' + str(mean - setpoint))
                 session.add_message(f'Average is within {params["threshold"]} K threshold. Proceeding with calibration.')
 
-                self.set_job_done()
                 return True, f"Servo temperature is stable within {params['threshold']} K"
 
             else:

--- a/agents/lakeshore372/LS372_agent.py
+++ b/agents/lakeshore372/LS372_agent.py
@@ -10,6 +10,7 @@ from socs.Lakeshore.Lakeshore372 import LS372
 on_rtd = os.environ.get('READTHEDOCS') == 'True'
 if not on_rtd:
     from ocs import ocs_agent, site_config
+    from ocs.ocs_twisted import TimeoutLock
 
 class LS372_Agent:
     """Agent to connect to a single Lakeshore 372 device.
@@ -22,7 +23,7 @@ class LS372_Agent:
 
     """
     def __init__(self, agent, name, ip, fake_data=False):
-        self.lock = threading.Semaphore()
+        self.lock = TimeoutLock()
         self.job = None
 
         self.name = name
@@ -33,6 +34,7 @@ class LS372_Agent:
 
         self.log = agent.log
         self.initialized = False
+        self.take_data = False
 
         self.agent = agent
         # Registers temperature feeds
@@ -43,19 +45,6 @@ class LS372_Agent:
                                  record=True,
                                  agg_params=agg_params,
                                  buffer_time=1)
-
-    def try_set_job(self, job_name):
-        print(self.job, job_name)
-        with self.lock:
-            if self.job == None:
-                self.job = job_name
-                return (True, 'ok')
-            else:
-                return (False, 'Conflict: "%s" is already running.' % self.job)
-
-    def set_job_done(self):
-        with self.lock:
-            self.job = None
 
     def init_lakeshore_task(self, session, params=None):
         """init_lakeshore_task(params=None)
@@ -79,26 +68,26 @@ class LS372_Agent:
             self.log.info("Lakeshore already initialized. Returning...")
             return True, "Already initialized"
 
-        ok, msg = self.try_set_job('init')
+        with self.lock.acquire_timeout(0, job='init') as acquired:
+            if not acquired:
+                self.log.warn(f"Could not start init because "
+                              f"{self.lock.job} is already running")
+                return False, "Could not acquire lock"
 
-        self.log.info('Initialized Lakeshore: {status}', status=ok)
-        if not ok:
-            return ok, msg
+            session.set_status('running')
 
-        session.set_status('running')
+            if self.fake_data:
+                self.res = random.randrange(1, 1000);
+                session.add_message("No initialization since faking data")
+                self.thermometers = ["thermA", "thermB"]
+            else:
+                self.module = LS372(self.ip)
+                print("Initialized Lakeshore module: {!s}".format(self.module))
+                session.add_message("Lakeshore initilized with ID: %s"%self.module.id)
 
-        if self.fake_data:
-            self.res = random.randrange(1, 1000);
-            session.add_message("No initialization since faking data")
-            self.thermometers = ["thermA", "thermB"]
-        else:
-            self.module = LS372(self.ip)
-            print("Initialized Lakeshore module: {!s}".format(self.module))
-            session.add_message("Lakeshore initilized with ID: %s"%self.module.id)
+                self.thermometers = [channel.name for channel in self.module.channels]
 
-            self.thermometers = [channel.name for channel in self.module.channels]
-        self.initialized = True
-        self.set_job_done()
+            self.initialized = True
 
         # Start data acquisition if requested
         if params.get('auto_acquire', False):
@@ -108,52 +97,55 @@ class LS372_Agent:
 
     def start_acq(self, session, params=None):
 
-        ok, msg = self.try_set_job('acq')
-        if not ok:
-             return ok, msg
+        with self.lock.acquire_timeout(0, job='acq') as acquired:
+            if not acquired:
+                self.log.warn(f"Could not start init because "
+                              f"{self.lock.job} is already running")
+                return False, "Could not acquire lock"
 
-        session.set_status('running')
-        self.log.info("Starting data acquisition for {}".format(self.agent.agent_address))
-        while True:
-            with self.lock:
-                if self.job == '!acq':
-                    break
-                elif self.job == 'acq':
-                    pass
+            session.set_status('running')
+            self.log.info("Starting data acquisition for {}".format(self.agent.agent_address))
+
+            self.take_data = True
+            while self.take_data:
+                if self.fake_data:
+
+                    data = {
+                        'timestamp': time.time(),
+                        'block_name': 'fake-data',
+                        'data': {}
+                    }
+                    for therm in self.thermometers:
+                        reading = np.random.normal(self.res, 20)
+                        data['data'][therm] = reading
+                    time.sleep(.1)
+                    
                 else:
-                    return 10
+                    active_channel = self.module.get_active_channel()
+                    data = {
+                        'timestamp': time.time(),
+                        'block_name': active_channel.name,
+                        'data': {}
+                    }
 
-            if self.fake_data:
-                for therm in self.thermometers:
-                    reading = np.random.normal(self.res, 20)
-                    data['data'][therm] = reading
-                time.sleep(.1)
-            else:
-                active_channel = self.module.get_active_channel()
-                data = {
-                    'timestamp': time.time(),
-                    'block_name': active_channel.name,
-                    'data': {}
-                }
+                    # Collect both temperature and resistance values from each Channel
+                    data['data'][active_channel.name + ' T'] = self.module.get_temp(unit='kelvin', chan=active_channel.channel_num)
+                    data['data'][active_channel.name + ' R'] = self.module.get_temp(unit='ohms', chan=active_channel.channel_num)
+                    time.sleep(.01)
 
-                # Collect both temperature and resistance values from each Channel
-                data['data'][active_channel.name + ' T'] = self.module.get_temp(unit='kelvin', chan=active_channel.channel_num)
-                data['data'][active_channel.name + ' R'] = self.module.get_temp(unit='ohms', chan=active_channel.channel_num)
-                time.sleep(.01)
+                session.app.publish_to_feed('temperatures', data)
 
-            session.app.publish_to_feed('temperatures', data)
-
-        self.set_job_done()
         return True, 'Acquisition exited cleanly.'
 
     def stop_acq(self, session, params=None):
-        ok = False
-        with self.lock:
-            if self.job =='acq':
-                self.job = '!acq'
-                ok = True
-        return (ok, {True: 'Requested process stop.',
-                    False: 'Failed to request process stop.'}[ok])
+        """
+        Stops acq process.
+        """
+        if self.take_data:
+            self.take_data = False
+            return True, 'requested to stop taking data.'
+        else:
+            return False, 'acq is not currently running'
 
     def set_heater_range(self, session, params):
         """
@@ -168,27 +160,28 @@ class LS372_Agent:
                the servo to adjust to the new heater range, typical value of
                ~600 seconds
         """
-        ok, msg = self.try_set_job('set_heater_range')
-        if not ok:
-            return ok, msg
+        with self.lock.acquire_timeout(0, job='set_heater_range') as acquired:
+            if not acquired:
+                self.log.warn(f"Could not start init because "
+                              f"{self.lock.job} is already running")
+                return False, "Could not acquire lock"
 
-        session.set_status('running')
+            session.set_status('running')
 
-        heater_string = params.get('heater', 'sample')
-        if heater_string.lower() == 'sample':
-            heater = self.module.sample_heater
-        elif heater_string.lower() == 'still':
-            heater = self.module.still_heater
+            heater_string = params.get('heater', 'sample')
+            if heater_string.lower() == 'sample':
+                heater = self.module.sample_heater
+            elif heater_string.lower() == 'still':
+                heater = self.module.still_heater
 
-        current_range = heater.get_heater_range()
+            current_range = heater.get_heater_range()
 
-        if params['range'] == current_range:
-            print("Current heater range matches commanded value. Proceeding unchanged.")
-        else:
-            heater.set_heater_range(params['range'])
-            time.sleep(params['wait'])
+            if params['range'] == current_range:
+                print("Current heater range matches commanded value. Proceeding unchanged.")
+            else:
+                heater.set_heater_range(params['range'])
+                time.sleep(params['wait'])
 
-        self.set_job_done()
         return True, f'Set {heater_string} heater range to {params["range"]}'
 
     def set_excitation_mode(self, session, params):
@@ -198,17 +191,23 @@ class LS372_Agent:
         :param params: dict with "channel" and "mode" keys for Channel.set_excitation_mode()
         :type params: dict
         """
-        ok, msg = self.try_set_job('set_excitation_mode')
-        if not ok:
-            return ok, msg
 
-        session.set_status('running')
+        with self.lock.acquire_timeout(0, job='set_excitation_mode') as acquired:
+            if not acquired:
+                self.log.warn(f"Could not start init because "
+                              f"{self.lock.job} is already running")
+                return False, "Could not acquire lock"
 
-        self.module.channels[params['channel']].set_excitation_mode(params['mode'])
-        session.add_message(f'post message in agent for Set channel {params["channel"]} excitation mode to {params["mode"]}')
-        print(f'print statement in agent for Set channel {params["channel"]} excitation mode to {params["mode"]}')
+            ok, msg = self.try_set_job('set_excitation_mode')
+            if not ok:
+                return ok, msg
 
-        self.set_job_done()
+            session.set_status('running')
+
+            self.module.channels[params['channel']].set_excitation_mode(params['mode'])
+            session.add_message(f'post message in agent for Set channel {params["channel"]} excitation mode to {params["mode"]}')
+            print(f'print statement in agent for Set channel {params["channel"]} excitation mode to {params["mode"]}')
+
         return True, f'return text for Set channel {params["channel"]} excitation mode to {params["mode"]}'
 
     def set_excitation(self, session, params):
@@ -218,22 +217,23 @@ class LS372_Agent:
         :param params: dict with "channel" and "value" keys for Channel.set_excitation()
         :type params: dict
         """
-        ok, msg = self.try_set_job('set_excitation')
-        if not ok:
-            return ok, msg
+        with self.lock.acquire_timeout(0, job='set_excitation') as acquired:
+            if not acquired:
+                self.log.warn(f"Could not start init because "
+                              f"{self.lock.job} is already running")
+                return False, "Could not acquire lock"
 
-        session.set_status('running')
+            session.set_status('running')
 
-        current_excitation = self.module.channels[params['channel']].get_excitation()
+            current_excitation = self.module.channels[params['channel']].get_excitation()
 
-        if params['value'] == current_excitation:
-            print(f'Channel {params["channel"]} excitation already set to {params["value"]}')
-        else:
-            self.module.channels[params['channel']].set_excitation(params['value'])
-            session.add_message(f'Set channel {params["channel"]} excitation to {params["value"]}')
-            print(f'Set channel {params["channel"]} excitation to {params["value"]}')
+            if params['value'] == current_excitation:
+                print(f'Channel {params["channel"]} excitation already set to {params["value"]}')
+            else:
+                self.module.channels[params['channel']].set_excitation(params['value'])
+                session.add_message(f'Set channel {params["channel"]} excitation to {params["value"]}')
+                print(f'Set channel {params["channel"]} excitation to {params["value"]}')
 
-        self.set_job_done()
         return True, f'Set channel {params["channel"]} excitation to {params["value"]}'
 
     def set_pid(self, session, params):
@@ -243,17 +243,18 @@ class LS372_Agent:
         :param params: dict with "P", "I", and "D" keys for Heater.set_pid()
         :type params: dict
         """
-        ok, msg = self.try_set_job('set_pid')
-        if not ok:
-            return ok, msg
+        with self.lock.acquire_timeout(0, job='set_pid') as acquired:
+            if not acquired:
+                self.log.warn(f"Could not start init because "
+                              f"{self.lock.job} is already running")
+                return False, "Could not acquire lock"
 
-        session.set_status('running')
+            session.set_status('running')
 
-        self.module.sample_heater.set_pid(params["P"], params["I"], params["D"])
-        session.add_message(f'post message text for Set PID to {params["P"]}, {params["I"]}, {params["D"]}')
-        print(f'print text for Set PID to {params["P"]}, {params["I"]}, {params["D"]}')
+            self.module.sample_heater.set_pid(params["P"], params["I"], params["D"])
+            session.add_message(f'post message text for Set PID to {params["P"]}, {params["I"]}, {params["D"]}')
+            print(f'print text for Set PID to {params["P"]}, {params["I"]}, {params["D"]}')
 
-        self.set_job_done()
         return True, f'return text for Set PID to {params["P"]}, {params["I"]}, {params["D"]}'
 
     def set_active_channel(self, session, params):
@@ -263,17 +264,18 @@ class LS372_Agent:
         :param params: dict with "channel" number
         :type params: dict
         """
-        ok, msg = self.try_set_job('set_active_channel')
-        if not ok:
-            return ok, msg
+        with self.lock.acquire_timeout(0, job='set_active_channel') as acquired:
+            if not acquired:
+                self.log.warn(f"Could not start init because "
+                              f"{self.lock.job} is already running")
+                return False, "Could not acquire lock"
 
-        session.set_status('running')
+            session.set_status('running')
 
-        self.module.set_active_channel(params["channel"])
-        session.add_message(f'post message text for set channel to {params["channel"]}')
-        print(f'print text for set channel to {params["channel"]}')
+            self.module.set_active_channel(params["channel"])
+            session.add_message(f'post message text for set channel to {params["channel"]}')
+            print(f'print text for set channel to {params["channel"]}')
 
-        self.set_job_done()
         return True, f'return text for set channel to {params["channel"]}'
 
     def set_autoscan(self, session, params):
@@ -281,20 +283,21 @@ class LS372_Agent:
         Sets autoscan on the LS372.
         :param params: dict with "autoscan" value
         """
-        ok, msg = self.try_set_job('set_autoscan')
-        if not ok:
-            return ok, msg
+        with self.lock.acquire_timeout(0, job='set_autoscan') as acquired:
+            if not acquired:
+                self.log.warn(f"Could not start init because "
+                              f"{self.lock.job} is already running")
+                return False, "Could not acquire lock"
 
-        session.set_status('running')
+            session.set_status('running')
 
-        if params['autoscan']:
-            self.module.enable_autoscan()
-            self.log.info('enabled autoscan')
-        else:
-            self.module.disable_autoscan()
-            self.log.info('disabled autoscan')
+            if params['autoscan']:
+                self.module.enable_autoscan()
+                self.log.info('enabled autoscan')
+            else:
+                self.module.disable_autoscan()
+                self.log.info('disabled autoscan')
 
-        self.set_job_done()
         return True, 'Set autoscan to {}'.format(params['autoscan'])
 
     def servo_to_temperature(self, session, params):
@@ -303,40 +306,41 @@ class LS372_Agent:
         :param params: dict with "temperature" Heater.set_setpoint() in unites of K
         :type params: dict
         """
-        ok, msg = self.try_set_job('servo_to_temperature')
-        if not ok:
-            return ok, msg
+        with self.lock.acquire_timeout(0, job='servo_to_temperature') as acquired:
+            if not acquired:
+                self.log.warn(f"Could not start init because "
+                              f"{self.lock.job} is already running")
+                return False, "Could not acquire lock"
 
-        session.set_status('running')
+            session.set_status('running')
 
-        # Check we're in correct control mode for servo.
-        if self.module.sample_heater.mode != 'Closed Loop':
-            session.add_message(f'Changing control to Closed Loop mode for servo.')
-            self.module.sample_heater.set_mode("Closed Loop")
+            # Check we're in correct control mode for servo.
+            if self.module.sample_heater.mode != 'Closed Loop':
+                session.add_message(f'Changing control to Closed Loop mode for servo.')
+                self.module.sample_heater.set_mode("Closed Loop")
 
-        # Check we aren't autoscanning.
-        if self.module.get_autoscan() is True:
-            session.add_message(f'Autoscan is enabled, disabling for PID control on dedicated channel.')
-            self.module.disable_autoscan()
+            # Check we aren't autoscanning.
+            if self.module.get_autoscan() is True:
+                session.add_message(f'Autoscan is enabled, disabling for PID control on dedicated channel.')
+                self.module.disable_autoscan()
 
-        # Check we're scanning same channel expected by heater for control.
-        if self.module.get_active_channel().channel_num != int(self.module.sample_heater.input):
-            session.add_message(f'Changing active channel to expected heater control input')
-            self.module.set_active_channel(int(self.module.sample_heater.input))
+            # Check we're scanning same channel expected by heater for control.
+            if self.module.get_active_channel().channel_num != int(self.module.sample_heater.input):
+                session.add_message(f'Changing active channel to expected heater control input')
+                self.module.set_active_channel(int(self.module.sample_heater.input))
 
-        # Check we're setup to take correct units.
-        if self.module.get_active_channel().units != 'kelvin':
-            session.add_message(f'Setting preferred units to Kelvin on heater control input.')
-            self.module.get_active_channel().set_units('kelvin')
+            # Check we're setup to take correct units.
+            if self.module.get_active_channel().units != 'kelvin':
+                session.add_message(f'Setting preferred units to Kelvin on heater control input.')
+                self.module.get_active_channel().set_units('kelvin')
 
-        # Make sure we aren't servoing too high in temperature.
-        if params["temperature"] > 1:
-            self.set_job_done()
-            return False, f'Servo temperature is set above 1K. Aborting.'
+            # Make sure we aren't servoing too high in temperature.
+            if params["temperature"] > 1:
+                self.set_job_done()
+                return False, f'Servo temperature is set above 1K. Aborting.'
 
-        self.module.sample_heater.set_setpoint(params["temperature"])
+            self.module.sample_heater.set_setpoint(params["temperature"])
 
-        self.set_job_done()
         return True, f'Setpoint now set to {params["temperature"]} K'
 
     def check_temperature_stability(self, session, params):
@@ -348,40 +352,42 @@ class LS372_Agent:
         measurements - number of measurements to average for stability check
         threshold - amount within which the average needs to be to the setpoint for stability
         """
-        ok, msg = self.try_set_job('check_temperature_stability')
-        if not ok:
-            return ok, msg
+        with self.lock.acquire_timeout(0, job='check_temp_stability') as acquired:
+            if not acquired:
+                self.log.warn(f"Could not start init because "
+                              f"{self.lock.job} is already running")
+                return False, "Could not acquire lock"
 
-        session.set_status('running')
+            session.set_status('running')
 
-        setpoint = float(self.module.sample_heater.get_setpoint())
+            setpoint = float(self.module.sample_heater.get_setpoint())
 
-        if params is None:
-            params = {'measurements': 10, 'threshold': 0.5e-3}
+            if params is None:
+                params = {'measurements': 10, 'threshold': 0.5e-3}
 
-        test_temps = []
+            test_temps = []
 
-        for i in range(params['measurements']):
-            test_temps.append(self.module.get_temp())
-            time.sleep(.1)  # sampling rate is 10 readings/sec, so wait 0.1 s for a new reading
+            for i in range(params['measurements']):
+                test_temps.append(self.module.get_temp())
+                time.sleep(.1)  # sampling rate is 10 readings/sec, so wait 0.1 s for a new reading
 
-        mean = np.mean(test_temps)
-        session.add_message(f'Average of {params["measurements"]} measurements is {mean} K.')
-        print(f'Average of {params["measurements"]} measurements is {mean} K.')
+            mean = np.mean(test_temps)
+            session.add_message(f'Average of {params["measurements"]} measurements is {mean} K.')
+            print(f'Average of {params["measurements"]} measurements is {mean} K.')
 
-        if np.abs(mean - setpoint) < params['threshold']:
-            print("passed threshold")
-            session.add_message(f'Setpoint Difference: ' + str(mean - setpoint))
-            session.add_message(f'Average is within {params["threshold"]} K threshold. Proceeding with calibration.')
+            if np.abs(mean - setpoint) < params['threshold']:
+                print("passed threshold")
+                session.add_message(f'Setpoint Difference: ' + str(mean - setpoint))
+                session.add_message(f'Average is within {params["threshold"]} K threshold. Proceeding with calibration.')
 
-            self.set_job_done()
-            return True, f"Servo temperature is stable within {params['threshold']} K"
+                self.set_job_done()
+                return True, f"Servo temperature is stable within {params['threshold']} K"
 
-        else:
-            print("we're in the else")
-            #adjust_heater(t,rest)
-            self.set_job_done()
-            return False, f"Temperature not stable within {params['threshold']}."
+            else:
+                print("we're in the else")
+                #adjust_heater(t,rest)
+
+        return False, f"Temperature not stable within {params['threshold']}."
 
     def set_output_mode(self, session, params=None):
         """
@@ -395,19 +401,20 @@ class LS372_Agent:
                     "Zone", "Still", "Closed Loop", or "Warm up"
         """
 
-        ok, msg = self.try_set_job('set_ouput_mode')
-        if not ok:
-            return ok, msg
+        with self.lock.acquire_timeout(0, job='set_output_mode') as acquired:
+            if not acquired:
+                self.log.warn(f"Could not start init because "
+                              f"{self.lock.job} is already running")
+                return False, "Could not acquire lock"
 
-        session.set_status('running')
+            session.set_status('running')
 
-        if params['heater'].lower() == 'still':
-            self.module.still_heater.set_mode(params['mode'])
-        if params['heater'].lower() == 'sample':
-            self.module.sample_heater.set_mode(params['mode'])
-        self.log.info("Set {} output mode to {}".format(params['heater'], params['mode']))
+            if params['heater'].lower() == 'still':
+                self.module.still_heater.set_mode(params['mode'])
+            if params['heater'].lower() == 'sample':
+                self.module.sample_heater.set_mode(params['mode'])
+            self.log.info("Set {} output mode to {}".format(params['heater'], params['mode']))
 
-        self.set_job_done()
         return True, "Set {} output mode to {}".format(params['heater'], params['mode'])
 
     def set_heater_output(self, session, params=None):
@@ -427,32 +434,33 @@ class LS372_Agent:
 
         """
 
-        ok, msg = self.try_set_job('set_heater_output')
-        if not ok:
-            return ok, msg
+        with self.lock.acquire_timeout(0, job='set_heater_output') as acquired:
+            if not acquired:
+                self.log.warn(f"Could not start init because "
+                              f"{self.lock.job} is already running")
+                return False, "Could not acquire lock"
 
-        heater = params['heater'].lower()
-        output = params['output']
+            heater = params['heater'].lower()
+            output = params['output']
 
-        display = params.get('display', None)
+            display = params.get('display', None)
 
-        if heater == 'still':
-            self.module.still_heater.set_heater_output(output, display_type=display)
-        if heater.lower() == 'sample':
-            self.log.info("display: {}\toutput: {}".format(display, output))
-            self.module.sample_heater.set_heater_output(output, display_type=display)
+            if heater == 'still':
+                self.module.still_heater.set_heater_output(output, display_type=display)
+            if heater.lower() == 'sample':
+                self.log.info("display: {}\toutput: {}".format(display, output))
+                self.module.sample_heater.set_heater_output(output, display_type=display)
 
-        self.log.info("Set {} heater display to {}, output to {}".format(heater, display, output))
+            self.log.info("Set {} heater display to {}, output to {}".format(heater, display, output))
 
-        session.set_status('running')
+            session.set_status('running')
 
-        data = {'timestamp': time.time(),
-                'block_name': '{}_heater_out'.format(heater),
-                'data': {'{}_heater_out'.format(heater): output}
-                }
-        session.app.publish_to_feed('temperatures', data)
+            data = {'timestamp': time.time(),
+                    'block_name': '{}_heater_out'.format(heater),
+                    'data': {'{}_heater_out'.format(heater): output}
+                    }
+            session.app.publish_to_feed('temperatures', data)
 
-        self.set_job_done()
         return True, "Set {} display to {}, output to {}".format(heater, display, output)
 
 def make_parser(parser=None):
@@ -495,7 +503,7 @@ if __name__ == '__main__':
 
     agent, runner = ocs_agent.init_site_agent(args)
 
-    lake_agent = LS372_Agent(agent, args.serial_number, args.ip_address , fake_data=False)
+    lake_agent = LS372_Agent(agent, args.serial_number, args.ip_address , fake_data=args.fake_data)
 
     agent.register_task('init_lakeshore', lake_agent.init_lakeshore_task,
                         startup=init_params)

--- a/agents/lakeshore372/LS372_agent.py
+++ b/agents/lakeshore372/LS372_agent.py
@@ -198,10 +198,6 @@ class LS372_Agent:
                               f"{self.lock.job} is already running")
                 return False, "Could not acquire lock"
 
-            ok, msg = self.try_set_job('set_excitation_mode')
-            if not ok:
-                return ok, msg
-
             session.set_status('running')
 
             self.module.channels[params['channel']].set_excitation_mode(params['mode'])


### PR DESCRIPTION
This PR replaces job locking in the LS372 agent with TimeoutLock, so people shouldn't get locked out of functions after they fail. Since the fake_data option doesn't really work with all tasks, I haven't been able to test most of the tasks, so if you want maybe you should test them out with hardware at yale. I have tested the acquisition process, and verified that if it raises an exception you can still call other tasks. 