### PR TITLE
Add dumb-init to Agent container entrypoints

### DIFF
--- a/agents/bluefors/Dockerfile
+++ b/agents/bluefors/Dockerfile
@@ -11,7 +11,7 @@ WORKDIR /app/socs/agents/bluefors/
 COPY . .
 
 # Run registry on container startup
-ENTRYPOINT ["python3", "-u", "bluefors_log_tracker.py"]
+ENTRYPOINT ["dumb-init", "python3", "-u", "bluefors_log_tracker.py"]
 
 # Sensible default instance-id
 CMD ["--instance-id=bluefors"]

--- a/agents/cryomech_cpa/Dockerfile
+++ b/agents/cryomech_cpa/Dockerfile
@@ -15,7 +15,7 @@ COPY . /app/socs/agents/cryomech-cpa/
 
 # Run agent on container startup
 
-ENTRYPOINT ["python3", "-u", "cryomech_cpa_agent.py"]
+ENTRYPOINT ["dumb-init", "python3", "-u", "cryomech_cpa_agent.py"]
 
 CMD ["--site-hub=ws://sisock-crossbar:8001/ws", \
      "--site-http=http://sisock-crossbar:8001/call"]

--- a/agents/labjack/Dockerfile
+++ b/agents/labjack/Dockerfile
@@ -24,7 +24,7 @@ RUN pip3 install --no-cache-dir https://labjack.com/sites/default/files/software
 
 
 # Run registry on container startup
