### PR TITLE
Rename invalid field names

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@
 # A container setup with an installation of socs.
 
 # Use the ocs image as a base
-FROM simonsobs/ocs:v0.6.0-1-g569b428
+FROM simonsobs/ocs:v0.6.0-67-g5993b6a-dev
 
 # Copy the current directory contents into the container at /app
 COPY . /app/socs/

--- a/agents/bluefors/bluefors_log_tracker.py
+++ b/agents/bluefors/bluefors_log_tracker.py
@@ -236,7 +236,7 @@ class LogParser:
             regex = re.compile(rf'{pattern},([0-9\.\+\-E]+)')
             m = regex.search(new_line)
             if log_type == 'channels':
-                data_array[pattern] = int(m.group(1))
+                data_array[pattern.replace('-', '_')] = int(m.group(1))
             else:
                 data_array[pattern] = float(m.group(1))
 

--- a/agents/cryomech_cpa/cryomech_cpa_agent.py
+++ b/agents/cryomech_cpa/cryomech_cpa_agent.py
@@ -80,20 +80,27 @@ class PTC:
         """
 
         # Associations between keys and their location in rawData
-        keyloc = {"Operating State": [9, 10],
-                  "Pump State": [11, 12],
-                  "Warnings": [15, 16, 13, 14],
-                  "Alarms": [19, 20, 17, 18],
-                  "Coolant In": [22, 21, 24, 23],
-                  "Coolant Out": [26, 25, 28, 27],
-                  "Oil": [30, 29, 32, 31],
-                  "Helium": [34, 33, 36, 35],
-                  "Low Pressure": [38, 37, 40, 39],
-                  "Low Pressure Average": [42, 41, 44, 43],
-                  "High Pressure": [46, 45, 48, 47],
-                  "High Pressure Average": [50, 49, 52, 51],
-                  "Delta Pressure": [54, 53, 56, 55],
-                  "Motor Current": [58, 57, 60, 59]}
+        # TODO: Does order of these lists matter?
+        keyloc = {"Operating_State": [9, 10],
+                  "Compressor_State": [11, 12],
+                  "Warning_State": [15, 16, 13, 14],
+                  "Alarm_State": [19, 20, 17, 18],
+                  "Coolant_In_Temp": [22, 21, 24, 23],
+                  "Coolant_Out_Temp": [26, 25, 28, 27],
+                  "Oil_Temp": [30, 29, 32, 31],
+                  "Helium_Temp": [34, 33, 36, 35],
+                  "Low_Pressure": [38, 37, 40, 39],
+                  "Low_Pressure_Average": [42, 41, 44, 43],
+                  "High_Pressure": [46, 45, 48, 47],
+                  "High_Pressure_Average": [50, 49, 52, 51],
+                  "Delta_Pressure_Average": [54, 53, 56, 55],
+                  "Motor_Current": [58, 57, 60, 59],
+                  "Hours_of_Opperation": [63, 64, 61, 62],
+                  "Pressure_Unit": [65, 66],
+                  "Temperature_Unit": [67, 68],
+                  "Serial_Number": [69, 70],
+                  "Model": [71, 72],
+                  "Software_Revision": [73, 74]}
 
         # Iterate through all keys and return the data in a usable format.
         # If there is an error in the string format, print the

--- a/agents/labjack/labjack_agent.py
+++ b/agents/labjack/labjack_agent.py
@@ -150,11 +150,11 @@ class LabJackAgent:
         print(f"Active channels is {active_channels}")
 
         if active_channels == 'T7-all':
-            self.sensors = ['Channel {}'.format(i+1) for i in range(14)]
+            self.sensors = ['Channel_{}'.format(i+1) for i in range(14)]
         elif active_channels == 'T4-all':
-            self.sensors = ['Channel {}'.format(i+1) for i in range(12)]    
+            self.sensors = ['Channel_{}'.format(i+1) for i in range(12)]    
         else:
-            self.sensors = ['Channel {}'.format(ch) for ch in active_channels]
+            self.sensors = ['Channel_{}'.format(ch) for ch in active_channels]
         self.ljf = LabJackFunctions()
         self.sampling_frequency = sampling_frequency
 
@@ -253,7 +253,7 @@ class LabJackAgent:
                         v = data['data'][sens + 'V']
                         value, units = \
                             self.ljf.unit_conversion(v, self.functions[sens])
-                        data['data'][sens + ' ' + units] = value
+                        data['data'][sens + '_' + units] = value
 
                 time.sleep(sleep_time)
 

--- a/agents/lakeshore240/LS240_agent.py
+++ b/agents/lakeshore240/LS240_agent.py
@@ -226,9 +226,9 @@ class LS240_Agent:
                 }
 
                 for chan in self.module.channels:
-                    chan_string = "Channel {}".format(chan.channel_num)
-                    data['data'][chan_string + ' T'] = chan.get_reading(unit='K')
-                    data['data'][chan_string + ' V'] = chan.get_reading(unit='S')
+                    chan_string = "Channel_{}".format(chan.channel_num)
+                    data['data'][chan_string + '_T'] = chan.get_reading(unit='K')
+                    data['data'][chan_string + '_V'] = chan.get_reading(unit='S')
 
                 self.agent.publish_to_feed('temperatures', data)
 

--- a/agents/lakeshore372/LS372_agent.py
+++ b/agents/lakeshore372/LS372_agent.py
@@ -265,9 +265,10 @@ class LS372_Agent:
                     }
 
                     # Collect both temperature and resistance values from each Channel
-                    data['data'][active_channel.name + ' T'] = \
+                    channel_str = active_channel.name.replace(' ', '_')
+                    data['data'][channel_str + '_T'] = \
                         self.module.get_temp(unit='kelvin', chan=active_channel.channel_num)
-                    data['data'][active_channel.name + ' R'] = \
+                    data['data'][channel_str + '_R'] = \
                         self.module.get_temp(unit='ohms', chan=active_channel.channel_num)
 
                 session.app.publish_to_feed('temperatures', data)

--- a/bin/rename_fields
+++ b/bin/rename_fields
@@ -8,32 +8,6 @@ import so3g
 from so3g.hk.translator import HKTranslator
 from spt3g import core
 
-def _build_file_list(target):
-    """Build list of files to scan.
-
-    Parameters
-    ----------
-    target : str
-        File or directory to scan.
-
-    Returns
-    -------
-    list
-        List of full paths to files for scanning.
-
-    """
-    _file_list = []
-    if os.path.isfile(target):
-        _file_list.append(target)
-    elif os.path.isdir(target):
-        a = os.walk(target)
-        for root, _, _file in a:
-            for g3 in _file:
-                if g3[-2:] == "g3":
-                    _file_list.append(os.path.join(root, g3))
-
-    return _file_list
-
 def rename_fields(field_name):
     """Rename invalid field names."""
     # Agents requiring no changes.
@@ -61,18 +35,23 @@ def rename_fields(field_name):
 
     # Agents that dynamically build their field lists:
     # labjack
-    # This is annoying one, can be any combination of "Channel" "1-14" and "Units", where units is user defined.
-    # Should rename via a str.replace(' ', '_')
+    # This is a tricky one, field names can be any combination of "Channel"
+    # "1-14" and "Units", where units is user defined. Should rename via a
+    # str.replace(' ', '_')
     
     # Lakeshore 240
-    # This is just like the labjack, though channels/units are well defined, i.e. all "Channel" "1-8" "V" and "T".
-    # Still, we should just do the same as with the labjack.
+    # This is just like the labjack, though channels/units are well defined,
+    # i.e. all "Channel" "1-8" "V" and "T".  Still, we should just do the same
+    # as with the labjack.
     
     # Lakeshore 372
-    # Same as the Lakeshore 240, except "T" and "R", instead of "T" and "V" for units.
+    # Same as the Lakeshore 240, except "T" and "R", instead of "T" and "V" for
+    # units.
 
     # 370 Agent
     # Same as the 372 Agent. Not sure if in use yet.
+
+    # All of the above are handled by:
     if field_name[:7] == "Channel":
         return field_name.replace(' ', '_')
 
@@ -90,7 +69,6 @@ class HKRenamer:
     changes.
 
     """
