### PR TITLE
Add stream-id argument to smurf stream simulator agent

### DIFF
--- a/agents/smurf_stream_simulator/smurf_stream_simulator.py
+++ b/agents/smurf_stream_simulator/smurf_stream_simulator.py
@@ -220,7 +220,6 @@ class SmurfStreamSimulator:
             f['sostream_id'] = self.stream_id
             self.writer.Process(f)
 
-
     def _send_end_flowcontrol_frame(self):
         """Send END flowcontrol frame."""
         if self.writer is not None:
@@ -347,6 +346,8 @@ def make_parser(parser=None):
                         help="Port to listen on.")
     pgroup.add_argument("--num-chans", default=528,
                         help="Number of detector channels to simulate.")
+    pgroup.add_argument("--stream-id", default="stream_sim",
+                        help="Stream ID for the simulator.")
 
     return parser
 
@@ -364,7 +365,8 @@ if __name__ == '__main__':
     agent, runner = ocs_agent.init_site_agent(args)
     sim = SmurfStreamSimulator(agent, target_host=args.target_host,
                                port=int(args.port),
-                               num_chans=int(args.num_chans))
+                               num_chans=int(args.num_chans),
+                               stream_id=args.stream_id)
 
     agent.register_process('stream', sim.start_background_streamer,
                            sim.stop_background_streamer,

--- a/docs/simulators/smurf_stream_simulator.rst
+++ b/docs/simulators/smurf_stream_simulator.rst
@@ -32,7 +32,8 @@ using all of the available arguments::
        'instance-id': 'smurf-stream',
        'arguments': [['--auto-start', True],
                      ['--port', '50000'],
-                     ['--num_chans', '528']]},
+                     ['--num_chans', '528'],
+                     ['--stream-id', 'stream_sim']]},
 
 Docker
 ``````
@@ -42,6 +43,8 @@ docker-compose service configuration is shown here::
   smurf-stream-sim:
     image: simonsobs/smurf-stream-sim
     hostname: ocs-docker
+    ports:
+      - "50000:50000"
     volumes:
       - ${OCS_CONFIG_DIR}:/config:ro
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Add a `--stream-id` argument to the SMuRF Stream Simulator Agent so we can set it in the site config file.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Needed this for scale testing with many different stream simulators running at once so I could output data to different directories, as those are set by the stream-id.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
This is being used currently in some scale testing currently with 14 simulators running on the same machine.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] Unless I am preparing a release, I have opened this PR onto the `develop` branch.
