### PR TITLE
Addes stream monitor to the smurf_recorder agent

### DIFF
--- a/agents/smurf_recorder/smurf_recorder.py
+++ b/agents/smurf_recorder/smurf_recorder.py
@@ -84,9 +84,9 @@ class SmurfRecorder:
 
         Args
         -----
-        channels : list, required
-            List of channel numbers to be monitored.
-            A maximum of 6 channels can be monitored at a time.
+        channels : List[Int], required
+            List of channel numbers (integers between 0 and 2048) to be
+            monitored. A maximum of 6 channels can be monitored at a time.
         """
         if params is None:
             params = {}
@@ -213,8 +213,9 @@ if __name__ == "__main__":
                            listener.stop_record,
                            startup=bool(args.auto_start))
     agent.register_task('set_monitored_channels',
-                        listener.set_monitored_channels)
-    agent.register_task('set_target_rate', listener.set_target_rate)
+                        listener.set_monitored_channels, blocking=False)
+    agent.register_task('set_target_rate', listener.set_target_rate,
+                        blocking=False)
 
 
     runner.run(agent, auto_reconnect=True)

--- a/agents/smurf_recorder/smurf_recorder.py
+++ b/agents/smurf_recorder/smurf_recorder.py
@@ -126,7 +126,7 @@ class SmurfRecorder:
 
         recorder = FrameRecorder(self.time_per_file, self.address,
                                  self.data_dir, self.stream_id,
-                                 self.target_rate)
+                                 target_rate=self.target_rate)
 
         while self.is_streaming:
             recorder.monitored_channels = self.monitored_channels

--- a/agents/smurf_recorder/smurf_recorder.py
+++ b/agents/smurf_recorder/smurf_recorder.py
@@ -86,9 +86,13 @@ class SmurfRecorder:
         -----
         channels : list, required
             List of channel numbers to be monitored.
+            A maximum of 6 channels can be monitored at a time.
         """
         if params is None:
             params = {}
+
+        if len(params['channels']) > 6:
+            return False, "Cannot monitor more than 6 channels"
 
         self.monitored_channels =  params['channels']
         return True, f"Set monitored channels to {self.monitored_channels}"
@@ -100,9 +104,13 @@ class SmurfRecorder:
         -----
         target_rate : float, required
             Target rate after downsampling for monitored channels in Hz.
+            Max target rate is 10 Hz.
         """
         if params is None:
             params = {}
+
+        if params['target_rate'] > 10:
+            return False, "Max target rate is 10 Hz"
 
         self.target_rate = params['target_rate']
         return True, f"Set target sampling rate to {self.target_rate}"

--- a/agents/smurf_recorder/smurf_recorder.py
+++ b/agents/smurf_recorder/smurf_recorder.py
@@ -58,11 +58,15 @@ class SmurfRecorder:
         false stops the recording of data.
     log : txaio.tx.Logger
         txaio logger object, created by the OCSAgent
-
+    target_rate : float
+        Target sampling rate for monitored channels.
+    monitored_channels : list
+        Readout channels to monitor. Incoming data for these channels will be
+        downsampled and published to an OCS feed.
     """
 
     def __init__(self, agent, time_per_file, data_dir, stream_id,
-                 address="localhost", port=4536):
+                 address="localhost", port=4536, target_rate=10):
         self.agent = agent
         self.time_per_file = time_per_file
         self.data_dir = data_dir
@@ -70,6 +74,38 @@ class SmurfRecorder:
         self.address = "tcp://{}:{}".format(address, port)
         self.is_streaming = False
         self.log = self.agent.log