-
     def __init__(self):
         pass
 
@@ -125,25 +103,80 @@ class HKRenamer:
         return self.Process(*args, **kwargs)
 
 
+def _build_file_list(target):
+    """Build list of files to scan.
+
+    Parameters
+    ----------
+    target : str
+        File or directory to scan.
+
+    Returns
+    -------
+    list
+        List of full paths to files for scanning.
+
+    """
+    _file_list = []
+    if os.path.isfile(target):
+        _file_list.append(target)
+    elif os.path.isdir(target):
+        a = os.walk(target)
+        for root, _, _file in a:
+            for g3 in _file:
+                if g3[-2:] == "g3":
+                    _file_list.append(os.path.join(root, g3))
+
+    return _file_list
+
+def run_pipeline(input_file, output_file):
+    """Method for the G3 Pipeline to demonstrate error in loop."""
+    p = core.G3Pipeline()
+    p.Add(core.G3Reader(input_file))
+    p.Add(HKTranslator())
+    p.Add(HKRenamer())
+    p.Add(core.G3Writer(output_file))
+    p.Run()
+
 if __name__ == '__main__':
     import argparse
     parser = argparse.ArgumentParser(
         usage='This program can be used to convert SO HK Frames to the '
         'latest schema version.')
     parser.add_argument('--output-directory', '-o')
