### PR TITLE
Adds pysmurf actions to the pysmurf archiver path

### DIFF
--- a/agents/pysmurf_archiver/pysmurf_archiver_agent.py
+++ b/agents/pysmurf_archiver/pysmurf_archiver_agent.py
@@ -22,11 +22,11 @@ def create_local_path(file, data_dir):
 
         The file path will be:
 
-            data_dir/<5 ctime digits>/<file_type>/<file_name>
+            data_dir/<5 ctime digits>/<pub_id>/<action_timestamp>_<action>/<plots or outputs>
 
         E.g.
 
-            /data/pysmurf/15647/tuning/1564799250_tuning_b1.txt
+            /data/pysmurf/15647/crate1slot2/1564799250_tune_band/outputs/1564799250_tuning_b1.txt
 
         In the case of duplicate datafiles being registered, the duplicates
         will still be copied over to the location `new_path_name.{i}` where

--- a/agents/pysmurf_archiver/pysmurf_archiver_agent.py
+++ b/agents/pysmurf_archiver/pysmurf_archiver_agent.py
@@ -54,11 +54,10 @@ def create_local_path(file, data_dir):
 
     # First tries to get action timestamp entry
     action_ts = file['action_timestamp']
-
     if action_ts is None:
         try:
             # If that doesn't exist, try to get the group timestamp from the filename
-            action_ts = int(filename.split('_')[0])
+            action_ts = int(os.path.splitext(filename)[0].split('_')[0])
         except ValueError as e:
             # If that doesn't work, just use the file creation timestamp
             action_ts = str(int(dt.timestamp()))

--- a/agents/pysmurf_archiver/pysmurf_archiver_agent.py
+++ b/agents/pysmurf_archiver/pysmurf_archiver_agent.py
@@ -50,7 +50,7 @@ def create_local_path(file, data_dir):
 
     dt = file['timestamp']
 
-    action = file['type']
+    action = file['action']
 
     # First tries to get action timestamp entry
     action_ts = file['action_timestamp']
@@ -239,7 +239,6 @@ class PysmurfArchiverAgent:
                     self.log.debug(f"Found {len(files)} uncopied files.")
 
                 for f in files:
-
                     new_path = create_local_path(f, self.data_dir)
 
                     md5sum = binascii.hexlify(f['md5sum']).decode()

--- a/agents/pysmurf_archiver/pysmurf_archiver_agent.py
+++ b/agents/pysmurf_archiver/pysmurf_archiver_agent.py
@@ -50,11 +50,28 @@ def create_local_path(file, data_dir):
 
     dt = file['timestamp']
 
+    action = file['type']
+
+    # First tries to get action timestamp entry
+    action_ts = file['action_timestamp']
+
+    if action_ts is None:
+        try:
+            # If that doesn't exist, try to get the group timestamp from the filename
+            action_ts = int(filename.split('_')[0])
+        except ValueError as e:
+            # If that doesn't work, just use the file creation timestamp
+            action_ts = str(int(dt.timestamp()))
+
+    dir_type = 'plots' if file['plot'] else 'outputs'
+
     subdir = os.path.join(
-                data_dir,
-                f"{str(dt.timestamp()):.5}",
-                f"{file['type']}"
-             )
+        data_dir,                       # Base directory
+        f"{str(dt.timestamp()):.5}",    # 5 ctime digits
+        file['pub_id'],                 # publisher id
+        f"{action_ts}_{action}",        # grouptime_action
+        dir_type,                       # plots/outputs
+    )
     new_path = os.path.join(subdir, filename)
     unique_path = new_path
     i = 1

--- a/agents/pysmurf_monitor/pysmurf_monitor.py
+++ b/agents/pysmurf_monitor/pysmurf_monitor.py
@@ -113,7 +113,7 @@ class PysmurfMonitor(DatagramProtocol):
                 'path':                 path,
                 'type':                 d['action'],
                 'timestamp':            datetime.datetime.utcfromtimestamp(d['timestamp']),
-                'action_timestamp':     d['action_ts'],
+                'action_timestamp':     d.get('action_ts'),
                 'format':               d['format'],
                 'plot':                 int(d['plot']),
                 'site':                 site,

--- a/agents/pysmurf_monitor/pysmurf_monitor.py
+++ b/agents/pysmurf_monitor/pysmurf_monitor.py
@@ -170,8 +170,8 @@ def make_parser(parser=None):
     pgroup.add_argument('--udp-port', type=int,
                         help="Port for upd-publisher")
     pgroup.add_argument('--create-table', type=bool,
-                        help="Specifies whether agent should create pysmurf_files"
-                             "table if none exist.", default=True)
+                        help="Specifies whether agent should create or update "
+                             "pysmurf_files table if non exists.", default=True)
 
     return parser
 

