### PR TITLE
Add network_mode to docker-compose example in SCPI PSU Agent docs

### DIFF
--- a/docs/agents/scpi_psu.rst
+++ b/docs/agents/scpi_psu.rst
@@ -49,6 +49,7 @@ An example docker-compose service configuration is shown here::
   ocs-psuK:
     image: simonsobs/ocs-scpi-psu-agent:latest
     hostname: ocs-docker
+    network_mode: "host"
     volumes:
       - ${OCS_CONFIG_DIR}:/config:ro
     command:
@@ -93,3 +94,4 @@ Agent API
 
 .. autoclass:: agents.scpi_psu.scpi_psu_agent.ScpiPsuAgent
     :members: monitor_output, set_voltage, set_current, set_output
+


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
@zhuber21 found a missing config option in the SCPI PSU Agent docs. Copying them as is will likely result in connection issues. The Agent should be on the host network to properly see the PSU's IP.