### PR TITLE
Start setup of pysmurf_aggregator from stream listener

### DIFF
--- a/agents/pysmurf_aggregator/Dockerfile
+++ b/agents/pysmurf_aggregator/Dockerfile
@@ -1,0 +1,15 @@
+# SOCS SMuRF Aggregator
+
+# Use socs base image
+FROM socs:latest
+
+# Set the working directory to registry directory
+WORKDIR /app/socs/agents/pysmurf_aggregator/
+COPY . .
+
+# Run registry on container startup
+ENTRYPOINT ["python3", "-u", "stream_listener.py"]
+
+# Default site-hub
+CMD ["--site-hub=ws://sisock-crossbar:8001/ws", \
+     "--site-http=http://sisock-crossbar:8001/call"]

--- a/agents/pysmurf_aggregator/stream_listener.py
+++ b/agents/pysmurf_aggregator/stream_listener.py
@@ -21,7 +21,7 @@ class G3StreamListener:
         self.log.info("Writing data to {}".format(data_dir))
         self.log.info("New file every {} seconds".format(time_per_file))
 
-        reader = core.G3Reader("tcp://localhost:{}".format(self.port))
+        reader = core.G3Reader("tcp://{}:{}".format(params.get('address', 'localhost'), self.port))
         writer = None
 
         last_meta = None

--- a/agents/pysmurf_aggregator/stream_listener.py
+++ b/agents/pysmurf_aggregator/stream_listener.py
@@ -6,6 +6,43 @@ from ocs import ocs_agent, site_config
 from spt3g import core
 
 
+def _create_file_path(start_time, data_dir):
+    """Create the file path for .g3 file output.
+
+    Note: This will create directories if they don't exist already.
+
+    Arguments
+    ---------
+    start_time : float
+        Timestamp for start of data collection
+    data_dir : str
+        Top level data directory for output
+
+    Returns
+    -------
+    str
+        Full filepath of .g3 file for output
+
+    """
+    start_datetime = datetime.datetime \
+                             .fromtimestamp(start_time,
+                                            tz=datetime
+                                            .timezone.utc)
+
+    sub_dir = os.path.join(data_dir,
+                           "{:.5}".format(str(start_time)))
+
+    # Create new dir for current day
+    if not os.path.exists(sub_dir):
+        os.makedirs(sub_dir)
+
+    time_string = start_datetime.strftime("%Y-%m-%d-%H-%M-%S")
+    filename = "{}.g3".format(time_string)
+    filepath = os.path.join(sub_dir, filename)
+
+    return filepath
+
+
 class G3StreamListener:
     def __init__(self, agent, address='localhost', port=4536):
         self.agent = agent
@@ -35,22 +72,7 @@ class G3StreamListener:
         while self.is_streaming:
             if writer is None:
                 start_time = time.time()
-                start_datetime = datetime.datetime \
-                                         .fromtimestamp(start_time,
-                                                        tz=datetime
-                                                        .timezone.utc)
-
-                sub_dir = os.path.join(data_dir,
-                                       "{:.5}".format(str(start_time)))
-
-                # Create new dir for current day
-                if not os.path.exists(sub_dir):
-                    os.makedirs(sub_dir)
-
-                time_string = start_datetime.strftime("%Y-%m-%d-%H-%M-%S")
-                filename = "{}.g3".format(time_string)
-                filepath = os.path.join(sub_dir, filename)
-
+                filepath = _create_file_path(start_time, data_dir)
                 writer = core.G3Writer(filename=filepath)
 
                 if last_meta is not None:

--- a/agents/pysmurf_aggregator/stream_listener.py
+++ b/agents/pysmurf_aggregator/stream_listener.py
@@ -83,6 +83,7 @@ class G3StreamListener:
                 if f.type == core.G3FrameType.Observation:
                     last_meta = f
                 writer(f)
+                writer.Flush()
 
             if (time.time() - start_time) > self.time_per_file:
                 writer(core.G3Frame(core.G3FrameType.EndProcessing))

--- a/agents/pysmurf_aggregator/stream_listener.py
+++ b/agents/pysmurf_aggregator/stream_listener.py
@@ -5,9 +5,10 @@ import os
 
 
 class G3StreamListener:
-    def __init__(self, agent, port=4536):
+    def __init__(self, agent, address='localhost', port=4536):
         self.agent = agent
         self.log = self.agent.log
+        self.address = address
         self.port = port
         self.is_streaming = False
 
@@ -20,8 +21,10 @@ class G3StreamListener:
 
         self.log.info("Writing data to {}".format(data_dir))
         self.log.info("New file every {} seconds".format(time_per_file))
+        self.log.info("Listening to {}:{}".format(self.address, self.port))
 
-        reader = core.G3Reader("tcp://{}:{}".format(params.get('address', 'localhost'), self.port))
+        reader = core.G3Reader("tcp://{}:{}".format(self.address,
+                                                    self.port))
         writer = None
 
         last_meta = None
