### PR TITLE
Remove check_port test

### DIFF
--- a/socs/agent/smurf_recorder.py
+++ b/socs/agent/smurf_recorder.py
@@ -22,34 +22,6 @@ class FlowControl(Enum):
     CLEANSE = 3
 
 
-def check_port(addr):
-    """
-    This function checks if socket port is currently open on a host. This can
-    be used to check if the smurf-streamer has created it's G3NetworkSender
-    object without attempting to create a G3Reader. This function is
-    non-blocking and should return immediately.
-
-    Parameters
-    ----------
-    addr: str
-        Address describing the port to connect to. For example:
-        ``tcp://localhost:4532``
-    """
-    host, port = addr.split('//')[-1].split(':')
-    port = int(port)
-
-    s = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
-    s.setblocking(True)
-    s.settimeout(0.0)
-    try:
-        s.connect((host, port))
-        return True
-    except socket.error:
-        return False
-    finally:
-        s.close()
-
-
 def _create_dirname(start_time, data_dir, stream_id):
     """Create the file path for .g3 file output.
 
@@ -243,14 +215,13 @@ class FrameRecorder:
         """
         reader = None
 
-        if (check_port(self.address)):
-            try:
-                reader = core.G3Reader(self.address,
-                                       timeout=timeout)
-                self.log.debug("G3Reader connection to {addr} established!",
-                               addr=self.address)
-            except RuntimeError:
-                self.log.error("G3Reader could not connect.")
+        try:
+            reader = core.G3Reader(self.address,
+                                   timeout=timeout)
+            self.log.debug("G3Reader connection to {addr} established!",
+                           addr=self.address)
+        except RuntimeError:
+            self.log.error("G3Reader could not connect.")
 
         # Prevent rapid connection attempts
         if self.last_connection_time is not None:


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Removes the check-port test from the smurf-recorder

## Description
<!--- Describe your changes in detail -->
Removes the check-port test from the smurf-recorder

## Motivation and Context
Recently noticed that the check port option isn't consistently representing whether a G3Streamer is running on that port. I just noticed that it was failing this check, and not connecting to the G3Reader. I believe the difference from when I tested before is that we switched to connecting to the port on the smurf-server directly instead of using a tunnel, which may have changed the behavior of the check_port function.  Best to just take this check out and deal with the log_fatal messages before it causes more problems.

## How Has This Been Tested?
Tested on k2so

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] Unless I am preparing a release, I have opened this PR onto the `develop` branch.
