### PR TITLE
CHWP Agent Feedback

### DIFF
--- a/agents/chwp/Dockerfile
+++ b/agents/chwp/Dockerfile
@@ -1,5 +1,4 @@
-# comment here...
-# 
+# CHWP Agent
 
 # Use socs base image
 FROM socs:latest
@@ -11,10 +10,10 @@ WORKDIR /app/socs/agents/chwp/
 COPY . .
 
 # Run registry on container startup
-ENTRYPOINT ["python3", "-u", "hwpbbb_agent.py"]
+ENTRYPOINT ["dumb-init", "python3", "-u", "hwpbbb_agent.py"]
 
 # Sensible default arguments
-CMD ["--site-hub=ws://sisock-crossbar:8001/ws", \
-     "--site-http=http://sisock-crossbar:8001/call"]
+CMD ["--site-hub=ws://crossbar:8001/ws", \
+     "--site-http=http://crossbar:8001/call"]
 
 EXPOSE 8080/udp

--- a/agents/chwp/hwpbbb_agent.py
+++ b/agents/chwp/hwpbbb_agent.py
@@ -59,8 +59,10 @@ import select
 import numpy as np
 
 ## Required by OCS
-from ocs import ocs_agent, site_config
-from ocs.ocs_twisted import TimeoutLock
+ON_RTD = os.environ.get('READTHEDOCS') == 'True'
+if not ON_RTD:
+    from ocs import ocs_agent, site_config
+    from ocs.ocs_twisted import TimeoutLock
 
 ## These three values (COUNTER_INFO_LENGTH, COUNTER_PACKET_SIZE, IRIG_PACKET_SIZE)
 ## should be consistent with the software on beaglebone.

--- a/agents/chwp/hwpbbb_agent.py
+++ b/agents/chwp/hwpbbb_agent.py
@@ -427,7 +427,7 @@ class EncoderParser:
            [4] binary encoding of the hour data
            [5-11] additional IRIG information which we do mot use
            [12-21] synchronization pulse clock counts
-	   [22-31] overflow count at each synchronization pulse
+           [22-31] overflow count at each synchronization pulse
 
            irig_queue structure:
            irig_queue = [Packet clock count,
@@ -442,7 +442,7 @@ class EncoderParser:
         unpacked_data = struct.unpack('<L' + 'L' + 'L'*10 + 'L'*10 + 'L'*10, data)
 
         # Start of the packet clock count
-	#overflow.append(unpacked_data[1])
+        #overflow.append(unpacked_data[1])
         #print "overflow: ", overflow
 
         rising_edge_time = unpacked_data[0] + (unpacked_data[1] << 32)

--- a/docs/agents/chwp_encoder.rst
+++ b/docs/agents/chwp_encoder.rst
@@ -6,14 +6,14 @@
 CHWP Encoder BBB Agent
 ======================
 
-The optical encoder signals of he CHWP are captured by Beaglebone Black (BBB)
-boards with the IRIG-B timng reference.
+The optical encoder signals of the CHWP are captured by Beaglebone Black (BBB)
+boards with the IRIG-B timing reference.
 This agent receives and decodes UDP packets from BBB and publishes the data
 feeds.
 
 Configuration File Examples
 ---------------------------
-Below are useful configurations examples for the relevent OCS files and for 
+Below are useful configurations examples for the relevant OCS files and for 
 running the agent in a docker container.
 
 ocs-config
@@ -42,7 +42,7 @@ the setting on the BBB side.
 Docker
 ``````
 The CHWP BBB agent can be run via a Docker container. The following is an 
-example of what to insest into your institution's docker-compose file.
+example of what to insert into your institution's docker-compose file.
 This again is an example to run multiple agents::
 
   ocs-hwpbbb-agent-HBA0:

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -37,6 +37,7 @@ Simulator Reference  Simulators are used to mock software and hardware
     :maxdepth: 2
 
     agents/bluefors_agent
+    agents/chwp_encoder
     agents/cryomech_cpa
     agents/labjack
     agents/lakeshore240


### PR DESCRIPTION
Here are some small suggestions to latest chwp agent PR (https://github.com/simonsobs/socs/pull/80). To maybe save a back and fourth on changes I just made updates as I re-reviewed the Agent. A quick summary:
* Found some small typos in the Sphinx docs, fixed those and added the new page to the index so it'll appear in the sidebar.
* Protected the ocs import for the automated documentation build (else that system fails to build the docs and publish to the web)
* Caught two tabs in the agent file, replaced them with spaces
* Added "dumb-init" an init system we started using recently within the Docker containers. Also removed "sisock-" from the default commands, as that's been removed from the OCS system.
* Added the [recommended logging system](https://ocs.readthedocs.io/en/develop/developer/agents.html#logging), and updated most print statements to use it (I didn't touch the print in `pretty_print_irig_info`, just out of concern of messing up the formatting). This'll making distinguishing errors a bit nicer in the [logging system](https://ocs.readthedocs.io/en/develop/user/logging.html) that'll be setup at the site (and that you might have in the lab.)