+        self.target_rate = target_rate
+        self.monitored_channels = []
+
+        self.agent.register_feed('detectors', record=True)
+
+    def set_monitored_channels(self, session, params=None):
+        """Sets channels that the recorder should monitor.
+
+        Args
+        -----
+        channels : list, required
+            List of channel numbers to be monitored.
+        """
+        if params is None:
+            params = {}
+
+        self.monitored_channels =  params['channels']
+        return True, f"Set monitored channels to {self.monitored_channels}"
+
+    def set_target_rate(self, session, params=None):
+        """Sets the target sample rate for monitored channels.
+
+        Args
+        -----
+        target_rate : float, required
+            Target rate after downsampling for monitored channels in Hz.
+        """
+        if params is None:
+            params = {}
+
+        self.target_rate = params['target_rate']
+        return True, f"Set target sampling rate to {self.target_rate}"
 
     def start_record(self, session, params=None):
         """start_record(params=None)
@@ -89,10 +125,16 @@ class SmurfRecorder:
         self.is_streaming = True
 
         recorder = FrameRecorder(self.time_per_file, self.address,
-                                 self.data_dir, self.stream_id)
+                                 self.data_dir, self.stream_id,
+                                 self.target_rate)
 
         while self.is_streaming:
+            recorder.monitored_channels = self.monitored_channels
+            recorder.target_rate = self.target_rate
             recorder.run()
+            for k, v in recorder.stream_data.items():
+                if v['timestamps']:
+                    self.agent.publish_to_feed('detectors', v)
 
         # Explicitly clean up when done
         del recorder
@@ -131,9 +173,13 @@ def make_parser(parser=None):
     pgroup.add_argument("--address", default="localhost",
                         help="Address to listen to.")
     pgroup.add_argument('--stream-id', default='None',
-                        help="Stream id of recorded stream. If one is not " 
-                             "present in the G3Frames, this is the stream-id" 
+                        help="Stream id of recorded stream. If one is not "
+                             "present in the G3Frames, this is the stream-id"
                              "that will be used to determine file paths.")
+    pgroup.add_argument('--target-rate', default=10, type=float,
+                       help="Target rate for monitored readout channels in "
+                            "Hz. This willl be the rate that detector data is "
+                            "streamed to an OCS feed")
 
     return parser
 
@@ -151,11 +197,16 @@ if __name__ == "__main__":
                              args.data_dir,
                              args.stream_id,
                              address=args.address,
-                             port=int(args.port))
+                             port=int(args.port),
+                             target_rate=args.target_rate)
 
     agent.register_process("record",
                            listener.start_record,
                            listener.stop_record,
                            startup=bool(args.auto_start))
+    agent.register_task('set_monitored_channels',
+                        listener.set_monitored_channels)
+    agent.register_task('set_target_rate', listener.set_target_rate)
+
 
     runner.run(agent, auto_reconnect=True)

--- a/agents/smurf_stream_simulator/smurf_stream_simulator.py
+++ b/agents/smurf_stream_simulator/smurf_stream_simulator.py
@@ -176,7 +176,7 @@ class SmurfStreamSimulator:
                     ts = core.G3Timestream([chan.read() for t in times])
                     ts.start = core.G3Time(frame_start * core.G3Units.sec)
                     ts.stop = core.G3Time(frame_stop * core.G3Units.sec)
-                    f['data'][str(i)] = ts
+                    f['data'][f"r{i:04}"] = ts
 
                 self.writer.Process(f)
                 self.log.info("Writing frame...")

--- a/socs/agent/smurf_recorder.py
+++ b/socs/agent/smurf_recorder.py
@@ -157,7 +157,7 @@ class FrameRecorder:
         the values will have the structure required by the OCS_Feed.
     """
     def __init__(self, file_duration, tcp_addr, data_dir, stream_id,
-                 target_rate):
+                 target_rate=10):
         # Parameters
         self.time_per_file = file_duration
         self.address = tcp_addr

--- a/socs/agent/smurf_recorder.py
+++ b/socs/agent/smurf_recorder.py
@@ -151,7 +151,7 @@ class FrameRecorder:
         be stored in ``stream_data`` after each ``run`` function call.
     target_rate : float
         Target sampling rate for monitored channels in Hz.
