### PR TITLE
Implement labjack ljm functionality to allow high sample rates

### DIFF
--- a/.github/workflows/develop.yml
+++ b/.github/workflows/develop.yml
@@ -38,7 +38,7 @@ jobs:
 
     - name: Test documentation build
       run: |
-        docker run --rm socs sh -c "make -C docs/ html"
+        docker run --rm -e READTHEDOCS=True socs sh -c "make -C docs/ html"
 
     # Dockerize
     - name: Build and push development docker image

--- a/.github/workflows/develop.yml
+++ b/.github/workflows/develop.yml
@@ -38,7 +38,7 @@ jobs:
 
     - name: Test documentation build
       run: |
-        docker run --rm -e READTHEDOCS=True socs sh -c "make -C docs/ html"
+        docker run --rm socs sh -c "make -C docs/ html"
 
     # Dockerize
     - name: Build and push development docker image

--- a/.github/workflows/official-docker-images.yml
+++ b/.github/workflows/official-docker-images.yml
@@ -30,7 +30,7 @@ jobs:
 
     - name: Test documentation build
       run: |
-        docker run --rm -e READTHEDOCS=True socs sh -c "make -C docs/ html"
+        docker run --rm socs sh -c "make -C docs/ html"
 
     # Dockerize
     - name: Build and push official docker image

--- a/.github/workflows/official-docker-images.yml
+++ b/.github/workflows/official-docker-images.yml
@@ -30,7 +30,7 @@ jobs:
 
     - name: Test documentation build
       run: |
-        docker run --rm socs sh -c "make -C docs/ html"
+        docker run --rm -e READTHEDOCS=True socs sh -c "make -C docs/ html"
 
     # Dockerize
     - name: Build and push official docker image

--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -35,4 +35,4 @@ jobs:
 
     - name: Test documentation build
       run: |
-        docker run --rm socs sh -c "make -C docs/ html"
+        docker run --rm -e READTHEDOCS=True socs sh -c "make -C docs/ html"

--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -35,4 +35,4 @@ jobs:
 
     - name: Test documentation build
       run: |
-        docker run --rm -e READTHEDOCS=True socs sh -c "make -C docs/ html"
+        docker run --rm socs sh -c "make -C docs/ html"

--- a/agents/labjack/Dockerfile
+++ b/agents/labjack/Dockerfile
@@ -22,7 +22,6 @@ RUN ./labjack_ljm_minimal_2020_03_30_x86_64/labjack_ljm_installer.run -- --no-re
 
 RUN pip3 install --no-cache-dir https://labjack.com/sites/default/files/software/Python_LJM_2019_04_03.zip
 
-
 # Run registry on container startup
 ENTRYPOINT ["dumb-init", "python3", "-u", "labjack_agent.py"]
 

--- a/agents/labjack/labjack_agent.py
+++ b/agents/labjack/labjack_agent.py
@@ -89,6 +89,10 @@ class LabJackFunctions:
         Given a voltage array and function information from the
         labjack_config.yaml file, applies a unit conversion.
         Returns the converted value and its units.
+        Args:
+            v_array (numpy array): The voltages to be converted.
+            function_info (dict): Specifies the type of function.
+                If custom, also gives the function.
         """
         if function_info["user_defined"] == 'False':
             function = getattr(self, function_info['type'])
@@ -308,8 +312,8 @@ class LabJackAgent:
                     'data': {},
                     'timestamp': timestamps[0]
                 }
-                for key in data['data'].keys():
-                    data_downsampled['data'][key] = data['data'][key][0]
+                for key, value in data['data'].items():
+                    data_downsampled['data'][key] = value[0]
                 self.agent.publish_to_feed('sensors_downsampled', data_downsampled)
                 session.data = data_downsampled
 

--- a/agents/labjack/labjack_agent.py
+++ b/agents/labjack/labjack_agent.py
@@ -2,7 +2,7 @@ import argparse
 import time
 import struct
 import os
-from pymodbus.client.sync import ModbusTcpClient
+from labjack import ljm
 import numexpr
 import yaml
 import csv
@@ -84,32 +84,34 @@ class LabJackFunctions:
     def __init__(self):
         pass
 
-    def unit_conversion(self, v, function_info):
+    def unit_conversion(self, v_array, function_info):
         """