-    parser.add_argument('files', nargs='+', help=
-                        "SO Housekeeping files to convert.")
+    parser.add_argument('target', nargs='+', help=
+                        "File or directory to process.")
     args = parser.parse_args()
 
     # Run me on a G3File containing a Housekeeping stream.
     core.set_log_level(core.G3LogLevel.LOG_INFO)
 
-    print(f'Streaming to {args.output_directory}')
-    for f in args.files:
-        print(os.path.join(args.output_directory, os.path.basename(f)))
-        p = core.G3Pipeline()
-        p.Add(core.G3Reader(f))
-        p.Add(HKTranslator())
-        p.Add(HKRenamer())
-        p.Add(core.G3Writer(os.path.join(args.output_directory, os.path.basename(f))))
-        p.Run()
+    # Run on just a single file target, outputs directly to -o.
+    if len(args.target) == 1 and os.path.isfile(args.target[0]):
+        print(f"Writing new version of {args.target} to {args.output_directory}")
+        if not os.path.exists(args.output_directory):
+            os.makedirs(args.output_directory)
+        run_pipeline(args.target, os.path.join(args.output_directory, os.path.basename(args.target[0])))
+    else:
+        # args.target could be list of directories, say. Likely just one directory.
+        for target in args.target:
+            print(f"Processing all .g3 files in {target}...")
+            file_list = _build_file_list(target)
+            # print(file_list)
+
+            # For each file in the directory (and its subdirectories), run the pipeline.
+            for _file in file_list:
+                # Remove target directory from path for output directory
+                out_partial_path = _file.strip(target)
+
+                # Build out the full path for output
+                output_file = os.path.join(args.output_directory, out_partial_path)
+
+                # Make sure the subdirectories in args.output_directory exist
+                output_directory = os.path.dirname(output_file)
+
+                if not os.path.exists(output_directory):
+                    os.makedirs(output_directory)
+
+                print(f"Writing new version of {_file} to {output_file}")
+                run_pipeline(_file, output_file)

--- a/bin/rename_fields
+++ b/bin/rename_fields
@@ -20,14 +20,18 @@ def rename_fields(field_name):
     renames = {"hs-still": "hs_still",
                "hs-mc": "hs_mc",
                "Operating State": "Operating_State",
-               "Pump State": "Pump_State",
-               "Coolant In": "Coolant_In",
-               "Coolant Out": "Coolant_Out",
+               "Pump State": "Compressor_State",
+               "Warnings": "Warning_State",
+               "Alarms": "Alarm_State",
+               "Coolant In": "Coolant_In_Temp",
+               "Coolant Out": "Coolant_Out_Temp",
+               "Oil": "Oil_Temp",
+               "Helium", "Helium_Temp",
                "Low Pressure": "Low_Pressure",
                "Low Pressure Average": "Low_Pressure_Average",
                "High Pressure": "High_Pressure",
                "High Pressure Average": "High_Pressure_Average",
-               "Delta Pressure": "Delta_Pressure",
+               "Delta Pressure": "Delta_Pressure_Average",
                "Motor Current": "Motor_Current"}
 
     if field_name in renames:

