### PR TITLE
Added table versioning and failed copy limit

### DIFF
--- a/agents/pysmurf_archiver/pysmurf_archiver_agent.py
+++ b/agents/pysmurf_archiver/pysmurf_archiver_agent.py
@@ -29,8 +29,9 @@ def create_local_path(file, data_dir):
             /data/pysmurf/15647/tuning/1564799250_tuning_b1.txt
 
         In the case of duplicate datafiles being registered, the duplicates
-        will still be copied over but put into a `duplicates` sub_directory
-        with a timestamp before the filename, so that data isn't overwritten.
+        will still be copied over to the location `new_path_name.{i}` where
+        `i` is the next unique index.
+
 
         Arguments
         ---------
@@ -55,17 +56,19 @@ def create_local_path(file, data_dir):
                 f"{file['type']}"
              )
     new_path = os.path.join(subdir, filename)
-    if os.path.exists(new_path):
-        print(f"Warning! Trying to archive duplicate of {new_path}. ")
-        subdir = os.path.join(subdir, 'duplicates')
-        new_path = os.path.join(subdir,
-                                f'{int(time.time())}_{filename}')
-        print(f"Saving duplicate file to {new_path}")
+    unique_path = new_path
+    i = 1
+    while os.path.exists(unique_path):
+        unique_path = new_path + f'.{i}'
+        i += 1
+    if unique_path != new_path:
+        print(f"Warning! Trying to archive duplicate of {new_path}! "
+              f"Will be archived as {unique_path} instead.")
 
     if not os.path.exists(subdir):
         os.makedirs(subdir)
 
-    return new_path
+    return unique_path
 
 
 class PysmurfArchiverAgent:

--- a/agents/pysmurf_archiver/pysmurf_archiver_agent.py
+++ b/agents/pysmurf_archiver/pysmurf_archiver_agent.py
@@ -28,6 +28,10 @@ def create_local_path(file, data_dir):
 
             /data/pysmurf/15647/tuning/1564799250_tuning_b1.txt
 
+        In the case of duplicate datafiles being registered, the duplicates
+        will still be copied over but put into a `duplicates` sub_directory
+        with a timestamp before the filename, so that data isn't overwritten.
+
         Arguments
         ---------
         file: dict
@@ -50,11 +54,18 @@ def create_local_path(file, data_dir):
                 f"{str(dt.timestamp()):.5}",
                 f"{file['type']}"
              )
+    new_path = os.path.join(subdir, filename)
+    if os.path.exists(new_path):
+        print(f"Warning! Trying to archive duplicate of {new_path}. ")
+        subdir = os.path.join(subdir, 'duplicates')
+        new_path = os.path.join(subdir,
+                                f'{int(time.time())}_{filename}')
+        print(f"Saving duplicate file to {new_path}")
 
     if not os.path.exists(subdir):
         os.makedirs(subdir)
 
-    return os.path.join(subdir, filename)
+    return new_path
 
 
 class PysmurfArchiverAgent:

--- a/agents/pysmurf_monitor/pysmurf_monitor.py
+++ b/agents/pysmurf_monitor/pysmurf_monitor.py
@@ -76,7 +76,7 @@ class PysmurfMonitor(DatagramProtocol):
 
     def _add_file_callback(self, res, d):
         """Callback for when a file is successfully added to DB"""
-        self.log.info("Added {} to pysmurf_files".format(d['path']))
+        self.log.info("Added {} to {}".format(d['path'], pysmurf_files_manager.table))
 
     def _add_file_errback(self, failure: Failure, d):
         """Errback for when there is an exception when adding file to DB"""

--- a/socs/db/pysmurf_files_manager.py
+++ b/socs/db/pysmurf_files_manager.py
@@ -82,7 +82,7 @@ def create_table(cur, update=True):
         except mysql.connector.errors.ProgrammingError as e:
             print(e)
     else:
-        print(f"Found table {table} table and not updating")
+        print(f"Found table {table} and not updating")
 
 
 def drop_table(cur):


### PR DESCRIPTION
This PR does two things: 

1. It versions the `pysmurf_files` table in the ocs database so that we can make changes to column structure without getting rid of previous data.

2. Puts a limit (of 5) on the number of failed copy attempts before the pysmurf-archiver gives up on copying a file.

This is to solve an issue where pysmurf will write and publish files that don't have unique names, like `mask.txt`. The table versioning was necessary for me to get rid of the Unique requirement on pysmurf file paths in the database. 

I also realized that we are getting an md5sum error sometimes because pysmurf will write and publish a file, and then that file might be changed after the md5sum is already in the database. I'm not sure what the correct thing to do is here for on the OCS side, but the limit on failed copy attempts prevents the archiver from continuously trying to copy this file (and compare its md5sum) forever.

If there are any suggestions on how OCS should handle this situation they are welcome, but I'd like to get some version of this PR merged relatively soon so that the archiver isn't completely broken when this happens. Thanks!