@@ -68,7 +71,9 @@ if __name__ == '__main__':
     site_config.reparse_args(args, 'G3StreamListener')
 
     agent, runner = ocs_agent.init_site_agent(args)
-    listener = G3StreamListener(agent, port=int(args.port))
+    listener = G3StreamListener(agent,
+                                address=args.address,
+                                port=int(args.port))
 
     agent.register_process('stream', listener.start_stream, listener.stop_stream)
 

--- a/agents/pysmurf_aggregator/stream_listener.py
+++ b/agents/pysmurf_aggregator/stream_listener.py
@@ -66,8 +66,10 @@ class G3StreamListener:
                 writer(core.G3Frame(core.G3FrameType.EndProcessing))
                 writer = None
 
+        # Once we're done writing close out the file
         if writer is not None:
             writer(core.G3Frame(core.G3FrameType.EndProcessing))
+            writer = None
 
         return True, "Finished Streaming"
 

--- a/agents/pysmurf_aggregator/stream_listener.py
+++ b/agents/pysmurf_aggregator/stream_listener.py
@@ -47,7 +47,7 @@ class G3StreamListener:
 
             frames = reader.Process(None)
             for f in frames:
-                if f.type == core.G3FrameType.Housekeeping:
+                if f.type == core.G3FrameType.Observation:
                     last_meta = f
                 writer(f)
 

--- a/agents/pysmurf_aggregator/stream_listener.py
+++ b/agents/pysmurf_aggregator/stream_listener.py
@@ -43,17 +43,69 @@ def _create_file_path(start_time, data_dir):
     return filepath
 
 
-class G3StreamListener:
-    def __init__(self, agent, time_per_file, data_dir, address='localhost', port=4536):
+class G3StreamAggregator:
+    """Aggregator for G3 data streams sent over the G3NetworkSender.
+
+    This Agent is built to work with the SMuRF data streamer, which collects
+    data from a SMuRF blade, packages it into a G3 Frame and sends it over the
+    network via a G3NetworkSender.
+
+    We read from the specified address with a G3Reader, and write the data to
+    .g3 files on disk.
+
+    Parameters
+    ----------
+    agent : OCSAgent
+        OCSAgent object which forms this Agent
+    time_per_file : int
+        Amount of time in seconds to have in each file. Files will be rotated
+        after this many seconds
+    data_dir : str
+        Location to write data files to. Subdirectories will be created within
+        this directory roughly corresponding to one day.
+    address : str
+        Address of the host sending the data via the G3NetworkSender
+    port : int
+        Port to listen for data on
+
+    Attributes
+    ----------
+    agent : OCSAgent
+        OCSAgent object which forms this Agent
+    time_per_file : int
+        Amount of time in seconds to have in each file. Files will be rotated
+        after this many seconds.
+    data_dir : str
+        Location to write data files to. Subdirectories will be created within
+        this directory roughly corresponding to one day.
+    address : str
+        Address of the host sending the data via the G3NetworkSender.
+    port : int
+        Port to listen for data on.
+    is_streaming : bool
+        Tracks whether or not the aggregator is writing to disk. Setting to
+        false stops the aggregation of data.
+    log : txaio.tx.Logger
+        txaio logger object, created by the OCSAgent
+
+    """
+
+    def __init__(self, agent, time_per_file, data_dir, address='localhost',
+                 port=4536):
         self.agent = agent
-        self.log = self.agent.log
+        self.time_per_file = time_per_file
+        self.data_dir = data_dir
         self.address = address
         self.port = port
         self.is_streaming = False
-        self.time_per_file = time_per_file
-        self.data_dir = data_dir
+        self.log = self.agent.log
 
-    def start_stream(self, session, params=None):
+    def start_aggregation(self, session, params=None):
+        """start_aggregation(params=None)
+
+        OCS Process to start data aggregation.
+
+        """
         if params is None:
             params = {}
 
@@ -94,11 +146,16 @@ class G3StreamListener:
             writer(core.G3Frame(core.G3FrameType.EndProcessing))
             writer = None
 
-        return True, "Finished Streaming"
+        return True, "Finished streaming"
 
-    def stop_stream(self, session, params=None):
+    def stop_aggregation(self, session, params=None):
+        """stop_aggregation(params=None)
+
+        Stop method associated with start_aggregation process.
+
+        """
         self.is_streaming = False
-        return True, "Stopping Streaming"
+        return True, "Stopping streaming"
 
 
 if __name__ == '__main__':
@@ -113,18 +170,18 @@ if __name__ == '__main__':
     pgroup.add_argument('--address', default='localhost')
 
     args = parser.parse_args()
-    site_config.reparse_args(args, 'G3StreamListener')
+    site_config.reparse_args(args, 'G3StreamAggregator')
 
     agent, runner = ocs_agent.init_site_agent(args)
