### PR TITLE
GitHub Actions and Contributing Guidelines

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,27 @@
+<!--- Provide a general summary of your changes in the Title above -->
+
+## Description
+<!--- Describe your changes in detail -->
+
+## Motivation and Context
+<!--- Why is this change required? What problem does it solve? -->
+<!--- If it fixes an open issue, please link to the issue here. -->
+
+## How Has This Been Tested?
+<!--- Please describe in detail how you tested your changes. -->
+<!--- Include details of your testing environment, tests ran to see how -->
+<!--- your change affects other areas of the code, etc. -->
+
+## Types of changes
+<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
+- [ ] Bug fix (non-breaking change which fixes an issue)
+- [ ] New feature (non-breaking change which adds functionality)
+- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
+
+## Checklist:
+<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
+<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
+- [ ] My code follows the code style of this project.
+- [ ] My change requires a change to the documentation.
+- [ ] I have updated the documentation accordingly.
+- [ ] Unless I am preparing a release, I have opened this PR onto the `develop` branch.

--- a/.github/workflows/develop.yml
+++ b/.github/workflows/develop.yml
@@ -1,0 +1,42 @@
+name: Build Develop Images
+
+on:
+  push:
+    branches: [ develop ]
+
+jobs:
+  build:
+    runs-on: ubuntu-18.04
+
+    steps:
+    - uses: actions/checkout@v2
+      # Fetch all history for all tags and branches
+      with:
+        fetch-depth: 0
+
+    # Test
+    - name: Build docker images
+      run: |
+        docker-compose build
+
+    - name: Test with pytest within a docker container
+      run: |
+        docker run -v $PWD:/coverage --rm socs sh -c "COVERAGE_FILE=/coverage/.coverage.docker python3 -m pytest -p no:wampy --cov /app/socs/socs/ ./tests/"
+
+    # Dockerize
+    - name: Build and push development docker image
+      env:
+        REGISTRY_PASSWORD: ${{ secrets.REGISTRY_PASSWORD }}
+        REGISTRY_USER: ${{ secrets.REGISTRY_USER }}
+        DOCKERHUB_ORG: "simonsobs"
+      run: |
+        export DOCKER_TAG=`git describe --tags --always`-dev
+        echo "${DOCKER_TAG}"
+        echo "${REGISTRY_PASSWORD}" | docker login -u "${REGISTRY_USER}" --password-stdin;
+
+        # Tag all images for upload to the registry
+        docker-compose config | grep 'image: ' | awk -F ': ' '{ print $2 }' | xargs -I {} docker tag {}:latest ${DOCKERHUB_ORG}/{}:${DOCKER_TAG}
+
+        # Upload to docker registry
+        docker-compose config | grep 'image: ' | awk -F ': ' '{ print $2 }' | xargs -I {} docker push ${DOCKERHUB_ORG}/{}:${DOCKER_TAG}
+        docker-compose config | grep 'image: ' | awk -F ': ' '{ print $2 }' | xargs -I {} echo ${DOCKERHUB_ORG}/{}:${DOCKER_TAG} pushed

--- a/.github/workflows/official-docker-images.yml
+++ b/.github/workflows/official-docker-images.yml
@@ -1,0 +1,43 @@
+name: Build Official Docker Images
+
+on:
+  release:
+    types: [ released ]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v2
+      # Fetch all history for all tags and branches
+      with:
+        fetch-depth: 0
+
+    # Test
+    - name: Build docker images
+      run: |
+        docker-compose build
+
+    - name: Test with pytest wtihin a docker container
+      run: |
+        docker run -v $PWD:/coverage --rm socs sh -c "COVERAGE_FILE=/coverage/.coverage.docker python3 -m pytest -p no:wampy --cov /app/socs/socs/ ./tests/"
+
+    # Dockerize
+    - name: Build and push official docker image
+      env:
+        REGISTRY_PASSWORD: ${{ secrets.REGISTRY_PASSWORD }}
+        REGISTRY_USER: ${{ secrets.REGISTRY_USER }}
+        DOCKERHUB_ORG: "simonsobs"
+      run: |
+        export DOCKER_TAG=`git describe --tags --always`
+        echo "${REGISTRY_PASSWORD}" | docker login -u "${REGISTRY_USER}" --password-stdin;
+
+        # Tag all images for upload to the registry
+        docker-compose config | grep 'image: ' | awk -F ': ' '{ print $2 }' | xargs -I {} docker tag {}:latest ${DOCKERHUB_ORG}/{}:latest
+        docker-compose config | grep 'image: ' | awk -F ': ' '{ print $2 }' | xargs -I {} docker tag {}:latest ${DOCKERHUB_ORG}/{}:${DOCKER_TAG}
+
+        # Upload to docker registry
+        docker-compose config | grep 'image: ' | awk -F ': ' '{ print $2 }' | xargs -I {} docker push ${DOCKERHUB_ORG}/{}:latest
+        docker-compose config | grep 'image: ' | awk -F ': ' '{ print $2 }' | xargs -I {} docker push ${DOCKERHUB_ORG}/{}:${DOCKER_TAG}
+        docker-compose config | grep 'image: ' | awk -F ': ' '{ print $2 }' | xargs -I {} echo ${DOCKERHUB_ORG}/{}:${DOCKER_TAG} pushed

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,10 +9,6 @@ python:
 
 stages:
   - test
