### PR TITLE
Add test stage to Travis CI Pipeline

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,6 +8,7 @@ python:
   - "3.6"
 
 stages:
+  - test
   - name: dockerize
     if: |
       branch = master AND \
@@ -15,6 +16,28 @@ stages:
 
 jobs:
   include:
+    - stage: test
+      install:
+        # Build the docker images with docker-compose
+        - docker-compose build
+
+      script:
+        # Run tests via pytest runner with coverage in a docker container
+        - docker run -v $PWD:/coverage --rm socs sh -c "COVERAGE_FILE=/coverage/.coverage.docker python3 -m pytest -p no:wampy --cov /app/socs/socs/ ./tests/"
+
+      after_success:
+        # Install coveralls
+        - pip install coveralls
+
+        # Combine results from suffixed .coverage.docker to fix paths from container testing
+        - coverage combine
+
+        # Show report with updated paths
+        - coverage report
+
+        # Publish results to coveralls
+        - coveralls
+
     - stage: dockerize
       install: true
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -7,10 +7,8 @@ FROM simonsobs/ocs:v0.6.0-1-g569b428
 # Copy the current directory contents into the container at /app
 COPY . /app/socs/
 
-WORKDIR /app/
+WORKDIR /app/socs/
 
 # Install socs
-RUN pip3 install -r socs/requirements.txt \
-    && pip3 install -e socs
-
-
+RUN pip3 install -r requirements.txt && \
+    pip3 install -e .

--- a/README.rst
+++ b/README.rst
@@ -9,6 +9,9 @@ SOCS - Simons Observatory Control System
     :target: https://socs.readthedocs.io/en/latest/?badge=latest
     :alt: Documentation Status
 
+.. image:: https://coveralls.io/repos/github/simonsobs/socs/badge.svg?branch=travis
+    :target: https://coveralls.io/github/simonsobs/socs?branch=travis
+
 Overview
 --------
 

--- a/tests/README.rst
+++ b/tests/README.rst
@@ -2,25 +2,27 @@
 Testing
 =======
 
-Unit tests for OCS. These are separated into tests for hardware and mock tests
-(meaning simulated hardware). While it'd be nice to test on hardware all the
-time it likely isn't feasible. For this reason we should mock up the hardware
-interfaces for thing we'd like to test so that we can test the code.
-
-These tests are likely the same, except with a fake hardware control class.
-Writing tests for hardware during development might be quicker than mocking up
-the interface, so we present this separation.
+Unit tests for OCS. These historically were separated into tests for hardware
+and mock tests (meaning simulated hardware). Automated tests currently run on
+all tests other than those in this old directories. Hardware tests are very
+useful, but not always able to be run, pending the availability of the
+hardware. All other tests should be runable independently.
 
 Running the Test Suite
 ----------------------
-Decide whether or not you're testing on actual hardware or just mock hardware,
-change to the appropriate directory and run with pytest::
+To run the tests, from the top level of the repo run::
 
-  cd mock/
-  pytest
+    $ python3 -m pytest -p no:wampy --cov-report html --cov socs ./tests/
+
+You can then view the coverage report in the typical ``htmlcov/`` directory.
+
+
+If you are running tests on hardware you likely want to run them directly from
+the hardware directory, which is configured to be ignored by the automatic test
+discovery in pytest.
 
 When running on hardware, call only the test you'd like to run. For instance,
 to test just the Lakeshore 372::
 
-  cd hardware/
-  pytest test_ls372.py
+  $ cd hardware/
+  $ python3 -m pytest test_ls372.py


### PR DESCRIPTION
After writing all those tests for the timestream aggregator I wanted to get this running on travis. This setup matches the setup we have for both the ocs and so3g repositories, where we run the tests within a docker container that has all the required dependencies.

The only potentially conflicting change is the small adjustments I made to the Dockerfile. I did this just to be consistent with how the ocs Dockerfile is organized, allowing the commands for running things to remain consistent across repos. Let me know if the changed WORKDIR is going to disrupt anything.

We also add test coverage reporting via coveralls like we have for ocs and so3g.