### PR TITLE
Add heartbeat control task to LS240 agent

### DIFF
--- a/agents/lakeshore240/LS240_agent.py
+++ b/agents/lakeshore240/LS240_agent.py
@@ -2,6 +2,7 @@ import time
 import os
 import argparse
 import warnings
+import txaio
 
 from typing import Optional
 
@@ -187,13 +188,28 @@ class LS240_Agent:
 
         return True, "Uploaded curve to channel {}".format(channel)
 
-    def acq(self, session, params=None):
-        """acq(params=None)
-
-        Task to start data acquisition.
+    def set_heartbeat_state(self, session, params=None):
+        """
+        Task to set the state of the agent heartbeat.
 
         Args:
+            heartbeat (bool): True for on, False for off
+        """
 
+        # Default to on, which is what we generally want to be true
+        heartbeat_state = params.get('heartbeat', True)
+
+        self.agent._heartbeat_on = heartbeat_state
+        self.log.info("Setting heartbeat_on: {}...".format(heartbeat_state))
+
+        return True, "Set heartbeat_on: {}".format(heartbeat_state)
+
+    def start_acq(self, session, params=None):
+        """acq(params=None)
+
+        Method to start data acquisition process.
+
+        Args:
             sampling_frequency (float):
                 Sampling frequency for data collection. Defaults to 2.5 Hz
 
@@ -267,6 +283,9 @@ def make_parser(parser=None):
 
 
 def main():
+    # Start logging
+    txaio.start_logging(level=os.environ.get("LOGLEVEL", "info"))
+
     p = site_config.add_arguments()
     parser = make_parser(parser=p)
 
@@ -331,7 +350,8 @@ def main():
                         startup=init_params)
     agent.register_task('set_values', therm.set_values)
     agent.register_task('upload_cal_curve', therm.upload_cal_curve)
-    agent.register_process('acq', therm.acq, therm.stop_acq)
+    agent.register_task('set_heartbeat', therm.set_heartbeat_state)
+    agent.register_process('acq', therm.start_acq, therm.stop_acq)
 
     runner.run(agent, auto_reconnect=True)
 

--- a/agents/lakeshore240/LS240_agent.py
+++ b/agents/lakeshore240/LS240_agent.py
@@ -188,22 +188,6 @@ class LS240_Agent:
 
         return True, "Uploaded curve to channel {}".format(channel)
 
-    def set_heartbeat_state(self, session, params=None):
-        """
-        Task to set the state of the agent heartbeat.
-
-        Args:
-            heartbeat (bool): True for on, False for off
-        """
-
-        # Default to on, which is what we generally want to be true
-        heartbeat_state = params.get('heartbeat', True)
-
-        self.agent._heartbeat_on = heartbeat_state
-        self.log.info("Setting heartbeat_on: {}...".format(heartbeat_state))
-
-        return True, "Set heartbeat_on: {}".format(heartbeat_state)
-
     def start_acq(self, session, params=None):
         """acq(params=None)
 
@@ -350,7 +334,6 @@ def main():
                         startup=init_params)
     agent.register_task('set_values', therm.set_values)
     agent.register_task('upload_cal_curve', therm.upload_cal_curve)
-    agent.register_task('set_heartbeat', therm.set_heartbeat_state)
     agent.register_process('acq', therm.start_acq, therm.stop_acq)
 
     runner.run(agent, auto_reconnect=True)


### PR DESCRIPTION
This commit adds a single task to the LS240 Agent for testing the disconnection
of an Agent heartbeat. We use the 240 Agent since it is an easy example that
has an accompanying software simulator.

We also adjust the acq method name to conform to naming conventions and update
its documentation.

Finally, we add txaio logging and a LOGLEVEL environment variable. 