### PR TITLE
Replace 'sisock-crossbar' with 'crossbar'

### DIFF
--- a/agents/cryomech_cpa/Dockerfile
+++ b/agents/cryomech_cpa/Dockerfile
@@ -17,5 +17,5 @@ COPY . /app/socs/agents/cryomech-cpa/
 
 ENTRYPOINT ["dumb-init", "python3", "-u", "cryomech_cpa_agent.py"]
 
-CMD ["--site-hub=ws://sisock-crossbar:8001/ws", \
-     "--site-http=http://sisock-crossbar:8001/call"]
+CMD ["--site-hub=ws://crossbar:8001/ws", \
+     "--site-http=http://crossbar:8001/call"]

--- a/agents/labjack/Dockerfile
+++ b/agents/labjack/Dockerfile
@@ -27,5 +27,5 @@ RUN pip3 install --no-cache-dir https://labjack.com/sites/default/files/software
 ENTRYPOINT ["dumb-init", "python3", "-u", "labjack_agent.py"]
 
 # Sensible default arguments
-CMD ["--site-hub=ws://sisock-crossbar:8001/ws", \
-     "--site-http=http://sisock-crossbar:8001/call"]
+CMD ["--site-hub=ws://crossbar:8001/ws", \
+     "--site-http=http://crossbar:8001/call"]

--- a/agents/lakeshore240/Dockerfile
+++ b/agents/lakeshore240/Dockerfile
@@ -13,5 +13,5 @@ COPY . .
 # Run registry on container startup
 ENTRYPOINT ["dumb-init", "python3", "-u", "LS240_agent.py"]
 
-CMD ["--site-hub=ws://sisock-crossbar:8001/ws", \
-     "--site-http=http://sisock-crossbar:8001/call"]
+CMD ["--site-hub=ws://crossbar:8001/ws", \
+     "--site-http=http://crossbar:8001/call"]

--- a/agents/lakeshore372/Dockerfile
+++ b/agents/lakeshore372/Dockerfile
@@ -14,5 +14,5 @@ COPY . .
 ENTRYPOINT ["dumb-init", "python3", "-u", "LS372_agent.py"]
 
 # Sensible default arguments
-CMD ["--site-hub=ws://sisock-crossbar:8001/ws", \
-     "--site-http=http://sisock-crossbar:8001/call"]
+CMD ["--site-hub=ws://crossbar:8001/ws", \
+     "--site-http=http://crossbar:8001/call"]

--- a/agents/meinberg_m1000/Dockerfile
+++ b/agents/meinberg_m1000/Dockerfile
@@ -20,5 +20,5 @@ COPY mibs/ /usr/local/lib/python3.6/dist-packages/pysnmp/smi/mibs/
 ENTRYPOINT ["dumb-init", "python3", "-u", "meinberg_m1000_agent.py"]
 
 # Default site-hub
-CMD ["--site-hub=ws://sisock-crossbar:8001/ws", \
-     "--site-http=http://sisock-crossbar:8001/call"]
+CMD ["--site-hub=ws://crossbar:8001/ws", \
+     "--site-http=http://crossbar:8001/call"]

--- a/agents/pfeiffer_tpg366/Dockerfile
+++ b/agents/pfeiffer_tpg366/Dockerfile
@@ -13,5 +13,5 @@ COPY . .
 # Run registry on container startup
 ENTRYPOINT ["dumb-init", "python3", "-u", "pfeiffer_tpg366_agent.py"]
 
-CMD ["--site-hub=ws://sisock-crossbar:8001/ws", \
-     "--site-http=http://sisock-crossbar:8001/call"]
+CMD ["--site-hub=ws://crossbar:8001/ws", \
+     "--site-http=http://crossbar:8001/call"]

--- a/agents/pysmurf_archiver/Dockerfile
+++ b/agents/pysmurf_archiver/Dockerfile
@@ -16,5 +16,5 @@ RUN pip3 install -r requirements.txt
 # Run registry on container startup
 ENTRYPOINT ["dumb-init", "python3", "-u", "pysmurf_archiver_agent.py"]
 
-CMD ["--site-hub=ws://sisock-crossbar:8001/ws", \
-     "--site-http=http://sisock-crossbar:8001/call"]
+CMD ["--site-hub=ws://crossbar:8001/ws", \
+     "--site-http=http://crossbar:8001/call"]

--- a/agents/pysmurf_controller/Dockerfile
+++ b/agents/pysmurf_controller/Dockerfile
@@ -34,5 +34,5 @@ RUN pip3 install -r requirements.txt
 ENTRYPOINT ["dumb-init", "python3", "-u", "pysmurf_controller.py"]
 
 # Sensible defaults for setup with sisock
-CMD ["--site-hub=ws://sisock-crossbar:8001/ws", \
-     "--site-http=http://sisock-crossbar:8001/call"]
+CMD ["--site-hub=ws://crossbar:8001/ws", \
+     "--site-http=http://crossbar:8001/call"]

--- a/agents/pysmurf_monitor/Dockerfile
+++ b/agents/pysmurf_monitor/Dockerfile
@@ -15,5 +15,5 @@ RUN pip3 install -r requirements.txt
 # Run registry on container startup
 ENTRYPOINT ["dumb-init", "python3", "-u", "pysmurf_monitor.py"]
 
