### PR TITLE
Fix some documentation errors and warnings

### DIFF
--- a/agents/cryomech_cpa/cryomech_cpa_agent.py
+++ b/agents/cryomech_cpa/cryomech_cpa_agent.py
@@ -1,15 +1,19 @@
 # Script to log and readout PTC data through ethernet connection.
 # Tamar Ervin and Jake Spisak, February 2019
 
+import os
 import argparse
 import time
 import struct
 import socket
 import signal
 from contextlib import contextmanager
-from ocs import site_config, ocs_agent
-from ocs.ocs_twisted import TimeoutLock
 import random
+
+ON_RTD = os.environ.get('READTHEDOCS') == 'True'
+if not ON_RTD:
+    from ocs import site_config, ocs_agent
+    from ocs.ocs_twisted import TimeoutLock
 
 STX = '\x02'
 ADDR = '\x10'

--- a/docs/agents/pysmurf/index.rst
+++ b/docs/agents/pysmurf/index.rst
@@ -6,7 +6,7 @@
 Pysmurf/OCS Overview
 ====================
 
-There are three agents used to interact with `pysmurf <https://github.com/slaclab/pysmurf>`_.
+There are three agents used to interact with `pysmurf <https://github.com/slaclab/pysmurf>`__.
 The Pysmurf Controller is used to run pysmurf scripts.
 The Pysmurf Monitor listens to pysmurf messages published with the *pysmurf publisher*.
 The Pysmurf Archiver copies files pysmurf writes onto a storage node.

--- a/docs/agents/pysmurf/pysmurf-controller.rst
+++ b/docs/agents/pysmurf/pysmurf-controller.rst
@@ -121,9 +121,4 @@ Agent API
 This agent registers the **run**, **abort**, and **tune_squids** tasks.
 
 .. autoclass:: agents.pysmurf_controller.pysmurf_controller.PysmurfController
-    :members: run, abort, tune_squids
-
-
-
-
-
+    :members: run_script, abort_script, tune_squids


### PR DESCRIPTION
#38 caused RTD builds to fail due to an unprotected OCS import.

There were also some lingering build warnings from an error in the pysmurf-controller docs, so I addressed those as well.