### PR TITLE
Bump ocs version to v0.7.1-9-g500447e-dev

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@
 # A container setup with an installation of socs.
 
 # Use the ocs image as a base
-FROM simonsobs/ocs:v0.7.1-7-g700b889-dev
+FROM simonsobs/ocs:v0.7.1-9-g500447e-dev
 
 # Copy the current directory contents into the container at /app
 COPY . /app/socs/


### PR DESCRIPTION
This introduces so3g v0.1.0-24-g5645096 and all that comes with it, including
Int64 support in G3VectorInts.

Will merge once tests pass.