### PR TITLE
Add delay in data collection to account for pause

### DIFF
--- a/docs/lakeshore372.rst
+++ b/docs/lakeshore372.rst
@@ -25,7 +25,8 @@ configuration block::
   {'agent-class': 'Lakeshore372Agent',
    'instance-id': 'LSA22YG',
    'arguments': [['--serial-number', 'LSA22YG'],
-                 ['--ip-address', '10.10.10.2']]},
+                 ['--ip-address', '10.10.10.2'],
+                 ['--dwell-time-delay', 0]]},
 
 Each device requires configuration under 'agent-instances'. See the OCS site
 configs documentation for more details.


### PR DESCRIPTION
The 372 inputs have a user set parameter called "change pause", which has a
minimum of 3 seconds. This is time after switching channels that the 372 waits
before collecting measurements. If the channel is queried in this time it'll
report the same value repeatedly. This means we end up collecting 3 seconds 
(or whatever the pause value is set to) of identical, stale, data points. This patch
addresses that by tracking when channels change, querying the pause setting
and sleeping for that time.

There's also some other minor cleanup that were simple things I noticed while
linting.