### PR TITLE
bump sodetlib and remove ocs install

### DIFF
--- a/agents/pysmurf_controller/Dockerfile
+++ b/agents/pysmurf_controller/Dockerfile
@@ -1,23 +1,9 @@
-FROM simonsobs/sodetlib:v0.1.0
-
-# Set locale
-ENV LANG C.UTF-8
-
-# Installs Jupyter requirements
-RUN pip3 install jupyter
+FROM simonsobs/sodetlib:v0.2.0-23-g90fd9f2
 
 WORKDIR /app
 
-# Installs OCS requirements
-#COPY requirements.txt .
-#RUN pip3 install -r requirements.txt
-
-# OCS installation
-RUN git clone https://github.com/simonsobs/ocs.git \
-    && pip3 install -r ocs/requirements.txt \
-    && pip3 install -e ocs
-
 # SOCS installation
+RUN pip3 install cryptography==3.3.2
 RUN git clone https://github.com/simonsobs/socs.git \
     && pip3 install -r socs/requirements.txt \
     && pip3 install -e socs

--- a/agents/pysmurf_controller/Dockerfile
+++ b/agents/pysmurf_controller/Dockerfile
@@ -3,7 +3,6 @@ FROM simonsobs/sodetlib:v0.2.0-23-g90fd9f2
 WORKDIR /app
 
 # SOCS installation
-RUN pip3 install cryptography==3.3.2
 RUN git clone https://github.com/simonsobs/socs.git \
     && pip3 install -r socs/requirements.txt \
     && pip3 install -e socs


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Updates sodetlib version to most recent, and removes ocs install since that is now done in the sodetlib docker.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
Tested with ocs-pysmurf-controller and emulator on smurf-srv-so3.