--- a/bin/rename_fields
+++ b/bin/rename_fields
@@ -1,0 +1,149 @@
+#!/usr/bin/env python3
+# Rename fields to valid names in recorded .g3 files. Also translate from HK v0 to HK v1.
+# Heavily based on the so3g.hk.translator.
+
+import os
+
+import so3g
+from so3g.hk.translator import HKTranslator
+from spt3g import core
+
+def _build_file_list(target):
+    """Build list of files to scan.
+
+    Parameters
+    ----------
+    target : str
+        File or directory to scan.
+
+    Returns
+    -------
+    list
+        List of full paths to files for scanning.
+
+    """
+    _file_list = []
+    if os.path.isfile(target):
+        _file_list.append(target)
+    elif os.path.isdir(target):
+        a = os.walk(target)
+        for root, _, _file in a:
+            for g3 in _file:
+                if g3[-2:] == "g3":
+                    _file_list.append(os.path.join(root, g3))
+
+    return _file_list
+
+def rename_fields(field_name):
+    """Rename invalid field names."""
+    # Agents requiring no changes.
+    # hwp_sim, keithley2230G-psu, pfeiffer_tpg366, pysmurf_archiver,
+    # pysmurf_controller, pysmurf monitor, smurf_recorder, smurf stream simulator,
+    # chwp Agent
+
+    # Agents that hardcode their fields:
+    # bluefors, cryomech_cpa
+    renames = {"hs-still": "hs_still",
+               "hs-mc": "hs_mc",
+               "Operating State": "Operating_State",
+               "Pump State": "Pump_State",
+               "Coolant In": "Coolant_In",
+               "Coolant Out": "Coolant_Out",
+               "Low Pressure": "Low_Pressure",
+               "Low Pressure Average": "Low_Pressure_Average",
+               "High Pressure": "High_Pressure",
+               "High Pressure Average": "High_Pressure_Average",
+               "Delta Pressure": "Delta_Pressure",
+               "Motor Current": "Motor_Current"}
+
+    if field_name in renames:
+        return renames[field_name]    
+
+    # Agents that dynamically build their field lists:
+    # labjack
+    # This is annoying one, can be any combination of "Channel" "1-14" and "Units", where units is user defined.
+    # Should rename via a str.replace(' ', '_')
+    
+    # Lakeshore 240
+    # This is just like the labjack, though channels/units are well defined, i.e. all "Channel" "1-8" "V" and "T".
+    # Still, we should just do the same as with the labjack.
+    
+    # Lakeshore 372
+    # Same as the Lakeshore 240, except "T" and "R", instead of "T" and "V" for units.
+
+    # 370 Agent
+    # Same as the 372 Agent. Not sure if in use yet.
+    if field_name[:7] == "Channel":
+        return field_name.replace(' ', '_')
+
+    return field_name
+
+# Other Agents
+# M1000 Agent
+# Probably lots of issues, not really in use yet, though some data did get
+# written to the Yale aggregator, but can probably be safely ignored/searched
+# for an deleted.
+
+class HKRenamer:
+    """Renames invalid field names. Changes here take into consideration
+    changes made to the Agents to fix the naming of fields and match those
+    changes.
+
+    """
+
+    def __init__(self):
+        pass
+
+    def Process(self, f):
+        if f.type == core.G3FrameType.EndProcessing:
+            return [f] 
+
+        if f.type != core.G3FrameType.Housekeeping:
+            return [f] 
+
+        # No difference in Session/Status for v0 -> v1.
+        if f.get('hkagg_type') != so3g.HKFrameType.data:
+            return [f] 
+
+        # Pop the data blocks out of the frame.
+        orig_blocks = f.pop('blocks')
+        f['blocks'] = core.G3VectorFrameObject()
+
+        # Now process the data blocks.
+        for block in orig_blocks:
+            new_block = core.G3TimesampleMap()
+            new_block.times = block.times
+            for k in block.keys():
+                v = block[k]
+                new_field = rename_fields(k)
+                # print(k, new_field)
+                new_block[new_field] = core.G3VectorDouble(v)
+            f['blocks'].append(new_block)
+        return [f] 
+
+    def __call__(self, *args, **kwargs):
+        return self.Process(*args, **kwargs)
+
+
+if __name__ == '__main__':
+    import argparse
+    parser = argparse.ArgumentParser(
+        usage='This program can be used to convert SO HK Frames to the '
+        'latest schema version.')
+    parser.add_argument('--output-directory', '-o')
+    parser.add_argument('files', nargs='+', help=
+                        "SO Housekeeping files to convert.")
+    args = parser.parse_args()
+
+    # Run me on a G3File containing a Housekeeping stream.
+    core.set_log_level(core.G3LogLevel.LOG_INFO)
+
+    print(f'Streaming to {args.output_directory}')
+    for f in args.files:
+        print(os.path.join(args.output_directory, os.path.basename(f)))
+        p = core.G3Pipeline()
+        p.Add(core.G3Reader(f))
+        p.Add(HKTranslator())
+        p.Add(HKRenamer())
+        p.Add(core.G3Writer(os.path.join(args.output_directory, os.path.basename(f))))
+        p.Run()

