### PR TITLE
Check uploaded calibration points

### DIFF
--- a/socs/Lakeshore/Lakeshore372.py
+++ b/socs/Lakeshore/Lakeshore372.py
@@ -227,12 +227,10 @@ class LS372:
 
         if '?' in message:
             self.com.send(msg_str)
-             # Try once, if we timeout, try again. Usually gets around single event glitches.
+            # Try once, if we timeout, try again. Usually gets around single event glitches.
             for attempt in range(2):
                 try:
-                    #print('before sending {}'.format(msg_str))
-                    #print('after sending {}'.format(msg_str))
-                    time.sleep(0.05)
+                    time.sleep(0.061)
                     resp = str(self.com.recv(4096), 'utf-8').strip()
                     break
                 except socket.timeout:
@@ -1296,6 +1294,7 @@ class Curve:
 
         # refresh curve attributes
         self.get_header()
+        self._check_curve(_file)
 
     def _check_curve(self, _file):
         """After setting a data point for calibration curve,
@@ -1311,12 +1310,9 @@ class Curve:
             content = f.readlines()
 
         #skipping header info
-
         values = []
         for i in range(9, len(content)):
             values.append(content[i].strip().split()) #data points that should have been uploaded
-
-
         for j in range(1, 201):
             try:
                 resp = self.get_data_point(j) #response from the 372
@@ -1327,7 +1323,7 @@ class Curve:
                 assert temperature == float(point[2]), "Point number %s not uploaded"%point[0]
                 print("Successfully uploaded %s, %s" %(units,temperature))
             #if AssertionError, tell 372 to re-upload points
-            except:
+            except AssertionError:
                 if units != float(point[1]):
                     self.set_curve(_file)
 
@@ -1372,7 +1368,7 @@ class Heater:
         self.filter = None
         self.delay = None
 
-        self.range =  None
+        self.range = None
 
         self.resistance = None
         self.max_current = None

--- a/socs/Lakeshore/Lakeshore372.py
+++ b/socs/Lakeshore/Lakeshore372.py
@@ -226,11 +226,13 @@ class LS372:
         msg_str = f'{message}\r\n'.encode()
 
         if '?' in message:
-            # Try once, if we timeout, try again. Usually gets around single event glitches.
+            self.com.send(msg_str)
+             # Try once, if we timeout, try again. Usually gets around single event glitches.
             for attempt in range(2):
                 try:
-                    self.com.send(msg_str)
-                    time.sleep(0.01)
+                    #print('before sending {}'.format(msg_str))
+                    #print('after sending {}'.format(msg_str))
+                    time.sleep(0.05)
                     resp = str(self.com.recv(4096), 'utf-8').strip()
                     break
                 except socket.timeout:
@@ -246,7 +248,7 @@ class LS372:
         if 'RDG' in message:
             time.sleep(0.1)  # Instrument sampling rate of 10 readings/s max (pg 34)
         else:
-            time.sleep(0.05)  # No comms for 50 ms after sending message
+            time.sleep(0.061)  # No comms for 61ms after sending message after trial & error (manual says50ms)
         return resp
 
     def get_id(self):
@@ -1202,8 +1204,7 @@ class Curve:
         resp = self.ls.msg(f"CRVPT? {self.curve_num},{index}").split(',')
         _units = float(resp[0])
         _temp = float(resp[1])
-        _curvature = float(resp[2])
-        return (_units, _temp, _curvature)
+        return (_units, _temp)
 
     def _set_data_point(self, index, units, kelvin, curvature=None):
         """Set a single data point with the CRVPT command.
@@ -1241,8 +1242,7 @@ class Curve:
             breakpoints.append(x)
 
         struct_array = np.array(breakpoints, dtype=[('units', 'f8'),
-                                                    ('temperature', 'f8'),
-                                                    ('curvature', 'f8')])
+                                                    ('temperature', 'f8')])
 
         self.breakpoints = struct_array
 
@@ -1295,7 +1295,41 @@ class Curve:
             self._set_data_point(point[0], point[1], point[2])
 
         # refresh curve attributes
-        return self.get_header()
+        self.get_header()
+
+    def _check_curve(self, _file):
+        """After setting a data point for calibration curve,
+        use CRVPT? command from get_data_point() to check
+        that all points of calibration curve  were uploaded.
+        If not, re-upload points.
+
+        :param _file: calibration curve file
+        :type _file: str
+        """
+
+        with open(_file) as f:
+            content = f.readlines()
+
+        #skipping header info
+
+        values = []
+        for i in range(9, len(content)):
+            values.append(content[i].strip().split()) #data points that should have been uploaded
+
+
+        for j in range(1, 201):
+            try:
+                resp = self.get_data_point(j) #response from the 372
+                point = values[j-1]
+                units = float(resp[0])
+                temperature = float(resp[1])
+                assert units == float(point[1]), "Point number %s not uploaded"%point[0]
+                assert temperature == float(point[2]), "Point number %s not uploaded"%point[0]
+                print("Successfully uploaded %s, %s" %(units,temperature))
+            #if AssertionError, tell 372 to re-upload points
+            except:
+                if units != float(point[1]):
+                    self.set_curve(_file)
 
     def delete_curve(self):
         """Delete the curve using the CRVDEL command.
@@ -1338,7 +1372,7 @@ class Heater:
         self.filter = None
         self.delay = None
 
-        self.range = None
+        self.range =  None
 
         self.resistance = None
         self.max_current = None


### PR DESCRIPTION
Curve upload method not fully reliable (not all 200 data points get fully uploaded at random times). Wrote a method to check uploaded calibration points; if points not uploaded, the method re-uploads calibration points. 

Timeout Error at 50ms; 61ms fixes this issue currently.