-    listener = G3StreamListener(agent,
-                                int(args.time_per_file),
-                                args.data_dir,
-                                address=args.address,
-                                port=int(args.port))
+    listener = G3StreamAggregator(agent,
+                                  int(args.time_per_file),
+                                  args.data_dir,
+                                  address=args.address,
+                                  port=int(args.port))
 
     agent.register_process('stream',
-                           listener.start_stream,
-                           listener.stop_stream,
+                           listener.start_aggregation,
+                           listener.stop_aggregation,
                            startup=bool(args.auto_start))
 
     runner.run(agent, auto_reconnect=True)

--- a/agents/timestream_aggregator/Dockerfile
+++ b/agents/timestream_aggregator/Dockerfile
@@ -4,11 +4,11 @@
 FROM socs:latest
 
 # Set the working directory to registry directory
-WORKDIR /app/socs/agents/pysmurf_aggregator/
+WORKDIR /app/socs/agents/timestream_aggregator/
 COPY . .
 
 # Run registry on container startup
-ENTRYPOINT ["python3", "-u", "stream_listener.py"]
+ENTRYPOINT ["python3", "-u", "timestream_aggregator.py"]
 
 # Default site-hub
 CMD ["--site-hub=ws://sisock-crossbar:8001/ws", \

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -40,11 +40,11 @@ services:
     build: ./agents/smurf-stream-simulator/
 
   # --------------------------------------------------------------------------
-  # Smurf stream listener/aggregator
+  # SMuRF timestream aggregator
   # --------------------------------------------------------------------------
-  ocs-pysmurf-aggregator:
-    image: "ocs-pysmurf-aggregator"
-    build: ./agents/pysmurf_aggregator/
+  ocs-timestream-aggregator:
+    image: "ocs-timestream-aggregator"
+    build: ./agents/timestream_aggregator/
 
   # --------------------------------------------------------------------------
   # The Bluefors log tracking Agent

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -40,6 +40,13 @@ services:
     build: ./agents/smurf-stream-simulator/
 
   # --------------------------------------------------------------------------
+  # Smurf stream listener/aggregator
+  # --------------------------------------------------------------------------
+  ocs-pysmurf-aggregator:
+    image: "ocs-pysmurf-aggregator"
+    build: ./agents/pysmurf_aggregator/
+
+  # --------------------------------------------------------------------------
   # The Bluefors log tracking Agent
   # --------------------------------------------------------------------------
   ocs-bluefors-agent:

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -24,6 +24,7 @@ Agent Reference
    lakeshore240
    lakeshore372
    bluefors_agent
+   timestream_aggregator
 
 
 Indices and tables

--- a/docs/timestream_aggregator.rst
+++ b/docs/timestream_aggregator.rst
@@ -1,0 +1,61 @@
+.. highlight:: rst
+
+.. _timestream_aggregator:
+
+===========================
+Timestream Aggregator Agent
+===========================
+
+The Timestream Aggregator Agent is an OCS Agent which listens for G3 Frames
+incoming from a G3NetworkSender connection using a G3Reader and writes them to
+disk. This is used in conjunction with the SMuRF Streamer to aggregate
+timestream data from the SMuRF systems.
+
+.. argparse::
+    :filename: ../agents/timestream_aggregator/timestream_aggregator.py
+    :func: make_parser
+    :prog: python3 timestream_aggregator.py
+
+Configuration File Examples
+---------------------------
+Below are configuration examples for the ocs config file and for running the
+Agent in a docker container.
+
+ocs-config
+``````````
+To configure the Timestream Aggregator we need to add a TimestreamAggregator
+block to our ocs configuration file. Here is an example configuration block
+using all of the available arguments::
+
+      {'agent-class': 'TimestreamAggregator',
+       'instance-id': 'timestream-agg',
+       'arguments': [['--auto-start', True],
+                     ['--time-per-file', '3600'],
+                     ['--data-dir', '/data/'],
+                     ['--port', '50000'],
+                     ['--address', 'smurf-stream-sim']]},
+
+A few things to keep in mind. The ``--data-dir`` is the directory within the
+container, the default is probably fine, but can be changed if needed, you'll
+just need to mount your directory appropriately when starting the container.
+The ``--address`` can be resolved by name if your containers are running within
+the same Docker environment, however if your setup differs this likely will be
+an IP address, with the container running with the "host" network-mode.
+
+Docker
+``````
+The Timestream Aggregator should be configured to run in a Docker container. An
+example docker-compose service configuration is shown here::
+
+  timestream-aggregator:
+    image: simonsobs/timestream-aggregator
+    hostname: ocs-docker
+    volumes:
+      - ${OCS_CONFIG_DIR}:/config:ro
+      - ./data:/data
+
+Agent API
+---------
+
+.. autoclass:: agents.timestream_aggregator.timestream_aggregator.TimestreamAggregator
+    :members: start_aggregation


### PR DESCRIPTION
Use old stream listener as basis for the pysmurf aggregator. This makes minimal
modifications for allowing the listener to run in a container. We also create
the Agent's Dockerfile and add it to the docker-compose file.

Just wanted to get a working baseline to start from. Open to suggestions for naming, etc.