--- a/bin/rename_fields
+++ b/bin/rename_fields
@@ -162,7 +162,7 @@ if __name__ == '__main__':
     args = parser.parse_args()
 
     # Run me on a G3File containing a Housekeeping stream.
-    core.set_log_level(core.G3LogLevel.LOG_INFO)
+    # core.set_log_level(core.G3LogLevel.LOG_INFO)
 
     # Run on just a single file target, outputs directly to -o.
     if len(args.target) == 1 and os.path.isfile(args.target[0]):
@@ -181,7 +181,7 @@ if __name__ == '__main__':
             # For each file in the directory (and its subdirectories), run the pipeline.
             for _file in file_list:
                 # Remove target directory from path for output directory
-                out_partial_path = _file.strip(target)
+                out_partial_path = _file.lstrip(target)
 
                 # Build out the full path for output
                 output_file = os.path.join(args.output_directory, out_partial_path)

--- a/bin/rename_fields
+++ b/bin/rename_fields
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
-# Rename fields to valid names in recorded .g3 files. Also translate from HK v0 to HK v1.
-# Heavily based on the so3g.hk.translator.
+# Rename fields to valid names in recorded .g3 files. Also translate from HK v0
+# to HK v1. This is heavily based on the so3g.hk.translator.
 
 import os
 
@@ -8,12 +8,13 @@ import so3g
 from so3g.hk.translator import HKTranslator
 from spt3g import core
 
+
 def rename_fields(field_name):
     """Rename invalid field names."""
     # Agents requiring no changes.
     # hwp_sim, keithley2230G-psu, pfeiffer_tpg366, pysmurf_archiver,
-    # pysmurf_controller, pysmurf monitor, smurf_recorder, smurf stream simulator,
-    # chwp Agent
+    # pysmurf_controller, pysmurf monitor, smurf_recorder, smurf stream
+    # simulator, chwp Agent
 
     # Agents that hardcode their fields:
     # bluefors, cryomech_cpa
@@ -26,7 +27,7 @@ def rename_fields(field_name):
                "Coolant In": "Coolant_In_Temp",
                "Coolant Out": "Coolant_Out_Temp",
                "Oil": "Oil_Temp",
-               "Helium", "Helium_Temp",
+               "Helium": "Helium_Temp",
                "Low Pressure": "Low_Pressure",
                "Low Pressure Average": "Low_Pressure_Average",
                "High Pressure": "High_Pressure",
@@ -35,19 +36,19 @@ def rename_fields(field_name):
                "Motor Current": "Motor_Current"}
 
     if field_name in renames:
-        return renames[field_name]    
+        return renames[field_name]
 
     # Agents that dynamically build their field lists:
     # labjack
     # This is a tricky one, field names can be any combination of "Channel"
     # "1-14" and "Units", where units is user defined. Should rename via a
     # str.replace(' ', '_')
-    
+
     # Lakeshore 240
     # This is just like the labjack, though channels/units are well defined,
     # i.e. all "Channel" "1-8" "V" and "T".  Still, we should just do the same
     # as with the labjack.
-    
+
     # Lakeshore 372
     # Same as the Lakeshore 240, except "T" and "R", instead of "T" and "V" for
     # units.
@@ -67,6 +68,7 @@ def rename_fields(field_name):
 # written to the Yale aggregator, but can probably be safely ignored/searched
 # for an deleted.
 
