### PR TITLE
Added dumb-init to pysmurf-controller reqs

### DIFF
--- a/agents/pysmurf_controller/requirements.txt
+++ b/agents/pysmurf_controller/requirements.txt
@@ -1,1 +1,2 @@
 mysql-connector>=2.1.6
+dumb-init


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Adds dumb-init to the pysmurf-controller requirements file.
## Description
Since the pysmurf-controller is built on the sodetlib image and not socs, it did not have dumb-init installed by default which was preventing it from starting correctly. This fixes it by adding it to the Docker requirements file.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Resolves https://github.com/simonsobs/smurf-issues/issues/16.

## How Has This Been Tested?
Tested by running the agent locally and checking that it actually started instead of throwing the error mentioned in the smurf-issue.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] Unless I am preparing a release, I have opened this PR onto the `develop` branch.
