### PR TITLE
Handle LS372 ConnectionError if device powered off at Agent startup

### DIFF
--- a/agents/lakeshore372/LS372_agent.py
+++ b/agents/lakeshore372/LS372_agent.py
@@ -166,7 +166,11 @@ class LS372_Agent:
                 except ConnectionError:
                     self.log.error("Could not connect to the LS372. Exiting.")
                     reactor.callFromThread(reactor.stop)
-                    return False, 'Lakeshore initialized failed'
+                    return False, 'Lakeshore initialization failed'
+                except Exception as e:
+                    self.log.error(f"Unhandled exception encountered: {e}")
+                    reactor.callFromThread(reactor.stop)
+                    return False, 'Lakeshore initialization failed'
 
                 print("Initialized Lakeshore module: {!s}".format(self.module))
                 session.add_message("Lakeshore initilized with ID: %s"%self.module.id)

--- a/agents/lakeshore372/LS372_agent.py
+++ b/agents/lakeshore372/LS372_agent.py
@@ -6,6 +6,7 @@ import numpy as np
 import txaio
 import threading
 from contextlib import contextmanager
+from twisted.internet import reactor
 
 from socs.Lakeshore.Lakeshore372 import LS372
 
@@ -160,7 +161,13 @@ class LS372_Agent:
                 session.add_message("No initialization since faking data")
                 self.thermometers = ["thermA", "thermB"]
             else:
-                self.module = LS372(self.ip)
+                try:
+                    self.module = LS372(self.ip)
+                except ConnectionError:
+                    self.log.error("Could not connect to the LS372. Exiting.")
+                    reactor.callFromThread(reactor.stop)
+                    return False, 'Lakeshore initialized failed'
+
                 print("Initialized Lakeshore module: {!s}".format(self.module))
                 session.add_message("Lakeshore initilized with ID: %s"%self.module.id)
 

--- a/socs/Lakeshore/Lakeshore372.py
+++ b/socs/Lakeshore/Lakeshore372.py
@@ -171,6 +171,36 @@ heater_display_key = { '1': 'current',
                 '2': 'power'}
 heater_display_lock = {v: k for k,v in heater_display_key.items()}
 
+def _establish_socket_connection(ip, timeout, port=7777):
+    """Establish socket connection to the LS372.
+
+    Parameters
+    ----------
+    ip : str
+        IP address of the LS372
+    timeout : int
+        timeout period for the socket connection in seconds
+    port : int
+        Port for the connection, defaults to the default LS372 port of 7777
+
+    Returns
+    -------
+    socket.socket
+        The socket object with open connection to the 372
+
+    """
+    com = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+    try:
+        com.connect((ip, port))
+    except OSError as e:
+        if 'No route to host' in e.strerror:
+            raise ConnectionError("Cannot connect to LS372")
+        else:
+            raise e
+    com.settimeout(timeout)
+
+    return com
+
 
 class LS372:
     """
@@ -181,9 +211,7 @@ class LS372:
                    index 0 corresponding to the control channel, 'A'
     """
     def __init__(self, ip, timeout=10, num_channels=16):
-        self.com = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
-        self.com.connect((ip, 7777))
-        self.com.settimeout(timeout)
+        self.com = _establish_socket_connection(ip, timeout)
         self.num_channels = num_channels
 
         self.id = self.get_id()


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
This introduces some error handling for connection errors to the 372 on Agent startup. When establishing the connection in the init task we watch for an OSError, make sure it relates to a ConnectionError and raise that for handling in the Agent.

Within the Agent we catch the ConnectionError and shutdown the reactor, exiting the Agent. 

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
fixes #164 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
This has been tested against a powered off LS372 at Yale.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] Unless I am preparing a release, I have opened this PR onto the `develop` branch.
