### PR TITLE
Remove mention of sisock data feed servers from 372 docs

### DIFF
--- a/docs/agents/bluefors_agent.rst
+++ b/docs/agents/bluefors_agent.rst
@@ -87,7 +87,6 @@ outline is:
 - Install ocs and socs
 - Configure your ocs-config file and perform the associated setup
 - Start the Bluefors agent and command it to acquire data via an OCS client
-- Create a sisock-data-feed-server container for live monitoring
 
 Configuration File Examples
 ---------------------------
@@ -111,7 +110,7 @@ Docker
 Example docker-compose configuration::
 
   ocs-bluefors:
-    image: grumpy.physics.yale.edu/ocs-bluefors-agent:latest
+    image: simonsobs/ocs-bluefors-agent:latest
     hostname: ocs-docker
     volumes:
       - ${OCS_CONFIG_DIR}:/config:ro

--- a/docs/agents/lakeshore240.rst
+++ b/docs/agents/lakeshore240.rst
@@ -66,10 +66,31 @@ configuration block that will automatically start data acquisition::
 Each device requires configuration under 'agent-instances'. See the OCS site
 configs documentation for more details.
 
-The following tasks are registered for the LS240 agent.
+Docker Configuration
+--------------------
 
-.. autoclass:: agents.lakeshore240.LS240_agent.LS240_Agent
-    :members: init_lakeshore_task, set_values, upload_cal_curve, acq, start_acq
+The Lakeshore 240 Agent can (and probably should) be configured to run in a
+Docker container. An example configuration is::
+
+  ocs-LSA24MA:
+    image: simonsobs/ocs-lakeshore240-agent:latest
+    devices:
+      - "/dev/LSA24MA:/dev/LSA24MA"
+    hostname: nuc-docker
+    volumes:
+      - ${OCS_CONFIG_DIR}:/config:ro
+    command:
+      - "--instance-id=LSA24MA"
+      - "--site-hub=ws://crossbar:8001/ws"
+      - "--site-http=http://crossbar:8001/call"
+
+The serial number will need to be updated in your configuration. The hostname
+should also match your configured host in your OCS configuration file. The
+site-hub and site-http need to point to your crossbar server, as described in
+the OCS documentation.
+
+Initial Setup
+-------------
 
 Out of the box, the Lakeshore 240 channels are not enabled or configured
 to correctly measure thermometers. To enable, you can use the ``set_values`` task
@@ -91,28 +112,9 @@ set channel 1 of a lakeshore module to read a diode::
     ls_client.set_values.start(channel=1, name="CHWP_01", **diode_params)
     ls_client.set_values.wait()
 
+Agent API
+---------
+The following tasks are registered for the LS240 agent.
 
-Docker Configuration
---------------------
-
-The Lakeshore 240 Agent can (and probably should) be configured to run in a
-Docker container. An example configuration is::
-
-  ocs-LSA24MA:
-    image: grumpy.physics.yale.edu/ocs-lakeshore240-agent:latest
-    depends_on:
-      - "crossbar"
-    devices:
-      - "/dev/LSA24MA:/dev/LSA24MA"
-    hostname: nuc-docker
-    volumes:
-      - ${OCS_CONFIG_DIR}:/config:ro
-    command:
-      - "--instance-id=LSA24MA"
-      - "--site-hub=ws://crossbar:8001/ws"
-      - "--site-http=http://crossbar:8001/call"
-
-The serial number will need to be updated in your configuration. The hostname
-should also match your configured host in your OCS configuration file. The
-site-hub and site-http need to point to your crossbar server, as described in
-the OCS documentation.
+.. autoclass:: agents.lakeshore240.LS240_agent.LS240_Agent
+    :members: init_lakeshore_task, set_values, upload_cal_curve, acq, start_acq

--- a/docs/agents/lakeshore372.rst
+++ b/docs/agents/lakeshore372.rst
@@ -54,23 +54,6 @@ example configuration is::
     system. In this example the crossbar server is running on localhost,
     ``127.0.0.1``, but on your network this may be different.
 
