### PR TITLE
Adds an OCS pathway for smurf metadata

### DIFF
--- a/agents/pysmurf_monitor/pysmurf_monitor.py
+++ b/agents/pysmurf_monitor/pysmurf_monitor.py
@@ -13,6 +13,7 @@ import argparse
 from twisted.enterprise import adbapi
 
 from socs.util import get_md5sum
+from ocs.agent.aggregator import Provider
 
 on_rtd = os.environ.get('READTHEDOCS') == 'True'
 if not on_rtd:
@@ -98,6 +99,7 @@ class PysmurfMonitor(DatagramProtocol):
             (host, port) of the sender.
         """
         data = json.loads(_data)
+        pub_id = data['id']
 
         if data['type'] in ['data_file']:
             self.log.info("New file: {fname}", fname=data['payload']['path'])
@@ -133,6 +135,32 @@ class PysmurfMonitor(DatagramProtocol):
             self.agent.publish_to_feed(
                 "pysmurf_session_data", data, from_reactor=True
             )
+
+        # Handles published metadata from the streamer
+        # Currently Pysmurf uses the "general" message type so we have to
+        # use the pub-id to notify, but we should change this in pysmurf.
+        elif pub_id.startswith("STREAMER:"):
+            self.log.debug("Received Metadata: {payload}", payload=data['payload'])
+            stream_id = pub_id.split(':')[1]
+            if '=' not in data['payload']:
+                self.log.warn("Could not extract key, val pair from message: {msg}",
+                              msg=data['payload'])
+                return
+            key, val = data['payload'].split('=')
+            key = Provider._enforce_field_name_rules(key)
+            try:
+                # Attempts to convert to float since smurf doesn't send any
+                # type info...
+                val = float(val)
+            except ValueError:
+                pass
+            feed_name = f'{stream_id}_meta'
+            if feed_name not in self.agent.feeds:
+                self.agent.register_feed(feed_name, record=True, buffer_time=0)
+            feed_data = {'block_name': key,
+                         'timestamp': data['time'],
+                         'data': {key: val}}
+            self.agent.publish_to_feed(feed_name, feed_data, from_reactor=True)
 
     def init(self, session, params=None):
         """


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
This PR adds a pipeline for publishing Rogue Metadata variables to an OCS feed. The smurf-server publishes specified metadata variables whenever they are queried, or regularly at some polling interval specified by the smurf-streamer.

## Description
<!--- Describe your changes in detail -->
This PR adds support for publishing Rogue Metadata updates to OCS feeds. The meta-data values which we want to monitor through this path can be set with the [meta registers file](https://github.com/simonsobs/smurf-streamer/blob/master/meta_registers.yaml), by making the variable group `2` if you want to just publish the variable through pysmurf, or `3` if you want to publisher the variable through pysmurf and send through the g3 stream. Setting the polling interval in that file will determine how often updates are published.

With [this commit](https://github.com/simonsobs/smurf-streamer/commit/5f00bf16cd403e2757ea54e795c7d7ae52ecfb7f) streamers will set their publisher_id to `"STREAMER:{stream_id}"` and sends data packets that look like this:
```
{'path': 'AMCc.SmurfProcessor.SOStream.dataDropCnt', 'value': 0, 'type': 'int'}
```
The feed-address will be the stream-id, and the field-name will be the variable path, modified to enforce field-name rules.

Here's an example of a grafana plot monitoring the number of channels being streamed:

<img width="1264" alt="Screen Shot 2021-05-27 at 11 00 30 AM" src="https://user-images.githubusercontent.com/4718487/119876718-0708d000-bedd-11eb-972c-e56147d1e83a.png">


## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
This is required to monitor FPGA temp, fan speeds, number of dropped samples, and more in grafana.
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
I've tested this on smurf-srv-so3 with the smurf in emulation mode at UCSD.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] Unless I am preparing a release, I have opened this PR onto the `develop` branch.
