### PR TITLE
Addressing typos in the Pfeiffer agent

### DIFF
--- a/agents/pfeiffer_tpg366/pfeiffer_tpg366_agent.py
+++ b/agents/pfeiffer_tpg366/pfeiffer_tpg366_agent.py
@@ -14,7 +14,7 @@ ENQ = '\x05'
 
 class Pfeiffer:
     """CLASS to control and retrieve data from the pfeiffer tpg366
-    pressure gauage controller
+    pressure gauge controller
 
 
     Args:
@@ -95,7 +95,7 @@ class PfeifferAgent:
         self.f_sample = f_sample
         self.take_data = False
         self.gauge = Pfeiffer(ip_address, int(port))
-        agg_params = {'frame length': 60, }
+        agg_params = {'frame_length': 60, }
 
         self.agent.register_feed('pressures',
                                  record=True,


### PR DESCRIPTION
A typo within the Pfeiffer agent was causing the OCS aggregator to crash. Specifically, the agent was assigning "frame length"  instead of "frame_length". This, and a minor documentation typo was addressed. 