-        Given a voltage and function information from the
+        Given a voltage array and function information from the
         labjack_config.yaml file, applies a unit conversion.
         Returns the converted value and its units.
         """
-
         if function_info["user_defined"] == 'False':
             function = getattr(self, function_info['type'])
-            return function(v)
+            return function(v_array)
 
+        # Custom function evaluation
         else:
             units = function_info['units']
-            value = float(numexpr.evaluate(function_info["function"]))
-            return value, units
+            new_values = []
+            for v in v_array:
+                new_values.append(float(numexpr.evaluate(function_info["function"])))
+            return new_values, units
 
-    def MKS390(self, v):
+    def MKS390(self, v_array):
         """
         Conversion function for the MKS390 Micro-Ion ATM
         Modular Vaccum Gauge.
         """
-        value = 1.3332*10**(2*v - 11)
+        value = 1.3332*10**(2*v_array - 11)
         units = 'mBar'
         return value, units
 
-    def warm_therm(self, v):
+    def warm_therm(self, v_array):
         """
         Conversion function for SO warm thermometry readout.
         Voltage is converted to resistance using the LJTick, which
@@ -118,7 +120,7 @@ class LabJackFunctions:
         for the thermistor model, serial number 10K4D25.
         """
         # LJTick voltage to resistance conversion
-        R = (2.5-v)*10000/v
+        R = (2.5-v_array)*10000/v_array
 
         # Import the Ohms to Celsius cal curve and apply cubic
         # interpolation to find the temperature
@@ -129,12 +131,17 @@ class LabJackFunctions:
         R_cal = np.array([float(RT[1]) for RT in lists[1:]])
         T_cal = np.flip(T_cal)
         R_cal = np.flip(R_cal)
-        RtoT = interp1d(R_cal, T_cal, kind='cubic')
+        try:
+            RtoT = interp1d(R_cal, T_cal, kind='cubic')
+            values = RtoT(R)
 
-        value = float(RtoT(R))
+        except ValueError:
+            print('Temperature outside thermometer range')
+            values = -1000 + np.zeros(len(R))
+
         units = 'C'
 
-        return value, units
+        return values, units
 
 
 # LabJack agent class
@@ -147,16 +154,16 @@ class LabJackAgent:
         self.lock = TimeoutLock()
         self.ip_address = ip_address
         self.module = None
-        print(f"Active channels is {active_channels}")
-
-        if active_channels == 'T7-all':
-            self.sensors = ['Channel_{}'.format(i+1) for i in range(14)]
-        elif active_channels == 'T4-all':
-            self.sensors = ['Channel_{}'.format(i+1) for i in range(12)]
-        else:
-            self.sensors = ['Channel_{}'.format(ch) for ch in active_channels]
         self.ljf = LabJackFunctions()
         self.sampling_frequency = sampling_frequency
+
+        # Labjack channels to read
+        if active_channels == 'T7-all':
+            self.chs = ['AIN{}'.format(i) for i in range(14)]
+        elif active_channels == 'T4-all':
+            self.chs = ['AIN{}'.format(i) for i in range(12)]
+        else:
+            self.chs = active_channels
 
         # Load dictionary of unit conversion functions from yaml file. Assumes
         # the file is in the $OCS_CONFIG_DIR directory
@@ -167,18 +174,30 @@ class LabJackAgent:
                                               function_file)
             with open(function_file_path, 'r') as stream:
                 self.functions = yaml.safe_load(stream)
+                if self.functions is None:
+                    self.functions = {}
                 print(f"Applying conversion functions: {self.functions}")
 
         self.initialized = False
         self.take_data = False
 
-        # Register feed
+        # Register main feed. Exclude influx due to potentially high scan rate
         agg_params = {
             'frame_length': 60,
+            'exclude_influx': True
         }
-        self.agent.register_feed('Sensors',
+        self.agent.register_feed('sensors',
                                  record=True,
                                  agg_params=agg_params,
+                                 buffer_time=1)
+
+        # Register downsampled feed for influx.
+        agg_params_downsampled = {
+            'frame_length': 60
+        }
+        self.agent.register_feed('sensors_downsampled',
+                                 record=True,
+                                 agg_params=agg_params_downsampled,
                                  buffer_time=1)
 
     # Task functions
@@ -197,10 +216,13 @@ class LabJackAgent:
                 return False, "Could not acquire lock."
 
             session.set_status('starting')
-
-            self.module = ModbusTcpClient(str(self.ip_address))
-
-        print("Initialized labjack module")
+            # Connect with the labjack
+            self.handle = ljm.openS("ANY", "ANY", self.ip_address)
+            info = ljm.getHandleInfo(self.handle)
+            print("\nOpened LabJack of type: %i, Connection type: %i,\n"
+                  "Serial number: %i, IP address: %s, Port: %i" %
+                  (info[0], info[1], info[2],
+                   ljm.numberToIP(info[3]), info[4]))
 
         session.add_message("Labjack initialized")
 
@@ -225,8 +247,13 @@ class LabJackAgent:
         if params is None:
             params = {}
 
-        f_sample = params.get('sampling_frequency', self.sampling_frequency)
-        sleep_time = 1/f_sample
+        # Setup streaming parameters. Data is collected and published in
+        # blocks at 1 Hz or the scan rate, whichever is less.
+        scan_rate_input = params.get('sampling_frequency',
+                                     self.sampling_frequency)
+        scans_per_read = max(1, int(scan_rate_input))
+        num_chs = len(self.chs)
+        ch_addrs = ljm.namesToAddresses(num_chs, self.chs)[0]
 
         with self.lock.acquire_timeout(0, job='acq') as acquired:
             if not acquired:
@@ -235,35 +262,62 @@ class LabJackAgent:
                 return False, "Could not acquire lock."
 
             session.set_status('running')
-
             self.take_data = True
 
+            # Start the data stream. Use the scan rate returned by the stream,
+            # which should be the same as the input scan rate.
+            scan_rate = ljm.eStreamStart(self.handle, scans_per_read, num_chs,
+                                         ch_addrs, scan_rate_input)
+            print(f"\nStream started with a scan rate of {scan_rate} Hz.")
+
+            cur_time = time.time()
             while self.take_data:
                 data = {
-                    'timestamp': time.time(),
                     'block_name': 'sens',
                     'data': {}
                 }
 
-                for i, sens in enumerate(self.sensors):
-                    rr = self.module.read_input_registers(2*i, 2)
-                    data['data'][sens + 'V'] = data_to_float32(rr.registers)
+                # Query the labjack
+                raw_output = ljm.eStreamRead(self.handle)
+                output = raw_output[0]
+
+                # Data comes in form ['AIN0_1', 'AIN1_1', 'AIN0_2', ...]
+                for i, ch in enumerate(self.chs):
+                    ch_output = output[i::num_chs]
+                    data['data'][ch + 'V'] = ch_output
 
                     # Apply unit conversion function for this channel
-                    if sens in self.functions.keys():
-                        v = data['data'][sens + 'V']
-                        value, units = \
-                            self.ljf.unit_conversion(v, self.functions[sens])
-                        data['data'][sens + '_' + units] = value
+                    if ch in self.functions.keys():
+                        new_ch_output, units = \
+                            self.ljf.unit_conversion(np.array(ch_output),
+                                                     self.functions[ch])
+                        data['data'][ch + units] = list(new_ch_output)
 
-                time.sleep(sleep_time)
+                # The labjack outputs at exactly the scan rate but doesn't
+                # generate timestamps. So create them here.
+                timestamps = [cur_time+i/scan_rate for i in range(scans_per_read)]
+                cur_time += scans_per_read/scan_rate
+                data['timestamps'] = timestamps
 
-                self.agent.publish_to_feed('Sensors', data)
+                self.agent.publish_to_feed('sensors', data)
 
-                # Allow this process to be queried to return current data
-                session.data = data
+                # Publish to the downsampled data feed only the first
+                # timestamp and data point for each channel.
+                data_downsampled = {
+                    'block_name': 'sens',
+                    'data': {},
+                    'timestamp': timestamps[0]
+                }
+                for key in data['data'].keys():
+                    data_downsampled['data'][key] = data['data'][key][0]
+                self.agent.publish_to_feed('sensors_downsampled', data_downsampled)
+                session.data = data_downsampled
 
-            self.agent.feeds['Sensors'].flush_buffer()
+            # Flush buffer and stop the data stream
+            self.agent.feeds['sensors'].flush_buffer()
+            self.agent.feeds['sensors_downsampled'].flush_buffer()
+            ljm.eStreamStop(self.handle)
+            print("Data stream stopped")
 
         return True, 'Acquisition exited cleanly.'
 

--- a/agents/labjack/labjack_agent.py
+++ b/agents/labjack/labjack_agent.py
@@ -2,7 +2,6 @@ import argparse
 import time
 import struct
 import os
-from labjack import ljm
 import numexpr
 import yaml
 import csv
@@ -11,6 +10,7 @@ import numpy as np
 
 ON_RTD = os.environ.get('READTHEDOCS') == 'True'
 if not ON_RTD:
+    from labjack import ljm
     from ocs import ocs_agent, site_config
     from ocs.ocs_twisted import TimeoutLock
 

--- a/agents/labjack/requirements.txt
+++ b/agents/labjack/requirements.txt
@@ -1,2 +1,3 @@
 numexpr
 scipy
+labjack-ljm

--- a/docs/agents/labjack.rst
+++ b/docs/agents/labjack.rst
@@ -31,7 +31,7 @@ available arguments::
          'instance-id': 'labjack',
          'arguments':[
            ['--ip-address', '10.10.10.150'],
-           ['--active-channels', ['1', '2', '3']],
+           ['--active-channels', ['AIN0', 'AIN1', 'AIN2']],
            ['--function-file', 'labjack-functions.yaml'],
            ['--mode', 'acq'],
            ['--sampling_frequency', '700'],
@@ -41,32 +41,36 @@ You should assign your LabJack a static IP, you'll need to know that here.
 The 'active-channels' argument specifies the channels that will be read out.
 It can be a list, 'T7-all', or 'T4-all'. The latter two read out all 
 14 or 12 analog channels on the T7 and T4, respectively. 'sampling_frequency'
-is in Hz, and has been tested sucessfully up to about 700 Hz. The 'function-file' 
-argument specifies the labjack configuration file, which is located in your 
-OCS configuration directory. This allows analog voltage inputs on the labjack 
-to be converted to different units. Here is an example labjack configuration 
-file::
+is in Hz, and has been tested sucessfully from 0.1 to 5000 Hz. To avoid 
+high sample rates potentially clogging up live monitoring, the main feed 
+doesn't get published to influxdb. Instead influx gets a seperate feed 
+downsampled to a maximum of 1Hz. Both the main and downsampled feeds are 
+published to g3 files. 
 
-    Channel_1:
+The 'function-file' argument specifies the labjack configuration file, which 
+is located in your OCS configuration directory. This allows analog voltage 
+inputs on the labjack to be converted to different units. Here is an example 
+labjack configuration file::
+
+    AIN0:
         user_defined: 'False'
         type: "MKS390"
 
-    Channel_2: 
+    AIN1: 
         user_defined: 'False'
         type: 'warm_therm'
 
-    Channel_3:
+    AIN2:
         user_defined: 'True'
         units: 'Ohms'
         function: '(2.5-v)*10000/v'
         
-In this example, Channels 1 and 2 (AIN0 and AIN1 on the labjack) are hooked
-up to the MKS390 pressure `gauge`_ and a `thermistor`_ from the SO-specified
-warm thermometry setup, respectively. Since these are defined functions in the
-LabJackFunctions class, specifying the name of their method is all that is
-needed. Channel 3 shows how to define a custom function. In this case, the user
-specifies the units and the function itself, which takes the input voltage 'v'
-as the only argument.
+In this example, channels AIN0 and AIN1 are hooked up to the MKS390 pressure 
+`gauge`_ and a `thermistor`_ from the SO-specified warm thermometry setup, 
+respectively. Since these are defined functions in theLabJackFunctions class, 
+specifying the name of their method is all that is needed. AIN2 shows how to 
+define a custom function. In this case, the user specifies the units and the 
+function itself, which takes the input voltage 'v' as the only argument.
 
 .. _gauge: https://www.mksinst.com/f/390-micro-ion-atm-modular-vacuum-gauge
 .. _thermistor: https://docs.rs-online.com/c868/0900766b8142cdef.pdf
@@ -78,6 +82,7 @@ example docker-compose service configuration is shown here::
 
   ocs-labjack:
     image: simonsobs/ocs-labjack-agent:latest
+    <<: *log-options
     hostname: ocs-docker
     network_mode: "host"
     volumes:
@@ -92,7 +97,7 @@ Example Client
 --------------
 Since labjack functionality is currently limited to acquiring data, which can 
 enabled on startup, users are likely to rarely need a client. This example
-shows the basic acquisition funcionality::
+shows the basic acquisition functionality::
 
     #Initialize the labjack
     from ocs import matched_client
@@ -105,6 +110,7 @@ shows the basic acquisition funcionality::
     print(session)
 
     #Get the current data values 1 second after starting acquistion
+    import time
     time.sleep(1)
     status, message, session = lj.acq.status()
     print(session["data"])

--- a/docs/agents/labjack.rst
+++ b/docs/agents/labjack.rst
@@ -67,13 +67,17 @@ labjack configuration file::
         
 In this example, channels AIN0 and AIN1 are hooked up to the MKS390 pressure 
 `gauge`_ and a `thermistor`_ from the SO-specified warm thermometry setup, 
-respectively. Since these are defined functions in theLabJackFunctions class, 
+respectively. Since these are defined functions in the LabJackFunctions class, 
 specifying the name of their method is all that is needed. AIN2 shows how to 
 define a custom function. In this case, the user specifies the units and the 
 function itself, which takes the input voltage 'v' as the only argument.
 
 .. _gauge: https://www.mksinst.com/f/390-micro-ion-atm-modular-vacuum-gauge
 .. _thermistor: https://docs.rs-online.com/c868/0900766b8142cdef.pdf
+
+.. note:: 
+    The (lower-case) letter 'v' must be used when writing user-defined 
+    functions. No other variable will be parsed correctly.
 
 Docker
 ``````


### PR DESCRIPTION
## Description
The previous labjack commit did not actually implement the labjack ljm module necessary for high sample rates. This does that. It also:
- Publishes data in blocks at no faster than 1Hz, eliminating the problem of dropped data at >100Hz sample rates.
- Implements a 2nd feed downsampled to no faster than 1Hz for use in influx (and excludes the main feed from influx)
- Changes the channel names to AIN0, AIN1, etc rather than Channel_1, Channel_2, etc
- Fixes issues with the 'T7-all' and 'T4-all' commands
- Updates documentation

## Motivation and Context
Solves:
- not being able to sample >100Hz
- 'T7-all' and 'T4-all' not working
- Channel names that didn't align with their names on the labjack

## How Has This Been Tested?
- Tested the main and downsampled feeds work from 0.1Hz to 5000Hz. 
- Confirmed the main feed is not published to influx
- Confirmed that the built-in and custom functions work
- Confirmed that the warm thermometry works on a real system

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] Unless I am preparing a release, I have opened this PR onto the `develop` branch.