-ENTRYPOINT ["python3", "-u", "labjack_agent.py"]
+ENTRYPOINT ["dumb-init", "python3", "-u", "labjack_agent.py"]
 
 # Sensible default arguments
 CMD ["--site-hub=ws://sisock-crossbar:8001/ws", \

--- a/agents/lakeshore240/Dockerfile
+++ b/agents/lakeshore240/Dockerfile
@@ -11,7 +11,7 @@ WORKDIR /app/socs/agents/lakeshore240/
 COPY . .
 
 # Run registry on container startup
-ENTRYPOINT ["python3", "-u", "LS240_agent.py"]
+ENTRYPOINT ["dumb-init", "python3", "-u", "LS240_agent.py"]
 
 CMD ["--site-hub=ws://sisock-crossbar:8001/ws", \
      "--site-http=http://sisock-crossbar:8001/call"]

--- a/agents/lakeshore372/Dockerfile
+++ b/agents/lakeshore372/Dockerfile
@@ -11,7 +11,7 @@ WORKDIR /app/socs/agents/lakeshore372/
 COPY . .
 
 # Run registry on container startup
-ENTRYPOINT ["python3", "-u", "LS372_agent.py"]
+ENTRYPOINT ["dumb-init", "python3", "-u", "LS372_agent.py"]
 
 # Sensible default arguments
 CMD ["--site-hub=ws://sisock-crossbar:8001/ws", \

--- a/agents/meinberg_m1000/Dockerfile
+++ b/agents/meinberg_m1000/Dockerfile
@@ -17,7 +17,7 @@ RUN true
 COPY mibs/ /usr/local/lib/python3.6/dist-packages/pysnmp/smi/mibs/
 
 # Run agent on container startup
-ENTRYPOINT ["python3", "-u", "meinberg_m1000_agent.py"]
+ENTRYPOINT ["dumb-init", "python3", "-u", "meinberg_m1000_agent.py"]
 
 # Default site-hub
 CMD ["--site-hub=ws://sisock-crossbar:8001/ws", \

--- a/agents/pfeiffer_tpg366/Dockerfile
+++ b/agents/pfeiffer_tpg366/Dockerfile
@@ -11,7 +11,7 @@ WORKDIR /app/socs/agents/pfeiffer_tpg366/
 COPY . .
 
 # Run registry on container startup
-ENTRYPOINT ["python3", "-u", "pfeiffer_tpg366_agent.py"]
+ENTRYPOINT ["dumb-init", "python3", "-u", "pfeiffer_tpg366_agent.py"]
 
 CMD ["--site-hub=ws://sisock-crossbar:8001/ws", \
      "--site-http=http://sisock-crossbar:8001/call"]

--- a/agents/pysmurf_archiver/Dockerfile
+++ b/agents/pysmurf_archiver/Dockerfile
@@ -14,7 +14,7 @@ RUN apt-get install rsync -y
 RUN pip3 install -r requirements.txt
 
 # Run registry on container startup
-ENTRYPOINT ["python3", "-u", "pysmurf_archiver_agent.py"]
+ENTRYPOINT ["dumb-init", "python3", "-u", "pysmurf_archiver_agent.py"]
 
 CMD ["--site-hub=ws://sisock-crossbar:8001/ws", \
      "--site-http=http://sisock-crossbar:8001/call"]

--- a/agents/pysmurf_controller/Dockerfile
+++ b/agents/pysmurf_controller/Dockerfile
@@ -31,7 +31,7 @@ WORKDIR /app/socs/agents/pysmurf_controller
 COPY . .
 RUN pip3 install -r requirements.txt
 
-ENTRYPOINT ["python3", "-u", "pysmurf_controller.py"]
+ENTRYPOINT ["dumb-init", "python3", "-u", "pysmurf_controller.py"]
 
 # Sensible defaults for setup with sisock
 CMD ["--site-hub=ws://sisock-crossbar:8001/ws", \

--- a/agents/pysmurf_monitor/Dockerfile
+++ b/agents/pysmurf_monitor/Dockerfile
@@ -13,7 +13,7 @@ RUN pip3 install -r requirements.txt
 
 
 # Run registry on container startup
-ENTRYPOINT ["python3", "-u", "pysmurf_monitor.py"]
+ENTRYPOINT ["dumb-init", "python3", "-u", "pysmurf_monitor.py"]
 
 CMD ["--site-hub=ws://sisock-crossbar:8001/ws", \
      "--site-http=http://sisock-crossbar:8001/call"]

--- a/agents/scpi_psu/Dockerfile
+++ b/agents/scpi_psu/Dockerfile
@@ -11,7 +11,7 @@ WORKDIR /app/socs/agents/scpi_psu/
 COPY . .
 
 # Run agent on container startup
-ENTRYPOINT ["python3", "-u", "scpi_psu_agent.py"]
+ENTRYPOINT ["dumb-init", "python3", "-u", "scpi_psu_agent.py"]
 
 CMD ["--site-hub=ws://sisock-crossbar:8001/ws", \
      "--site-http=http://sisock-crossbar:8001/call"]

--- a/agents/smurf_recorder/Dockerfile
+++ b/agents/smurf_recorder/Dockerfile
@@ -8,7 +8,7 @@ WORKDIR /app/socs/agents/smurf_recorder/
 COPY . .
 
 # Run registry on container startup
-ENTRYPOINT ["python3", "-u", "smurf_recorder.py"]
+ENTRYPOINT ["dumb-init", "python3", "-u", "smurf_recorder.py"]
 
 # Default site-hub
 CMD ["--site-hub=ws://sisock-crossbar:8001/ws", \

--- a/agents/smurf_stream_simulator/Dockerfile
+++ b/agents/smurf_stream_simulator/Dockerfile
@@ -7,7 +7,7 @@ FROM socs:latest
 WORKDIR /app/socs/agents/smurf_stream_simulator/
 COPY . .
 # Run registry on container startup
-ENTRYPOINT ["python3", "-u", "smurf_stream_simulator.py"]
+ENTRYPOINT ["dumb-init", "python3", "-u", "smurf_stream_simulator.py"]
 
 
 CMD ["--site-hub=ws://sisock-crossbar:8001/ws", \


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Just like https://github.com/simonsobs/ocs/pull/171 we add dumb-init to the Agent entry points.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Solves the issue raised in https://github.com/simonsobs/ocs/issues/168.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
Individual containers are untested, however adding dumb-init isn't expected to cause any issues.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] Unless I am preparing a release, I have opened this PR onto the `develop` branch.
