### PR TITLE
lakeshore372: allow Tasks to run while acq Process is running

### DIFF
--- a/agents/lakeshore372/LS372_agent.py
+++ b/agents/lakeshore372/LS372_agent.py
@@ -4,6 +4,8 @@ import argparse
 import time
 import numpy as np
 import txaio
+import threading
+from contextlib import contextmanager
 
 from socs.Lakeshore.Lakeshore372 import LS372
 
@@ -11,6 +13,60 @@ ON_RTD = os.environ.get('READTHEDOCS') == 'True'
 if not ON_RTD:
     from ocs import ocs_agent, site_config
     from ocs.ocs_twisted import TimeoutLock
+
+
+class YieldingLock:
+    """A lock protected by a lock.  This braided arrangement guarantees
+    that a thread waiting on the lock will get priority over a thread
+    that has just released the lock and wants to reacquire it.
+
+    The typical use case is a Process that wants to hold the lock as
+    much as possible, but occasionally release the lock (without
+    sleeping for long) so another thread can access a resource.  The
+    method release_and_acquire() is provided to make this a one-liner.
+
+    """
+    def __init__(self, default_timeout=None):
+        self.job = None
+        self._next = threading.Lock()
+        self._active = threading.Lock()
+        self._default_timeout = default_timeout
+
+    def acquire(self, timeout=None, job=None):
+        if timeout is None:
+            timeout = self._default_timeout
+        if timeout is None or timeout == 0.:
+            kw = {'blocking': False}
+        else:
+            kw = {'blocking': True, 'timeout': timeout}
+        result = False
+        if self._next.acquire(**kw):
+            if self._active.acquire(**kw):
+                self.job = job
+                result = True
+            self._next.release()
+        return result
+
+    def release(self):
+        self.job = None
+        return self._active.release()
+
+    def release_and_acquire(self, timeout=None):
+        job = self.job
+        self.release()
+        return self.acquire(timeout=timeout, job=job)
+
+    @contextmanager
+    def acquire_timeout(self, timeout=None, job='unnamed'):
+        result = self.acquire(timeout=timeout, job=job)
+        if result:
+            try:
+                yield result
+            finally:
+                self.release()
+        else:
+            yield result
+
 
 class LS372_Agent:
     """Agent to connect to a single Lakeshore 372 device.
@@ -35,11 +91,12 @@ class LS372_Agent:
         # this lock.
         self._acq_proc_lock = TimeoutLock()
 
-        # self._lock is the general Task lock, that is held by the acq
-        # Process only when accessing the hardware.  Tasks that are,
-        # in principal, safe to run during idle time in the acq
-        # process can try to acquire this lock.
-        self._lock = TimeoutLock()
+        # self._lock is held by the acq Process only when accessing
+        # the hardware but released occasionally so that (short) Tasks
+        # may run.  Use a YieldingLock to guarantee that a waiting
+        # Task gets activated preferentially, even if the acq thread
+        # immediately tries to reacquire.
+        self._lock = YieldingLock(default_timeout=5)
 
         self.name = name
         self.ip = ip
@@ -61,16 +118,6 @@ class LS372_Agent:
                                  record=True,
                                  agg_params=agg_params,
                                  buffer_time=1)
-
-    def _lock_acquire(self, job, timeout=5):
-        # Returns a ContextManager -- the abstraction here is just to
-        # set a default timeout parameter.
-        return self._lock.acquire_timeout(timeout=timeout, job=job)
-
-    def _acq_proc_lock_acquire(self, job, timeout=0):
-        # Returns a ContextManager -- the abstraction here is just to
-        # set a default timeout parameter.
-        return self._acq_proc_lock.acquire_timeout(timeout=timeout, job=job)
 
     def init_lakeshore_task(self, session, params=None):
         """init_lakeshore_task(params=None)
@@ -94,8 +141,9 @@ class LS372_Agent:
             self.log.info("Lakeshore already initialized. Returning...")
             return True, "Already initialized"
 
-        with self._lock_acquire('init') as acquired1, \
-             self._acq_proc_lock_acquire('init') as acquired2:
+        with self._lock.acquire_timeout(job='init') as acquired1, \
+             self._acq_proc_lock.acquire_timeout(timeout=0., job='init') \
+             as acquired2:
             if not acquired1:
                 self.log.warn(f"Could not start init because "
                               f"{self._lock.job} is already running")
@@ -128,8 +176,9 @@ class LS372_Agent:
 
     def start_acq(self, session, params=None):
 
-        with self._acq_proc_lock_acquire(job='acq') as acq_acquired, \
-             self._lock_acquire(job='acq') as acquired:
+        with self._acq_proc_lock.acquire_timeout(timeout=0, job='acq') \
+             as acq_acquired, \
+             self._lock.acquire_timeout(job='acq') as acquired:
             if not acq_acquired:
                 self.log.warn(f"Could not start Process because "
                               f"{self._acq_proc_lock.job} is already running")
@@ -150,9 +199,7 @@ class LS372_Agent:
                 # Relinquish sampling lock occasionally.
                 if time.time() - last_release > 1.:
                     last_release = time.time()
