### PR TITLE
session_data pathway for pysmurf-controller

### DIFF
--- a/agents/pysmurf_controller/pysmurf_controller.py
+++ b/agents/pysmurf_controller/pysmurf_controller.py
@@ -1,4 +1,4 @@
-from twisted.internet import reactor, protocol
+from twisted.internet import reactor, protocol, threads
 from twisted.python.failure import Failure
 from twisted.internet.error import ProcessDone, ProcessTerminated
 from twisted.internet.defer import inlineCallbacks, Deferred
@@ -151,7 +151,8 @@ class PysmurfController:
                 # causes problems...
                 logger = None
                 if isinstance(log, str):
-                    log_file = open(log, 'a')
+                    self.log.info("Logging output to file {}".format(log))
+                    log_file = yield threads.deferToThread(open, log, 'a')
                     logger = Logger(observer=FileLogObserver(log_file, log_formatter))
                 elif log:
                     # If log==True, use agent's logger

--- a/agents/pysmurf_controller/pysmurf_controller.py
+++ b/agents/pysmurf_controller/pysmurf_controller.py
@@ -108,10 +108,11 @@ class PysmurfController:
         data, feed = _data
 
         if self.current_session is not None:
-            if isinstance(data, dict):
-                self.current_session.data.update(data)
-            else:
-                self.log.warn("Session data not passed as a dict!! Skipping...")
+            if data['id'] == os.environ.get("SMURFPUB_ID"):
+                if isinstance(data, dict):
+                    self.current_session.data.update(data['payload'])
+                else:
+                    self.log.warn("Session data not passed as a dict!! Skipping...")
 
     @inlineCallbacks
     def _run_script(self, script, args, log, session):

--- a/agents/pysmurf_monitor/pysmurf_monitor.py
+++ b/agents/pysmurf_monitor/pysmurf_monitor.py
@@ -52,6 +52,8 @@ class PysmurfMonitor(DatagramProtocol):
         self.agent: ocs_agent.OCSAgent = agent
         self.log = agent.log
 
+        self.agent.register_feed('pysmurf_session_data')
+
         self.create_table = bool(args.create_table)
 
         site, instance = self.agent.agent_address.split('.')
@@ -116,6 +118,11 @@ class PysmurfMonitor(DatagramProtocol):
             deferred = self.dbpool.runInteraction(pysmurf_files_manager.add_entry, d)
             deferred.addErrback(self._add_file_errback, d)
             deferred.addCallback(self._add_file_callback, d)
+
+        elif data['type'] == "session_data":
+            self.agent.publish_to_feed(
+                "pysmurf_session_data", data['payload'], from_reactor=True
+            )
 
     def init(self, session, params=None):
         """

--- a/agents/pysmurf_monitor/pysmurf_monitor.py
+++ b/agents/pysmurf_monitor/pysmurf_monitor.py
@@ -121,7 +121,7 @@ class PysmurfMonitor(DatagramProtocol):
 
         elif data['type'] == "session_data":
             self.agent.publish_to_feed(
-                "pysmurf_session_data", data['payload'], from_reactor=True
+                "pysmurf_session_data", data, from_reactor=True
             )
 
     def init(self, session, params=None):

--- a/docs/agents/pysmurf/pysmurf-controller.rst
+++ b/docs/agents/pysmurf/pysmurf-controller.rst
@@ -123,8 +123,11 @@ ocs client script. This is now possible by using the smurf publisher.
 If you want to access the location of a smurf datafile,
 you can put the following into your pysmurf-script::
 
+    active_channels = S.which_on(0)
     datafile = S.stream_data_on()
-    S.pub.publish({'datafile': datafile}, msgtype='session_data')
+    S.pub.publish({
+        'datafile': datafile, 'active_channels': active_channels
+    }, msgtype='session_data')
 
 Marking the publish call with ``msgtype='session_data'`` will make the
 pysmurf-monitor (if it exists) pass this data back to the pysmurf-controller. You can
@@ -142,7 +145,24 @@ you can run::
     ok, msg, sess = controller.run.wait()
     print(sess['data'])
 
-    >> {'datafile': '/data/smurf_data/20200316/1584401673/outputs/1584402020.dat'}
+    >> {
+        'datafile': '/data/smurf_data/20200316/1584401673/outputs/1584402020.dat',
+        'active_channels': [0,1,2,3,4]
+    }
+
+You can also use this to communicate pysmurf status info to the client. For
+instance you can run::
+
+    S.pub.publish({'status': 'Starting take_stream_data'}, msgtype='session_data')
+    datafile = S.take_stream_data(10) # Streams data for 10 seconds
+    S.pub.publish({
+        'status': 'Finished take_stream_data', 'datafile': datafile
+     }, msgtype='session_data')
+
+Then if you inspect the session object returned from ``controller.run.status()``
+you'll be able to check whether or not ``take_stream_data`` has finished or not.
+This can be extremely helpful to monitor progress in long-running pysmurf
+scripts from the ocs-web monitor.
 
 Agent API
 ---------------

--- a/docs/agents/pysmurf/pysmurf-controller.rst
+++ b/docs/agents/pysmurf/pysmurf-controller.rst
@@ -29,7 +29,7 @@ Example site-config entry::
 
       {'agent-class': 'PysmurfController',
        'instance-id': 'pysmurf-controller',
-       'arguments': []},
+       'arguments': [['--monitor-id', 'pysmurf-monitor']]},
 
 
 Pysmurf Publisher options
@@ -114,6 +114,35 @@ OCS client from my host computer::
 
 where my ``$OCS_CONFIG_DIR`` is mounted to ``/config`` in the docker.
 
+
+Passing Session Data
+---------------------
+
+Often you might want to take data from your pysmurf-script, and access it from
+ocs client script. This is now possible by using the smurf publisher.
+If you want to access the location of a smurf datafile,
+you can put the following into your pysmurf-script::
+
+    datafile = S.stream_data_on()
+    S.pub.publish({'datafile': datafile}, msgtype='session_data')
+
+Marking the publish call with ``msgtype='session_data'`` will make the
+pysmurf-monitor (if it exists) pass this data back to the pysmurf-controller. You can
+then view the data from the client by running ``status`` or ``wait`` to check the
+session data. For example, if the ``tune.py`` file publishes the datafile variable,
+you can run::
+
+    from ocs.matched_client import MatchedClient
+
+    controller = MatchedClient('pysmurf-controller', args=[])
+
+    script_path = '/config/scripts/pysmurf/tune.py'
+    controller.run.start(script=script_path))
+
+    ok, msg, sess = controller.run.wait()
+    print(sess['data'])
+
+    >> {'datafile': '/data/smurf_data/20200316/1584401673/outputs/1584402020.dat'}
 
 Agent API
 ---------------


### PR DESCRIPTION
This PR adds a pathway to communicate data from a running pysmurf script to the pysmurf-controller's session data variable.

If you call `S.pub.publish(data, msgtype="session_data")` for some dict `data`, then they pysmurf-monitor will publish `data` to an ocs_feed. The pysmurf-controller will then receive that data, then update the current session's `session_data` variable. The pysmurf-controller needs to be told which pysmurf-monitor to listen to, which can be done using the `--monitor-id` site-arg.

Since there will only ever be one script running at a time, I took Matthew's suggestion and made the controller's tasks all run in the reactor thread. I've tested it and it seems to work fine, but Matthew if you could look at it and verify that it's correct that would be awesome.