### PR TITLE
Added docs on how to setup .ssh permissions for pysmurf archiver

### DIFF
--- a/docs/agents/pysmurf/pysmurf-archiver.rst
+++ b/docs/agents/pysmurf/pysmurf-archiver.rst
@@ -38,7 +38,8 @@ Example site-config entry::
 
 Setting up SSH Permissions
 --------------------------
-This still needs work...
+For instructions on how to setup ssh-permissions for the pysmurf-archiver,
+see the following SO-wiki page: http://simonsobservatory.wikidot.com/daq:smurf-ssh-permissions
 
 Docker Configuration
 --------------------
@@ -55,6 +56,7 @@ The docker-compose entry is similar to that of the pysmurf-monitor. For example:
             MYSQL_PASSWORD: ${DB_PW}
         volumes:
             - ${OCS_CONFIG_DIR}:/config
+            - /home/ocs:/home/ocs
             - /data:/data
         depends_on:
             - "sisock-crossbar"


### PR DESCRIPTION
Not much here to review, but I thought this would be a good place to discuss/finalize how to setup ssh permissions for the pysmurf-archiver so it can copy over files from the smurf-server. The docs describe how I currently set it up at UCSD, and it seems to work and not require much effort. If you have any problems with it let me know, otherwise I'll go ahead and merge it and use this method whenever I set up the archiver.

