### PR TITLE
bump sodetlib version

### DIFF
--- a/agents/pysmurf_controller/Dockerfile
+++ b/agents/pysmurf_controller/Dockerfile
@@ -1,4 +1,4 @@
-FROM simonsobs/sodetlib:v0.0.1
+FROM simonsobs/sodetlib:v0.1.0
 
 # Set locale
 ENV LANG C.UTF-8


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
bump pysmurf-controller to socs version v0.1.0 to fix schema error in pysmurf.
Will merge if tests pass because it's needed at UCSD.