### PR TITLE
Bluefors Agent data feed bugfix

### DIFF
--- a/agents/bluefors/bluefors_log_tracker.py
+++ b/agents/bluefors/bluefors_log_tracker.py
@@ -171,7 +171,7 @@ class LogParser:
             'data': {}
         }
 
-        data['data'][log_name] = data_value
+        data['data'][log_name] = float(data_value)
 
         return data
 

--- a/docs/bluefors_agent.rst
+++ b/docs/bluefors_agent.rst
@@ -116,6 +116,9 @@ Example docker-compose configuration::
     volumes:
       - ${OCS_CONFIG_DIR}:/config:ro
       - /home/simonsobs/bluefors/logs/:/logs:ro
+    environment:
+      LOGLEVEL: "info"
+      FRAME_LENGTH: 600
 
 Depending on how you are running your containers it might be easier to hard
 code the `OCS_CONFIG_DIR` environment variable.


### PR DESCRIPTION
This fixes a bug in the Bluefors log Agent that causes the aggregator to crash by accidentally passing a string to the OCS Feed. This issue still needs to be address in the HK Aggregator (see https://github.com/simonsobs/ocs/issues/72), but this solves the problem in the Agent.

We also add some things that were useful in debugging, such as logging, the ability to set the frame length via environment variable, and the ability to set the log level via environment variable.