### PR TITLE
Clamp ds_factor in smurf recorder

### DIFF
--- a/socs/agent/smurf_recorder.py
+++ b/socs/agent/smurf_recorder.py
@@ -461,6 +461,9 @@ class FrameRecorder:
             ds_factor = (frame['data'].sample_rate/core.G3Units.Hz) \
                         // self.target_rate
             ds_factor = max(int(ds_factor), 1)
+            n_samples = frame['data'].n_samples
+            if 1 < n_samples <= ds_factor:
+                ds_factor = n_samples - 1
             times = [
                 t.time / core.G3Units.s
                 for t in frame['data'].times()[::ds_factor]


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Clamps the downsample factor in smurf_recorder's stream monitoring function, solving #122.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Slicing with step size larger than the length of the would cause spt3g to log a fatal error.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
Tested running this locally with the smurf-recorder with `target_rate=0.1` and short file sizes.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] Unless I am preparing a release, I have opened this PR onto the `develop` branch.