--- a/agents/pysmurf_monitor/pysmurf_monitor.py
+++ b/agents/pysmurf_monitor/pysmurf_monitor.py
@@ -111,7 +111,7 @@ class PysmurfMonitor(DatagramProtocol):
 
             entry = {
                 'path':                 path,
-                'type':                 d['action'],
+                'action':               d['action'],
                 'timestamp':            datetime.datetime.utcfromtimestamp(d['timestamp']),
                 'action_timestamp':     d.get('action_ts'),
                 'format':               d['format'],

--- a/agents/pysmurf_monitor/pysmurf_monitor.py
+++ b/agents/pysmurf_monitor/pysmurf_monitor.py
@@ -101,21 +101,31 @@ class PysmurfMonitor(DatagramProtocol):
 
         if data['type'] in ['data_file']:
             self.log.info("New file: {fname}", fname=data['payload']['path'])
-            d = data['payload'].copy()
+            d = data['payload']
 
+            site, instance = self.agent.agent_address.split('.')
+
+            path = d['path']
             if (d['format'] == 'npy') and (not d['path'].endswith('.npy')):
-                d['path'] += '.npy'
+                path += '.npy'
 
-            # Adds additional db info to dict
-            d['timestamp'] = datetime.datetime.utcfromtimestamp(d['timestamp'])
-            d['md5sum'] = get_md5sum(d['path'])
-            d['plot'] = int(d['plot'])
-            d['pub_id'] = data['id']
-            d['script_id'] = data['script']
+            entry = {
+                'path':                 path,
+                'type':                 d['action'],
+                'timestamp':            datetime.datetime.utcfromtimestamp(d['timestamp']),
+                'action_timestamp':     d['action_ts'],
+                'format':               d['format'],
+                'plot':                 int(d['plot']),
+                'site':                 site,
+                'pub_id':               data['id'],
+                'instance_id':          instance,
+                'copied':               0,
+                'failed_copy_attempts': 0,
+                'md5sum':               get_md5sum(d['path']),
+                'socs_version':         socs.__version__,
+            }
 
-            d.update(self.base_file_info)
-
-            deferred = self.dbpool.runInteraction(pysmurf_files_manager.add_entry, d)
+            deferred = self.dbpool.runInteraction(pysmurf_files_manager.add_entry, entry)
             deferred.addErrback(self._add_file_errback, d)
             deferred.addCallback(self._add_file_callback, d)
 

--- a/docs/agents/pysmurf/pysmurf-archiver.rst
+++ b/docs/agents/pysmurf/pysmurf-archiver.rst
@@ -60,3 +60,26 @@ The docker-compose entry is similar to that of the pysmurf-monitor. For example:
             - /data:/data
         depends_on:
             - "sisock-crossbar"
+
+Archived Path
+--------------
+
+The archiver uses the ``action`` and ``action_timestamp`` fields so that
+plots and outputs that are created during a single user action are archived
+together. Action names for pysmurf and sodetlib functions are generally the
+top-level function name that the user runs, but actions can also be set at
+runtime with the keyword argument ``pub_action``.
+
+The archived path is determined by::
+
+    <data_dir>/<5 ctime digits>/<pub_id>/<action_timestamp>_<action>/<plots or outputs>
+
+Where ``<data_dir>`` is the ocs-site argument for the archiver, the 5 ctime
+digits corresponds with ~ 1 day of data, and ``<pub_id>`` is the pysmurf
+publisher id.
+For instance, if a user runs ``S.tracking_setup`` at ``ctime`` 1589517264,
+on crate=1, slot=2, the output might be stored in the directory::
+
+    <data_dir>/15895/crate1_slot2/1589517264_tracking_setup/outputs
+
+.. autofunction:: agents.pysmurf_archiver.pysmurf_archiver_agent.create_local_path

--- a/docs/agents/pysmurf/pysmurf-monitor.rst
+++ b/docs/agents/pysmurf/pysmurf-monitor.rst
@@ -41,16 +41,21 @@ The database is located in a MariaDB docker container running on the crossbar
 system. The database name is ``files``, and it is also used to index hk files
 written by the hk-aggregator.
 
-The table containing the pysmurf file info is called ``pysmurf_files``.
-The pysmurf monitor will create/update this table if it does not exist or if
-columns have been added, but you can also create, update, and drop this table
+The table containing the pysmurf file info is called ``pysmurf_files_v<VERSION>``
+where ``VERSION`` is the current iteration of the table.
+This version number will increment anytime the table schema is changed, so
+we don't lose information about old files.
+The pysmurf-monitor agent will create the newest version of the ``pysmurf_files``
+table automatically if it does not yet exist, but you can also create and drop this table
 outside of OCS using the ``socs.db.pysmurf_files_manager`` module by calling::
 
     python3 socs/db/pysmurf_files_manager.py create
 
 and entering the db password at the prompt.
 
-..  list-table:: Columns
+Below are the columns that exist in ``pysmurf_files_v1``:
+
+..  list-table:: ``pysmurf_files_v1`` columns
     :widths: 10 10 60
 
     * - path (required)
@@ -58,13 +63,19 @@ and entering the db password at the prompt.
       - Filepath. At first it is the path on the smurf-server, and
         once copied it is the path on the storage node.
 
-    * - type (required)
+    * - action
       - str
-      - Type of file. **E.g.** "tuning" or "config_snapshot"
+      - `Pysmurf action` corresponding to the file. All files with the same
+        action will be grouped together once archived.
 
     * - timestamp
       - datetime
       - Time at which file was written
+
+    * - action_timestamp
+      - int
+      - unix timestamp corresponding to the start of the pysmurf action.
+        This determines how files are grouped once archived.
 
     * - format
       - str

--- a/socs/db/pysmurf_files_manager.py
+++ b/socs/db/pysmurf_files_manager.py
@@ -16,12 +16,12 @@ class Column:
     def __str__(self):
         return " ".join([self.name, self.type, self.opts])
 
-TABLE_VERSION = 0
+TABLE_VERSION = 1
 table = f'pysmurf_files_v{TABLE_VERSION}'
 columns = [
     Column("id", "INT", opts="NOT NULL AUTO_INCREMENT PRIMARY KEY"),
     Column("path", "VARCHAR(260)", opts="NOT NULL"),
-    Column("type", "VARCHAR(32)", opts="NOT NULL"),
+    Column("action", "VARCHAR(32)"),
     Column("timestamp", "TIMESTAMP"),
     Column("action_timestamp", "INT"),
     Column("format", "VARCHAR(32)"),

--- a/socs/db/pysmurf_files_manager.py
+++ b/socs/db/pysmurf_files_manager.py
@@ -23,6 +23,7 @@ columns = [
     Column("path", "VARCHAR(260)", opts="NOT NULL"),
     Column("type", "VARCHAR(32)", opts="NOT NULL"),
     Column("timestamp", "TIMESTAMP"),
+    Column("action_timestamp", "INT"),
     Column("format", "VARCHAR(32)"),
     Column("plot", "TINYINT(1)"),
     Column("site", "VARCHAR(32)"),
@@ -49,7 +50,7 @@ def add_entry(cur, entry):
             "Keys allowed: {}".format(entry.keys(), col_dict.keys())
         )
     keys = list(entry.keys())
-    vals = [entry[k] for k in keys]
+    vals = [entry[k] for k in keys if entry[k] is not None]
     fmts = [col_dict[k].fmt for k in keys]
 
     query = "INSERT INTO {} ({}) VALUES ({})"\

--- a/socs/db/pysmurf_files_manager.py
+++ b/socs/db/pysmurf_files_manager.py
@@ -49,9 +49,14 @@ def add_entry(cur, entry):
             "Keys given: {}\n"
             "Keys allowed: {}".format(entry.keys(), col_dict.keys())
         )
-    keys = list(entry.keys())
-    vals = [entry[k] for k in keys if entry[k] is not None]
-    fmts = [col_dict[k].fmt for k in keys]
+
+    keys, vals, fmts = [], [], []
+    for k in list(entry.keys()):
+        if entry[k] is None:
+            continue
+        keys.append(k)
+        vals.append(entry[k])
+        fmts.append(col_dict[k].fmt)
 
     query = "INSERT INTO {} ({}) VALUES ({})"\
             .format(table, ", ".join(keys), ", ".join(fmts))


### PR DESCRIPTION
This fixes the archiver path based on what we decided at the pysmurf meeting, using "pysmurf actions" implemented [here](https://github.com/slaclab/pysmurf/pull/317). With this, the OCS archived path looks something like:
```
base/<5 ctime digits>/<smurfpub_id>/<grouptime_action>/<outputs or plots>/filename
```
Where the grouptime is the pysmurf timestamp at which the top-level function is called, and the action name is set in pysmurf (but right now is usually the smurf function name). For example:
```
/data/pysmurf/15844/smurf_emulator/1584400934_take_stream_data/outputs/1584400934.dat
```

This is backwards compatible with versions of pysmurf without the publisher actions, but we should probably wait on this until the pysmurf branch is merged.