### PR TITLE
modified archiver path creation

### DIFF
--- a/agents/pysmurf_archiver/pysmurf_archiver_agent.py
+++ b/agents/pysmurf_archiver/pysmurf_archiver_agent.py
@@ -21,11 +21,13 @@ def create_local_path(file, data_dir):
 
         The file path will be:
 
-            data_dir/<5 ctime digits>/<file_type>/<file_name>
+            data_dir/<5 ctime digits>/<pub_id>/<time_action>/outputs/fname
 
-        E.g.
+        or 
 
-            /data/pysmurf/15647/tuning/1564799250_tuning_b1.txt
+            data_dir/<5 ctime digits>/<pub_id>/<time_action>/plots/fname
+        
+        depending on whether the file is a plot
 
         Arguments
         ---------
@@ -42,13 +44,18 @@ def create_local_path(file, data_dir):
 
     print(file['path'])
     filename = os.path.basename(file['path'])
+    filename_ts = filename.split('_')[0]
 
     dt = file['timestamp']
 
+    dir_type = "plots" if file['plot'] else 'outputs'
+
     subdir = os.path.join(
-                data_dir,
-                f"{str(dt.timestamp()):.5}",
-                f"{file['type']}"
+                data_dir,                       # Base directory
+                f"{str(dt.timestamp()):.5}",    # 5 ctime digits
+                file['pub_id'],                 # Publisher_id
+                                                # timestamp_function
+                dir_type                        # plots/outputs
              )
 
     if not os.path.exists(subdir):
@@ -217,7 +224,7 @@ class PysmurfArchiverAgent:
                         # If file copied successfully
                         self.log.debug("Successfully coppied file {}".format(f['path']))
                         query = """
-                            UPDATE pysmurf_files SET path=%s, copied=1 
+                            UPDATE pysmurf_files SET archived_path=%s, copied=1 
                             WHERE id=%s
                         """
                         cur.execute(query, (new_path, f['id']))

--- a/agents/pysmurf_archiver/pysmurf_archiver_agent.py
+++ b/agents/pysmurf_archiver/pysmurf_archiver_agent.py
@@ -13,6 +13,51 @@ on_rtd = os.environ.get('READTHEDOCS') == 'True'
 if not on_rtd:
     from ocs import ocs_agent, site_config
 
+action_types = {
+    # These tags are doubled up in different functions, so just grouping like
+    # this for now...
+    "adc": 'adc',  
+    "dac": 'dac',
+
+    # From smurf_util.py
+    "bias_bump": 'bias_bump',
+    "delay": 'estimate_phase_delay',
+    "mask": 'gcp_mask',
+    
+    #from smurf_tune.py
+    "amp_vs_err": 'tracking_setup',
+    "eta": 'eta_fit',
+    "find_freq": 'find_peak',
+    "flux_ramp": 'flux_ramp_check',
+    "full_band_resp": 'full_band_resp',
+    "resonances": 'tune_band',
+    "response": 'full_band_resp',
+    "sweep_response": 'find_freq',
+    "tracking": 'tracking_setup',
+    "tune": 'tune',
+
+    # From smurf_noise.py
+    # Grouping all noise files together...
+    "datafiles": 'noise',
+    "noise": 'noise',
+    "noise_timestream": 'noise',
+    "noise_vs_tone_data": 'noise',
+    "noise_vs_tone_tone": 'noise',
+    "noise_vs": 'noise',
+    "psd": 'noise',
+
+    # From smurf_iv.py
+    "iv": 'slow_iv',
+    "iv_bias": 'slow_iv',
+    "iv_hist": 'slow_iv',
+    "iv_raw": 'slow_iv',
+    "iv_stream": 'slow_iv',
+    "opt_efficiency": 'opt_eff',
+    "plc_bias": 'partial_load_curve',
+    "plc_raw": 'partial_load_curve',
+    "plc_stream": 'partial_load_curve'
+}
+
 
 def create_local_path(file, data_dir):
     """
@@ -44,19 +89,29 @@ def create_local_path(file, data_dir):
 
     print(file['path'])
     filename = os.path.basename(file['path'])
-    filename_ts = filename.split('_')[0]
-
     dt = file['timestamp']
-
     dir_type = "plots" if file['plot'] else 'outputs'
 
+    time_action_string = ""
+    try:
+        group_time = int(filename.split('_')[0])
+        time_action_string += str(group_time) + "_"
+    except ValueError as e:
+        print("Filename does not start with a timestamp. Using file creation timestamp")
+        time_action_string += str(int(dt.timestamp())) + "_"
+
+    # Tries to get general action name from dict, but defaults to type if not 
+    # present
+    time_action_string += action_types.get(file['type'], file['type'])
+
+
     subdir = os.path.join(
-                data_dir,                       # Base directory
-                f"{str(dt.timestamp()):.5}",    # 5 ctime digits
-                file['pub_id'],                 # Publisher_id
-                                                # timestamp_function
-                dir_type                        # plots/outputs
-             )
+        data_dir,                       # Base directory
+        f"{str(dt.timestamp()):.5}",    # 5 ctime digits
+        file['pub_id'],                 # Publisher_id
+        time_action_string,             # grouptime_action
+        dir_type                        # plots/outputs
+    )
 
     if not os.path.exists(subdir):
         os.makedirs(subdir)

--- a/socs/db/pysmurf_files_manager.py
+++ b/socs/db/pysmurf_files_manager.py
@@ -20,6 +20,7 @@ class Column:
 columns = [
     Column("id", "INT", opts="NOT NULL AUTO_INCREMENT PRIMARY KEY"),
     Column("path", "VARCHAR(260)", opts="UNIQUE NOT NULL"),
+    Column('archived_path', 'VARCHAR(260)', opts='UNIQUE'),
     Column("type", "VARCHAR(32)", opts="NOT NULL"),
     Column("timestamp", "TIMESTAMP"),
     Column("format", "VARCHAR(32)"),


### PR DESCRIPTION
I mostly wanted to start this PR so we can decide if we want to change the pysmurf_archiver path based on what we talked about 1.5 weeks ago before the pton meeting. Based on that discussion, the path should be something like 
```
data_dir/<5 ctime digits>/<pub_id>/<time_action>/outputs/fname
```
or
```
data_dir/<5 ctime digits>/<pub_id>/<time_action>/plots/fname
```

For example: `/data/pysmurf/15058/crate1_slot2/1580857504_find_freq/outputs/1580857504_amp_sweep_resp.txt`

The only thing I'm not quite sure about is how to get the <time_action> value. The time I can almost always get from the first part of the filename, and then they will all be grouped together, but the only thing I can think of for the action is submitting the function name whenever a new file is registered. Can anyone think of a better idea for this? If that's the case then it might be hard to have this by the pton meeting since it'll require a pysmurf pull-request.

In this branch there's kind of a stop-gap that has that structure, but without the <time_action> section that we can use for now, or we can just stick with the old format for this meeting and mention we want to change it soon after. Any thoughts?