-  - name: dockerize
-    if: |
-      branch = master AND \
-      type = push
 
 jobs:
   include:
@@ -37,26 +33,3 @@ jobs:
 
         # Publish results to coveralls
         - coveralls
-
-    - stage: dockerize
-      install: true
-
-      before_script:
-        # Use the git tag to tag docker image
-        - export DOCKER_TAG=`git describe --tags --always`
-        # Login to docker
-        - echo "${REGISTRY_PASSWORD}" | docker login -u "${REGISTRY_USER}" --password-stdin;
-
-      script:
-        # Build the docker images with docker-compose
-        - docker-compose build
-
-      after_success:
-        # Tag all images for upload to the registry
-        - "docker-compose config | grep 'image: ' | awk -F ': ' '{ print $2 }' | xargs -I {} docker tag {}:latest ${DOCKERHUB_ORG}/{}:latest"
-        - "docker-compose config | grep 'image: ' | awk -F ': ' '{ print $2 }' | xargs -I {} docker tag {}:latest ${DOCKERHUB_ORG}/{}:${DOCKER_TAG}"
-
-        # Upload to docker registry
-        - "docker-compose config | grep 'image: ' | awk -F ': ' '{ print $2 }' | xargs -I {} docker push ${DOCKERHUB_ORG}/{}:${DOCKER_TAG}"
-        - "docker-compose config | grep 'image: ' | awk -F ': ' '{ print $2 }' | xargs -I {} docker push ${DOCKERHUB_ORG}/{}:latest"
-        - "docker-compose config | grep 'image: ' | awk -F ': ' '{ print $2 }' | xargs -I {} echo ${DOCKERHUB_ORG}/{}:${DOCKER_TAG} pushed"

--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -1,0 +1,55 @@
+====================
+Contributing to SOCS
+====================
+
+Branches
+--------
+
+There are two long-lived branches in SOCS, ``master`` and ``develop``.
+``master`` should be considered stable, and will only move forward on official
+releases. ``develop`` may be unstable, and is where all development should take
+place. This branching model follows the one in the OCS_ repository.
+
+What this means for you, the contributor, is that you should base your feature
+branches off of the latest ``develop`` branch, and pull request them into
+``develop``. Detailed steps below.
+
+.. _OCS: https://github.com/simonsobs/ocs
+
+Pull Requests
+-------------
+
+When opening a pull request, you should push your feature branch, and select
+the ``develop`` branch as the base branch, the branch you want to merge your
+feature branch into. This is the default branch, so it should be automatically
+selected for you.
+
+Releases
+--------
+
+    **Note:** Releases will be issued by core maintainers of SOCS.
+
+If you are trying to issue a release of SOCS you should follow these steps:
+
+1. Open a Pull Request, comparing ``develop`` to the ``master`` base branch.
+   Describe the features added for this release.
+2. Make a merge commit when you merge this PR.
+
+   * This merge commit will be what is tagged for the release.
+   * ``develop`` is now one commit behind ``master`` (the merge commit)
+
+3. Pull the latest ``master`` and ``develop`` branches to your work station.
+4. Checkout ``develop``, then run ``git merge --ff-only master``, catching ``develop`` up to ``master``.
+5. ``push origin develop`` to update the remote ``develop`` branch.
+
+The ``develop`` and ``master`` branches are now aligned, and ``master`` is
+ready to be released. You can use the GitHub release interface to create a new
+release, copying the change log you wrote in the PR and otherwise describing the
+release.
+
+Development Guide
+-----------------
+
+Contributors should follow the recommendations made in the `SO Developer Guide`_.
+
+.. _SO Developer Guide: https://simons1.princeton.edu/docs/so_dev_guide/html/

