### PR TITLE
Adds stream_id component to SmurfRecorder file path

### DIFF
--- a/agents/smurf_stream_simulator/smurf_stream_simulator.py
+++ b/agents/smurf_stream_simulator/smurf_stream_simulator.py
@@ -72,6 +72,8 @@ class SmurfStreamSimulator:
         Port to send data over
     num_chans : int
         Number of channels to simulate
+    stream_id : str
+        Stream ID to put into G3Frames. Defaults to "stream_sim"
 
     Attributes
     ----------
@@ -95,12 +97,15 @@ class SmurfStreamSimulator:
         List of simulated channels to stream
 
     """
-    def __init__(self, agent, target_host="*", port=4536, num_chans=528):
+    def __init__(self, agent, target_host="*", port=4536, num_chans=528,
+                 stream_id='stream_sim'):
         self.agent = agent
         self.log = agent.log
         self.target_host = target_host
 
         self.port = port
+
+        self.stream_id = stream_id
 
         self.writer = None
         self.is_streaming = False
@@ -164,6 +169,7 @@ class SmurfStreamSimulator:
                 f = core.G3Frame(core.G3FrameType.Scan)
                 f['session_id'] = 0
                 f['frame_num'] = frame_num
+                f['sostream_id'] = self.stream_id
                 f['data'] = core.G3TimestreamMap()
 
                 for i, chan in enumerate(self.channels):
@@ -211,6 +217,7 @@ class SmurfStreamSimulator:
             f = core.G3Frame(core.G3FrameType.Observation)
             f['session_id'] = 0
             f['start_time'] = time.time()
+            f['sostream_id'] = self.stream_id
             self.writer.Process(f)
 
 

--- a/docs/agents/smurf_recorder.rst
+++ b/docs/agents/smurf_recorder.rst
@@ -34,6 +34,14 @@ connection will need to be reestablished in the next iteration of the loop.
 This should be fine, as long as we do not enter a state where many connections
 are made in succession.
 
+G3Files will be written to the path::
+
+    <data_dir>/<5 ctime digits>/<stream-id>/filename
+
+The recorder will attempt to read the stream-id from the G3Frames, however
+if no stream-id is present, the stream-id passed in the site arguments will
+be used.
+
 The recorder will write the frames to file with file names and location based
 on the timestamp when the acquisition was started (i.e. the first frame was
 written.) Files will be at most "time-per-file" long, which is configurable but
@@ -75,7 +83,8 @@ using all of the available arguments::
                      ['--time-per-file', '600'],
                      ['--data-dir', '/data/'],
                      ['--port', '50000'],
-                     ['--address', 'smurf-stream-sim']]},
+                     ['--address', 'smurf-stream-sim'],
+                     ['--stream-id', 'crate1slot2']]},
 
 A few things to keep in mind. The ``--data-dir`` is the directory within the
 container, the default is probably fine, but can be changed if needed, you'll

--- a/socs/agent/smurf_recorder.py
+++ b/socs/agent/smurf_recorder.py
@@ -20,7 +20,7 @@ class FlowControl(Enum):
     CLEANSE = 3
 
 
-def _create_dirname(start_time, data_dir):
+def _create_dirname(start_time, data_dir, stream_id):
     """Create the file path for .g3 file output.
 
     Note: This will create directories if they don't exist already.
@@ -31,6 +31,8 @@ def _create_dirname(start_time, data_dir):
         Timestamp for start of data collection
     data_dir : str
         Top level data directory for output
+    stream_id : str
+        Stream id of colleciton
 
     Returns
     -------
@@ -39,7 +41,8 @@ def _create_dirname(start_time, data_dir):
 
     """
     sub_dir = os.path.join(data_dir,
-                           "{:.5}".format(str(start_time)))
+                           "{:.5}".format(str(start_time)),
+                           stream_id)
 
     # Create new dir for current day
     if not os.path.exists(sub_dir):
@@ -95,6 +98,8 @@ class FrameRecorder:
     data_dir : str
         Location to write data files to. Subdirectories will be created within
         this directory roughly corresponding to one day.
+    stream_id : str
+        Stream ID to use to determine file path if one is not found in frames.
 
     Attributes
     ----------
@@ -143,11 +148,12 @@ class FrameRecorder:
         also contain the tracked suffix.
 
     """
-    def __init__(self, file_duration, tcp_addr, data_dir):
+    def __init__(self, file_duration, tcp_addr, data_dir, stream_id):
         # Parameters
         self.time_per_file = file_duration
         self.address = tcp_addr
         self.data_dir = data_dir
+        self.stream_id = stream_id
         self.log = txaio.make_logger()
 
         # Reader/Writer
@@ -327,7 +333,15 @@ class FrameRecorder:
 
             # Only create new dir and basename if we've finished an acquisition
             if self.filename_suffix == 0:
-                self.dirname = _create_dirname(self.start_time, self.data_dir)
+                stream_id = self.stream_id
+                for f in self.frames:
+                    if f.get('sostream_id') is not None:
+                        stream_id = f['sostream_id']
+                        break
+
+                self.dirname = _create_dirname(self.start_time,
+                                               self.data_dir,
+                                               stream_id)
                 self.basename = int(self.start_time)
 
             suffix = "_{:03d}".format(self.filename_suffix)

--- a/socs/agent/smurf_recorder.py
+++ b/socs/agent/smurf_recorder.py
@@ -32,7 +32,7 @@ def _create_dirname(start_time, data_dir, stream_id):
     data_dir : str
         Top level data directory for output
     stream_id : str
-        Stream id of colleciton
+        Stream id of collection
 
     Returns
     -------

--- a/tests/agents/test_smurf_recorder.py
+++ b/tests/agents/test_smurf_recorder.py
@@ -11,7 +11,7 @@ from spt3g import core
 @pytest.fixture
 def frame_recorder(tmpdir):
     p = tmpdir.mkdir("data")
-    record = FrameRecorder(10, "tcp://127.0.0.1:4536", p)
+    record = FrameRecorder(10, "tcp://127.0.0.1:4536", p, 'test_id')
     return record
 
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
This PR modifies the smurf-recorder file path to include the stream-id.

## Description
<!--- Describe your changes in detail -->
Based on [this](http://simonsobservatory.wdfiles.com/local--files/smurfdaq-user-interface-2020/readout_data_storage.pdf?ukey=4b10d8a49a529d110dc49cb2377d031215082f6d) presentation that Marius gave at the last Smurf-DAQ workshop, detector timestreams should be organized according to 
```
<data_dir>/<date-code>/<stream-id>/files
```
Currently data is just recorded as `<data_dir>/<date-code>/files`, so this must be updated before we can operate with multiple slots. 

This PR adds the `stream_id` variable to the path, which the SmurfRecorder will either pull from a G3Frame if possible, or use a default provided as a command line argument. In the next release of the `smurf-streamer` all frames will be tagged with the stream_id, however when running with the current iteration of the software, a default will need provided in the site-config.

This PR also includes modifications to the StreamSimulator to tag frames with a stream_id.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Modifies SmurfRecorder path to accommodate multiple slots and crates.


## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
I tested these changes by running the modified versions of the StreamSimulator, and the SmurfRecorder and verified that the new filepaths were correct.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project.
- [X] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [X] Unless I am preparing a release, I have opened this PR onto the `develop` branch.