-To view the 372 temperatures data feed in the live monitor an accompanying
-data-feed server will need to be run. An example of this configuration is::
-
-  sisock-LSA22YE:
-    image: grumpy.physics.yale.edu/sisock-data-feed-server:latest
-    environment:
-        TARGET: LSA22YE # match to instance-id of agent to monitor, used for data feed subscription
-        NAME: 'LSA22YE' # will appear in sisock a front of field name
-        DESCRIPTION: "LS372 with two ROXes for calibration."
-        FEED: "temperatures"
-    logging:
-      options:
-        max-size: "20m"
-        max-file: "10"
-
-For additional configuration see the sisock data-feed-server documentation.
-
 .. note::
     The serial numbers here will need to be updated for your device.
 

--- a/docs/agents/lakeshore372.rst
+++ b/docs/agents/lakeshore372.rst
@@ -38,7 +38,7 @@ The Lakeshore 372 Agent should be configured to run in a Docker container. An
 example configuration is::
 
   ocs-LSA22YE:
-    image: grumpy.physics.yale.edu/ocs-lakeshore372-agent:latest
+    image: simonsobs/ocs-lakeshore372-agent:latest
     hostname: ocs-docker
     network_mode: "host"
     volumes:

--- a/docs/agents/pysmurf/pysmurf-archiver.rst
+++ b/docs/agents/pysmurf/pysmurf-archiver.rst
@@ -58,8 +58,6 @@ The docker-compose entry is similar to that of the pysmurf-monitor. For example:
             - ${OCS_CONFIG_DIR}:/config
             - /home/ocs:/home/ocs
             - /data:/data
-        depends_on:
-            - "crossbar"
 
 Archived Path
 --------------

--- a/docs/agents/pysmurf/pysmurf-controller.rst
+++ b/docs/agents/pysmurf/pysmurf-controller.rst
@@ -85,8 +85,6 @@ named ``ocs-pysmurf-monitor`` might look something like::
             - ${OCS_CONFIG_DIR}:/config
             - /data:/data
             - /path/to/dev/pysmurf/:/usr/local/src/pysmurf
-        depends_on:
-            - "crossbar"
 
 
 

--- a/docs/agents/pysmurf/pysmurf-monitor.rst
+++ b/docs/agents/pysmurf/pysmurf-monitor.rst
@@ -138,8 +138,6 @@ An example docker-compose entry might look like::
         volumes:
             - ${OCS_CONFIG_DIR}:/config
             - /data:/data
-        depends_on:
-            - "crossbar"
 
 Where DB_HOST, DB, DB_USER, and DB_PW are set in the ``.env`` file in the same dir as
 the docker-compose file.

--- a/docs/simulators/ls240_simulator.rst
+++ b/docs/simulators/ls240_simulator.rst
@@ -48,9 +48,9 @@ docker-compose service configuration is shown here::
     image: simonsobs/ocs-lakeshore240-simulator:latest
     hostname: ocs-docker
 
-It is helpful to have other live monitor components such as Grafana and either
-the sisock quick look components or an InfluxDB container for quickly
-visualizing whether the 240 Agent is getting data from the simulator.
+It is helpful to have other live monitor components such as Grafana and an
+InfluxDB container for quickly visualizing whether the 240 Agent is getting
+data from the simulator.
 
 Running Outside of Docker
 -------------------------


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
This expanded a bit from my initial goal of updating the 372 Agent docs. There were several aspects of the 372 docs that were similar in other Agents that I thought needed some updating. These updates are:
* Remove mention of sisock -- i.e. updates from "sisock-crossbar" to "crossbar" where needed, mention of sisock-data-node-servers
* Removal of `depends_on: crossbar` from example docker-compose configurations. We made the recommendation to separate crossbar from main compose files, so this'll not work anymore. It never really did the thing we wanted, which is wait for crossbar to come up before starting the agents that depend on it. But it's also not really a problem any more, ever since https://github.com/simonsobs/ocs/pull/180.
* Update image URLs from the old docker registry we hosted to the ones now hosted on Dockerhub.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Update docs that were recently being referenced.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] Unless I am preparing a release, I have opened this PR onto the `develop` branch.