-CMD ["--site-hub=ws://sisock-crossbar:8001/ws", \
-     "--site-http=http://sisock-crossbar:8001/call"]
+CMD ["--site-hub=ws://crossbar:8001/ws", \
+     "--site-http=http://crossbar:8001/call"]

--- a/agents/scpi_psu/Dockerfile
+++ b/agents/scpi_psu/Dockerfile
@@ -13,5 +13,5 @@ COPY . .
 # Run agent on container startup
 ENTRYPOINT ["dumb-init", "python3", "-u", "scpi_psu_agent.py"]
 
-CMD ["--site-hub=ws://sisock-crossbar:8001/ws", \
-     "--site-http=http://sisock-crossbar:8001/call"]
+CMD ["--site-hub=ws://crossbar:8001/ws", \
+     "--site-http=http://crossbar:8001/call"]

--- a/agents/smurf_recorder/Dockerfile
+++ b/agents/smurf_recorder/Dockerfile
@@ -11,5 +11,5 @@ COPY . .
 ENTRYPOINT ["dumb-init", "python3", "-u", "smurf_recorder.py"]
 
 # Default site-hub
-CMD ["--site-hub=ws://sisock-crossbar:8001/ws", \
-     "--site-http=http://sisock-crossbar:8001/call"]
+CMD ["--site-hub=ws://crossbar:8001/ws", \
+     "--site-http=http://crossbar:8001/call"]

--- a/agents/smurf_stream_simulator/Dockerfile
+++ b/agents/smurf_stream_simulator/Dockerfile
@@ -10,5 +10,5 @@ COPY . .
 ENTRYPOINT ["dumb-init", "python3", "-u", "smurf_stream_simulator.py"]
 
 
-CMD ["--site-hub=ws://sisock-crossbar:8001/ws", \
-     "--site-http=http://sisock-crossbar:8001/call"]
+CMD ["--site-hub=ws://crossbar:8001/ws", \
+     "--site-http=http://crossbar:8001/call"]

--- a/agents/synacc/Dockerfile
+++ b/agents/synacc/Dockerfile
@@ -15,5 +15,5 @@ RUN pip3 install -r requirements.txt
 ENTRYPOINT ["python3", "-u", "synacc.py"]
 
 # Sensible default arguments
-CMD ["--site-hub=ws://sisock-crossbar:8001/ws", \
-     "--site-http=http://sisock-crossbar:8001/call"]
+CMD ["--site-hub=ws://crossbar:8001/ws", \
+     "--site-http=http://crossbar:8001/call"]

--- a/docs/agents/lakeshore240.rst
+++ b/docs/agents/lakeshore240.rst
@@ -101,7 +101,7 @@ Docker container. An example configuration is::
   ocs-LSA24MA:
     image: grumpy.physics.yale.edu/ocs-lakeshore240-agent:latest
     depends_on:
-      - "sisock-crossbar"
+      - "crossbar"
     devices:
       - "/dev/LSA24MA:/dev/LSA24MA"
     hostname: nuc-docker
@@ -109,8 +109,8 @@ Docker container. An example configuration is::
       - ${OCS_CONFIG_DIR}:/config:ro
     command:
       - "--instance-id=LSA24MA"
-      - "--site-hub=ws://sisock-crossbar:8001/ws"
-      - "--site-http=http://sisock-crossbar:8001/call"
+      - "--site-hub=ws://crossbar:8001/ws"
+      - "--site-http=http://crossbar:8001/call"
 
 The serial number will need to be updated in your configuration. The hostname
 should also match your configured host in your OCS configuration file. The

--- a/docs/agents/pysmurf/pysmurf-archiver.rst
+++ b/docs/agents/pysmurf/pysmurf-archiver.rst
@@ -59,7 +59,7 @@ The docker-compose entry is similar to that of the pysmurf-monitor. For example:
             - /home/ocs:/home/ocs
             - /data:/data
         depends_on:
-            - "sisock-crossbar"
+            - "crossbar"
 
 Archived Path
 --------------

--- a/docs/agents/pysmurf/pysmurf-controller.rst
+++ b/docs/agents/pysmurf/pysmurf-controller.rst
@@ -86,7 +86,7 @@ named ``ocs-pysmurf-monitor`` might look something like::
             - /data:/data
             - /path/to/dev/pysmurf/:/usr/local/src/pysmurf
         depends_on:
-            - "sisock-crossbar"
+            - "crossbar"
 
 
 

--- a/docs/agents/pysmurf/pysmurf-monitor.rst
+++ b/docs/agents/pysmurf/pysmurf-monitor.rst
@@ -139,7 +139,7 @@ An example docker-compose entry might look like::
             - ${OCS_CONFIG_DIR}:/config
             - /data:/data
         depends_on:
-            - "sisock-crossbar"
+            - "crossbar"
 
 Where DB_HOST, DB, DB_USER, and DB_PW are set in the ``.env`` file in the same dir as
 the docker-compose file.


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Replace all Dockerfile default CMDs that specify 'sisock-crossbar' with just 'crossbar'. Also replace instances in the documentation.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Upstream, OCS has made this change, redrawing the boundary between OCS and sisock (https://github.com/simonsobs/ocs/issues/135). For compatibility we should do the same here.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
Not yet tested, but changes follow from OCS where this has been tested. Plus it's just a configuration change, however one that needs to be announced.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] Unless I am preparing a release, I have opened this PR onto the `develop` branch.