+
 class HKRenamer:
     """Renames invalid field names. Changes here take into consideration
     changes made to the Agents to fix the naming of fields and match those
@@ -78,14 +80,14 @@ class HKRenamer:
 
     def Process(self, f):
         if f.type == core.G3FrameType.EndProcessing:
-            return [f] 
+            return [f]
 
         if f.type != core.G3FrameType.Housekeeping:
-            return [f] 
+            return [f]
 
         # No difference in Session/Status for v0 -> v1.
         if f.get('hkagg_type') != so3g.HKFrameType.data:
-            return [f] 
+            return [f]
 
         # Pop the data blocks out of the frame.
         orig_blocks = f.pop('blocks')
@@ -101,7 +103,7 @@ class HKRenamer:
                 # print(k, new_field)
                 new_block[new_field] = core.G3VectorDouble(v)
             f['blocks'].append(new_block)
-        return [f] 
+        return [f]
 
     def __call__(self, *args, **kwargs):
         return self.Process(*args, **kwargs)
@@ -133,6 +135,7 @@ def _build_file_list(target):
 
     return _file_list
 
+
 def run_pipeline(input_file, output_file):
     """Method for the G3 Pipeline to demonstrate error in loop."""
     p = core.G3Pipeline()
@@ -142,14 +145,20 @@ def run_pipeline(input_file, output_file):
     p.Add(core.G3Writer(output_file))
     p.Run()
 
+
 if __name__ == '__main__':
     import argparse
     parser = argparse.ArgumentParser(
-        usage='This program can be used to convert SO HK Frames to the '
-        'latest schema version.')
-    parser.add_argument('--output-directory', '-o')
-    parser.add_argument('target', nargs='+', help=
-                        "File or directory to process.")
+        description='This program is used to correct a selection of invalid '
+                    'field names in .g3 HK files written with SOCS Agents '
+                    'prior to the v0.1.0 release of SOCS. It will also '
+                    'simultaneously upgrade any HK v0 files to the HK v1 '
+                    'format.')
+    parser.add_argument('target', nargs='+',
+                        help="File or directory to process.")
+    parser.add_argument('--output-directory', '-o', default='./',
+                        help="Output directory for rewritten .g3 files. "
+                             "(default: ./)")
     args = parser.parse_args()
 
     # Run me on a G3File containing a Housekeeping stream.
@@ -157,16 +166,17 @@ if __name__ == '__main__':
 
     # Run on just a single file target, outputs directly to -o.
     if len(args.target) == 1 and os.path.isfile(args.target[0]):
-        print(f"Writing new version of {args.target} to {args.output_directory}")
         if not os.path.exists(args.output_directory):
             os.makedirs(args.output_directory)
-        run_pipeline(args.target, os.path.join(args.output_directory, os.path.basename(args.target[0])))
+
+        out_file = os.path.join(args.output_directory, os.path.basename(args.target[0]))
+        print(f"Writing new version of {args.target} to {out_file}")
+        run_pipeline(args.target, out_file)
     else:
         # args.target could be list of directories, say. Likely just one directory.
         for target in args.target:
             print(f"Processing all .g3 files in {target}...")
             file_list = _build_file_list(target)
-            # print(file_list)
 
             # For each file in the directory (and its subdirectories), run the pipeline.
             for _file in file_list:

--- a/bin/rename_fields
+++ b/bin/rename_fields
@@ -8,6 +8,7 @@ import so3g
 from so3g.hk.translator import HKTranslator
 from spt3g import core
 
+from ocs.ocs_feed import Feed
 
 def rename_fields(field_name):
     """Rename invalid field names."""
@@ -100,6 +101,16 @@ class HKRenamer:
             for k in block.keys():
                 v = block[k]
                 new_field = rename_fields(k)
+
+                # Catch any still invalid names
+                try:
+                    valid_field = Feed.verify_data_field_string(new_field)
+                except ValueError:
+                    raise ValueError("An unexpected invalid field name, " +
+                                     f"'{new_field}', was encountered. Please " +
+                                     "report this field name as an issue to " +
+                                     "the socs repository.")
+
                 # print(k, new_field)
                 new_block[new_field] = core.G3VectorDouble(v)
             f['blocks'].append(new_block)


### PR DESCRIPTION
This PR adds the `rename_fields` script, which attempts to correct all invalid field names that might have been previously recorded in .g3 files across all OCS/SOCS Agents. Since we want to eliminate any invalid field names in current Agents, we also simultaneously make updates to all SOCS Agents with invalid field names.

I've tested this on single days worth of data at Yale, and on single files from UCSD's system. It seems to work, but a review of the functionality of the renamer and additional verification from someone else would be helpful. To help with testing I've added some functionality to the `checkdata` script in ocs (see https://github.com/simonsobs/ocs/pull/147) to identify invalid field names. The sort of ultimate test will be in converting the Yale data set and re-uploading to InfluxDB. This will occur before we do so at any other institution.

@JakeSpisak - I attempted to cover some of the changes mentioned recently in #74 and #88. Can you take a look at the changes to that Agent that I've made and comment, particularly at the questions raised in 42a27cf?