### PR TITLE
Fixing errors on the Pfeiffer agent

### DIFF
--- a/agents/pfeiffer_tpg366/pfeiffer_tpg366_agent.py
+++ b/agents/pfeiffer_tpg366/pfeiffer_tpg366_agent.py
@@ -53,6 +53,7 @@ class Pfeiffer:
         self.comm.send(ENQ.encode())
         read_str = self.comm.recv(BUFF_SIZE).decode()
         pressure_str = read_str.split(',')[-1].split('\r')[0]
+        pressure = float(pressure_str)
         return pressure
 
     def read_pressure_all(self):

--- a/agents/pfeiffer_tpg366/pfeiffer_tpg366_agent.py
+++ b/agents/pfeiffer_tpg366/pfeiffer_tpg366_agent.py
@@ -53,7 +53,6 @@ class Pfeiffer:
         self.comm.send(ENQ.encode())
         read_str = self.comm.recv(BUFF_SIZE).decode()
         pressure_str = read_str.split(',')[-1].split('\r')[0]
-        pressure = float(pressure_str)
         return pressure
 
     def read_pressure_all(self):
@@ -74,8 +73,8 @@ class Pfeiffer:
         self.comm.send(ENQ.encode())
         read_str = self.comm.recv(BUFF_SIZE).decode()
         pressure_str = read_str.split('\r')[0]
-        gauge_states = pressure_str.split(',')[::2]
-        gauge_states = np.array(gauge_states, dtype=int)
+        #gauge_states = pressure_str.split(',')[::2]
+        #gauge_states = np.array(gauge_states, dtype=int)
         pressures = pressure_str.split(',')[1::2]
         pressures = [float(p) for p in pressures]
         return pressures


### PR DESCRIPTION
The line querying gauge states was causing errors when trying to read channels that were off. I commented out that line so that the agent would stop crashing. 