-    scan_data : dict
+    stream_data : dict
         Data containing downsampled timestream data from the monitored. This
         dict will have the channel name (such as ``r0012``) as the key, and
         the values will have the structure required by the OCS_Feed.

--- a/socs/agent/smurf_recorder.py
+++ b/socs/agent/smurf_recorder.py
@@ -146,9 +146,18 @@ class FrameRecorder:
     basename : str
         The basename of the file currently being used. The actual file will
         also contain the tracked suffix.
-
+    monitored_channels : list
+        List of readout channels to be monitored. Data from these channels will
+        be stored in ``stream_data`` after each ``run`` function call.
+    target_rate : float
+        Target sampling rate for monitored channels in Hz.
+    scan_data : dict
+        Data containing downsampled timestream data from the monitored. This
+        dict will have the channel name (such as ``r0012``) as the key, and
+        the values will have the structure required by the OCS_Feed.
     """
-    def __init__(self, file_duration, tcp_addr, data_dir, stream_id):
+    def __init__(self, file_duration, tcp_addr, data_dir, stream_id,
+                 target_rate):
         # Parameters
         self.time_per_file = file_duration
         self.address = tcp_addr
@@ -171,6 +180,10 @@ class FrameRecorder:
         self.start_time = None
         self.dirname = None
         self.basename = None
+
+        self.monitored_channels = []
+        self.target_rate = target_rate
+        self.stream_data = {}
 
     def __del__(self):
         """Clean up by closing out the file once writing is complete."""
@@ -426,7 +439,36 @@ class FrameRecorder:
         """
         self.read_frames()
         self.check_for_frame_gap(10)
+        self.read_stream_data()
         if self.frames:
             self.create_new_file()
             self.write_frames_to_file()
             self.split_acquisition()
+
+    def read_stream_data(self):
+        """Reads stream data from ``self.frames``, downsamples it, and stores
+        it in ``self.stream_data``.
+        """
+        chan_keys = [f'r{c:04}' for c in self.monitored_channels]
+        self.stream_data = {
+            k: {'timestamps': [], 'block_name': k, 'data': {k:[]}}
+            for k in chan_keys
+        }
+
+        for frame in self.frames:
+            if frame.type != core.G3FrameType.Scan:
+                continue
+            ds_factor = (frame['data'].sample_rate/core.G3Units.Hz) \
+                        // self.target_rate
+            ds_factor = max(int(ds_factor), 1)
+            times = [
+                t.time / core.G3Units.s
+                for t in frame['data'].times()[::ds_factor]
+            ]
+            for key in chan_keys:
+                data = frame['data'].get(key)
+                if data is None:
+                    continue
+                self.stream_data[key]['timestamps'].extend(times)
+                self.stream_data[key]['data'][key].extend(list(data[::ds_factor]))
+


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
This PR adds functionality to the smurf_recorder agent to monitor specified readout channels, downsample incoming data for those channels, and sends them to grafana.

## Description
<!--- Describe your changes in detail -->
This adds two new tasks to the smurf recorder agent. `set_monitored_channels` will set update the list of channels to stream, and `set_target_rate` sets the sample rate that the detector data will be downsampled to.

It also adds a function `read_stream_data` to the `FrameRecorder` class that loops through incoming frames and records downsampled data for the monitored channels so it can be published by the agent.

This PR also changes the G3TimestreamMap keys in the smurf_stream_simulator to be the same as the data currently passed by the real smurf-streamer (e.g. 'r0012' instead of '12').

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
This will allow detector data to be viewed in grafana, which will be very useful for RF and optical tests.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
I've tested by manually running the smurf_recorder modified smurf_stream_simulator locally and was able to view the monitored timestreams on grafana, and verified that `set_monitored_channels` and `set_target_rate` both work as expected. 

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] Unless I am preparing a release, I have opened this PR onto the `develop` branch.
