### PR TITLE
Adds set_status calls to some operations

### DIFF
--- a/agents/pysmurf_archiver/pysmurf_archiver_agent.py
+++ b/agents/pysmurf_archiver/pysmurf_archiver_agent.py
@@ -222,6 +222,7 @@ class PysmurfArchiverAgent:
         it'll increment the `failed_copy_attempts` counter.
         """
         self.running = True
+        session.set_status('running')
         while self.running:
 
             with get_db_connection(**self.sql_config) as con:
@@ -268,6 +269,7 @@ class PysmurfArchiverAgent:
 
     def stop(self, session, params=None):
         """ Stopper for run process """
+        session.set_status('stopping')
         self.running = False
 
 

--- a/agents/smurf_recorder/smurf_recorder.py
+++ b/agents/smurf_recorder/smurf_recorder.py
@@ -136,6 +136,7 @@ class SmurfRecorder:
                                  self.data_dir, self.stream_id,
                                  target_rate=self.target_rate)
 
+        session.set_status('running')
         while self.is_streaming:
             recorder.monitored_channels = self.monitored_channels
             recorder.target_rate = self.target_rate
@@ -156,6 +157,7 @@ class SmurfRecorder:
 
         """
         self.is_streaming = False
+        session.set_status('stopping')
         return True, "Stopping Recording"
 
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Adds `set_status` calls to SmurfRecorder and SmurfArchiver operations.

## Description
<!--- Describe your changes in detail -->
Adds `set_status` calls to SmurfRecorder and SmurfArchiver operations.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Status was showing up as `starting` and never changed to `running` in the grafana operations monitor.


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] Unless I am preparing a release, I have opened this PR onto the `develop` branch.