-                    self._lock.release()
-                    time.sleep(.1)
-                    if not self._lock.acquire(timeout=10):
+                    if not self._lock.release_and_acquire(timeout=10):
                         self.log.warn(f"Failed to re-acquire sampling lock, "
                                       f"currently held by {self._lock.job}.")
                         continue
@@ -250,7 +297,7 @@ class LS372_Agent:
                the servo to adjust to the new heater range, typical value of
                ~600 seconds
         """
-        with self._lock_acquire('set_heater_range') as acquired:
+        with self._lock.acquire_timeout(job='set_heater_range') as acquired:
             if not acquired:
                 self.log.warn(f"Could not start Task because "
                               f"{self._lock.job} is already running")
@@ -282,7 +329,7 @@ class LS372_Agent:
         :type params: dict
         """
 
-        with self._lock_acquire('set_excitation_mode') as acquired:
+        with self._lock.acquire_timeout(job='set_excitation_mode') as acquired:
             if not acquired:
                 self.log.warn(f"Could not start Task because "
                               f"{self._lock.job} is already running")
@@ -303,7 +350,7 @@ class LS372_Agent:
         :param params: dict with "channel" and "value" keys for Channel.set_excitation()
         :type params: dict
         """
-        with self._lock_acquire('set_excitation') as acquired:
+        with self._lock.acquire_timeout(job='set_excitation') as acquired:
             if not acquired:
                 self.log.warn(f"Could not start Task because "
                               f"{self._lock.job} is already running")
@@ -329,7 +376,7 @@ class LS372_Agent:
         :param params: dict with "P", "I", and "D" keys for Heater.set_pid()
         :type params: dict
         """
-        with self._lock_acquire('set_pid') as acquired:
+        with self._lock.acquire_timeout(job='set_pid') as acquired:
             if not acquired:
                 self.log.warn(f"Could not start Task because "
                               f"{self._lock.job} is already running")
@@ -350,7 +397,7 @@ class LS372_Agent:
         :param params: dict with "channel" number
         :type params: dict
         """
-        with self._lock_acquire('set_active_channel') as acquired:
+        with self._lock.acquire_timeout(job='set_active_channel') as acquired:
             if not acquired:
                 self.log.warn(f"Could not start Task because "
                               f"{self._lock.job} is already running")
@@ -369,7 +416,7 @@ class LS372_Agent:
         Sets autoscan on the LS372.
         :param params: dict with "autoscan" value
         """
-        with self._lock_acquire('set_autoscan') as acquired:
+        with self._lock.acquire_timeout(job='set_autoscan') as acquired:
             if not acquired:
                 self.log.warn(f"Could not start Task because "
                               f"{self._lock.job} is already running")
@@ -392,7 +439,7 @@ class LS372_Agent:
         :param params: dict with "temperature" Heater.set_setpoint() in unites of K
         :type params: dict
         """
-        with self._lock_acquire('servo_to_temperature') as acquired:
+        with self._lock.acquire_timeout(job='servo_to_temperature') as acquired:
             if not acquired:
                 self.log.warn(f"Could not start Task because "
                               f"{self._lock.job} is already running")
@@ -437,7 +484,7 @@ class LS372_Agent:
         measurements - number of measurements to average for stability check
         threshold - amount within which the average needs to be to the setpoint for stability
         """
-        with self._lock_acquire('check_temp_stability') as acquired:
+        with self._lock.acquire_timeout(job='check_temp_stability') as acquired:
             if not acquired:
                 self.log.warn(f"Could not start Task because "
                               f"{self._lock.job} is already running")
@@ -485,7 +532,7 @@ class LS372_Agent:
                     "Zone", "Still", "Closed Loop", or "Warm up"
         """
 
-        with self._lock_acquire('set_output_mode') as acquired:
+        with self._lock.acquire_timeout(job='set_output_mode') as acquired:
             if not acquired:
                 self.log.warn(f"Could not start Task because "
                               f"{self._lock.job} is already running")
@@ -518,7 +565,7 @@ class LS372_Agent:
 
         """
 
-        with self._lock_acquire('set_heater_output') as acquired:
+        with self._lock.acquire_timeout(job='set_heater_output') as acquired:
             if not acquired:
                 self.log.warn(f"Could not start Task because "
                               f"{self._lock.job} is already running")

--- a/agents/lakeshore372/LS372_agent.py
+++ b/agents/lakeshore372/LS372_agent.py
@@ -183,7 +183,7 @@ class LS372_Agent:
                 self.log.warn(f"Could not start Process because "
                               f"{self._acq_proc_lock.job} is already running")
                 return False, "Could not acquire lock"
-            if not acq_acquired:
+            if not acquired:
                 self.log.warn(f"Could not start Process because "
                               f"{self._lock.job} is holding the lock")
                 return False, "Could not acquire lock"


### PR DESCRIPTION
This is accomplished by adding a lock to guard the acq Process from other
runs of the acq Process, then using the usual job lock to guard only
hardware i/o in the acq Process.

Added some helper functions to return the right ContextManager with an
appropriate timeout... these could instead be provided by OCS.

Also removed misleading working in the lock warnings.