### PR TITLE
Catch labjack stream error

### DIFF
--- a/agents/labjack/labjack_agent.py
+++ b/agents/labjack/labjack_agent.py
@@ -11,6 +11,7 @@ import numpy as np
 ON_RTD = os.environ.get('READTHEDOCS') == 'True'
 if not ON_RTD:
     from labjack import ljm
+    from labjack.ljm.ljm import LJMError
     from ocs import ocs_agent, site_config
     from ocs.ocs_twisted import TimeoutLock
 
@@ -270,8 +271,14 @@ class LabJackAgent:
 
             # Start the data stream. Use the scan rate returned by the stream,
             # which should be the same as the input scan rate.
-            scan_rate = ljm.eStreamStart(self.handle, scans_per_read, num_chs,
-                                         ch_addrs, scan_rate_input)
+            try:
+                scan_rate = ljm.eStreamStart(self.handle, scans_per_read, num_chs,
+                                             ch_addrs, scan_rate_input)
+            except LJMError: #in case the stream is running
+                print("Stopping previous stream")
+                ljm.eStreamStop(self.handle) 
+                scan_rate = ljm.eStreamStart(self.handle, scans_per_read, num_chs,
+                                             ch_addrs, scan_rate_input)
             print(f"\nStream started with a scan rate of {scan_rate} Hz.")
 
             cur_time = time.time()

--- a/agents/labjack/labjack_agent.py
+++ b/agents/labjack/labjack_agent.py
@@ -86,7 +86,6 @@ class LabJackFunctions:
     """
     def __init__(self):
         self.log = txaio.make_logger()
-        pass
 
     def unit_conversion(self, v_array, function_info):
         """
@@ -228,9 +227,9 @@ class LabJackAgent:
             self.handle = ljm.openS("ANY", "ANY", self.ip_address)
             info = ljm.getHandleInfo(self.handle)
             self.log.info("\nOpened LabJack of type: %i, Connection type: %i,\n"
-                  "Serial number: %i, IP address: %s, Port: %i" %
-                  (info[0], info[1], info[2],
-                   ljm.numberToIP(info[3]), info[4]))
+                          "Serial number: %i, IP address: %s, Port: %i" %
+                          (info[0], info[1], info[2],
+                           ljm.numberToIP(info[3]), info[4]))
 
         session.add_message("Labjack initialized")
 
@@ -277,10 +276,10 @@ class LabJackAgent:
             try:
                 scan_rate = ljm.eStreamStart(self.handle, scans_per_read, num_chs,
                                              ch_addrs, scan_rate_input)
-            except LJMError as e: #in case the stream is running
+            except LJMError as e:  # in case the stream is running
                 self.log.error(e)
                 self.log.error("Stopping previous stream and starting new one")
-                ljm.eStreamStop(self.handle) 
+                ljm.eStreamStop(self.handle)
                 scan_rate = ljm.eStreamStart(self.handle, scans_per_read, num_chs,
                                              ch_addrs, scan_rate_input)
             self.log.info(f"\nStream started with a scan rate of {scan_rate} Hz.")
@@ -366,6 +365,9 @@ def make_parser(parser=None):
 
 
 if __name__ == '__main__':
+    # Start logging
+    txaio.start_logging(level=os.environ.get("LOGLEVEL", "info"))
+
     site_parser = site_config.add_arguments()
     parser = make_parser(site_parser)
 


### PR DESCRIPTION
## Description
If the labjack is disconnected, the data stream will still be active. The previous version of this agent would then throw an error when the agent is restarted, since you can't start a stream if one is already running. The fix here is to check for this error, and if it occurs, stop the stream first. (A cleaner way would be to check if the stream is running, but I couldn't figure out how to do that).

## Motivation and Context
See the description. I noticed this error at UCSD when the ethernet from the labjack was disconnected while the agent was running.

## How Has This Been Tested?
I reproduced the error without the agent changes implemented, then confirmed that the changes stopped the stream and sucessfully started it again.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] Unless I am preparing a release, I have opened this PR onto the `develop` branch.