--- a/README.rst
+++ b/README.rst
@@ -12,17 +12,18 @@ SOCS - Simons Observatory Control System
 .. image:: https://coveralls.io/repos/github/simonsobs/socs/badge.svg?branch=travis
     :target: https://coveralls.io/github/simonsobs/socs?branch=travis
 
+.. image:: https://img.shields.io/badge/dockerhub-latest-blue
+    :target: https://hub.docker.com/r/simonsobs/ocs/tags
+
 Overview
 --------
 
 This repository, `SOCS`_, contains hardware control code for the
 Simons Observatory.  This code operates within the framework provided
-by `OCS`_.  People who liked OCS and SOCS also liked `Sisock`_, our
-time-domain data query system with grafana integration.
+by `OCS`_.
 
 .. _`OCS`: https://github.com/simonsobs/ocs/
 .. _SOCS: https://github.com/simonsobs/socs/
-.. _`SiSock`: https://github.com/simonsobs/sisock/
 
 Installation
 ------------
@@ -44,6 +45,40 @@ configured host if it does not already exist:
 See the `ocs docs`_ for more details.
 
 .. _`ocs docs`: https://ocs.readthedocs.io/en/latest/site_config.html
+
+Docker Images
+-------------
+Docker images for SOCS and each Agent are available on `Docker Hub`_. Official
+releases will be tagged with their release version, i.e. ``v0.1.0``. These are
+only built on release, and the ``latest`` tag will point to the latest of these
+released tags. These should be considered stable.
+
+Development images will be tagged with the latest released version tag, the
+number of commits ahead of that release, the latest commit hash, and the tag
+``-dev``, i.e.  ``v0.0.2-81-g9c10ba6-dev``. These get built on each commit to
+the ``develop`` branch, and are useful for testing and development, but should
+be considered unstable.
+
+.. _Docker Hub: https://hub.docker.com/u/simonsobs
+
+Documentation
+-------------
+The SOCS documentation can be built using sphinx once you have performed the
+installation::
+
+  cd docs/
+  make html
+
+You can then open ``docs/_build/html/index.html`` in your preferred web
+browser. You can also find a copy hosted on `Read the Docs`_.
+
+.. _Read the Docs: https://socs.readthedocs.io/en/latest/
+
+Contributing
+------------
+For guidelines on how to contribute to OCS see `CONTRIBUTING.rst`_.
+
+.. _CONTRIBUTING.rst: CONTRIBUTING.rst
 
 License
 --------

--- a/README.rst
+++ b/README.rst
@@ -28,7 +28,13 @@ by `OCS`_.
 Installation
 ------------
 
-This code can be used directly from the source tree.
+To install SOCS, clone the repository and install with `pip`:
+
+.. code-block:: bash
+
+    git clone https://github.com/simonsobs/socs.git
+    cd socs/
+    pip3 install -r requirements.txt .
 
 In order for OCS tools to find these agents, you must add the full
 path to the agents directory, e.g. ``/home/simons/code/socs/agents/``,

--- a/docs/user/installation.rst
+++ b/docs/user/installation.rst
@@ -7,11 +7,11 @@ To checkout SOCS, clone the repository and run `setup.py`::
 
   git clone https://github.com/simonsobs/socs.git
   cd socs/
-  python3 setup.py install
+  pip3 install -r requirements.txt .
 
 .. note::
     If you are expecting to develop socs code you should consider using
-    'develop' instead of 'install'.
+    the `-e` flag.
 
 .. note::
     If you would like to install for just the local user, throw the `--user`


### PR DESCRIPTION
This implements nearly identical CI workflows and contributing guidelines to those established for the OCS directory in https://github.com/simonsobs/ocs/pull/146/. Docker builds are moved from Travis CI to GitHub Actions for more fine grained control over image tags, notably triggering official builds on GitHub releases.

One other change, separated in 9273a32, involves changing the recommended installation command set in the docs and README to bring it inline with the recommendation of using pip in the OCS docs, rather than calling `setup.py` directly.