### PR TITLE
Bluefors inode handling

### DIFF
--- a/agents/bluefors/Dockerfile
+++ b/agents/bluefors/Dockerfile
@@ -14,4 +14,6 @@ COPY . .
 ENTRYPOINT ["dumb-init", "python3", "-u", "bluefors_log_tracker.py"]
 
 # Sensible default instance-id
-CMD ["--instance-id=bluefors"]
+CMD ["--instance-id=bluefors", \
+     "--site-hub=ws://crossbar:8001/ws", \
+     "--site-http=http://crossbar:8001/call"]

--- a/agents/bluefors/bluefors_log_tracker.py
+++ b/agents/bluefors/bluefors_log_tracker.py
@@ -399,7 +399,7 @@ class LogParser:
                 LOG.debug("Data: {d}", d=data)
                 # If the file was reopened due to an inode change we don't know
                 # if the last line is recent enough to be worth publishing. Check
-                if (time.time() - data['timestamp']) < stale_time*60:
+                if (time.time() - data['timestamp']) < int(stale_time)*60:
                     app_session.app.publish_to_feed('bluefors', data)
                 else:
                     LOG.warn("Not publishing stale data. Make sure your log " +

--- a/agents/bluefors/bluefors_log_tracker.py
+++ b/agents/bluefors/bluefors_log_tracker.py
@@ -415,7 +415,7 @@ class BlueforsAgent:
         self.agent.register_feed('bluefors',
                                  record=True,
                                  agg_params=agg_params,
-                                 buffer_time=1)
+                                 )
 
     def try_set_job(self, job_name):
         print(self.job, job_name)

--- a/agents/bluefors/bluefors_log_tracker.py
+++ b/agents/bluefors/bluefors_log_tracker.py
@@ -441,6 +441,9 @@ class BlueforsAgent:
         # Create file objects for all logs in today's directory
         self.log_tracker.open_all_logs()
 
+        # Setup the Parser object with tracking info
+        parser = LogParser(self.log_tracker)
+
         while True:
             with self.lock:
                 if self.job == '!acq':
@@ -455,9 +458,6 @@ class BlueforsAgent:
 
             # Ensure all the logs we want are open
             self.log_tracker.check_open_files()
-
-            # Pass tracking information to parser class
-            parser = LogParser(self.log_tracker)
 
             # Check for new lines and publish to feed
             parser.read_and_publish_logs(session)

--- a/agents/bluefors/bluefors_log_tracker.py
+++ b/agents/bluefors/bluefors_log_tracker.py
@@ -31,6 +31,16 @@ class LogTracker:
         log_dir : str
             Top level log directory
 
+        Attributes
+        ----------
+        log_dir : str
+            Top level log directory
+        date : datetime.date
+            Today's date. Used to determine the active log directory
+        file_objects : dict
+            A dictionary with filenames as keys, and open file objects as
+            values
+
         """
         self.log_dir = log_dir
         self.date = datetime.date.fromtimestamp(time.time())

--- a/agents/bluefors/bluefors_log_tracker.py
+++ b/agents/bluefors/bluefors_log_tracker.py
@@ -22,42 +22,42 @@ LOG = txaio.make_logger()
 
 
 class LogTracker:
-    def __init__(self, log_dir):
-        """Log Tracking helper class. Always tracks current date's logs.
+    """Log Tracking helper class. Always tracks current date's logs.
 
-        Parameters
-        ----------
-        log_dir : str
-            Top level log directory
+    Parameters
+    ----------
+    log_dir : str
+        Top level log directory
 
-        Attributes
-        ----------
-        log_dir : str
-            Top level log directory
-        date : datetime.date
-            Today's date. Used to determine the active log directory
-        file_objects : dict
-            A dictionary with filenames as keys, and another dict as the value.
-            Each of these sub-dictionaries has two keys, "file_object", and
-            "stat_results", with the open file object, and os.stat results as
-            values, respectively. For example::
+    Attributes
+    ----------
+    log_dir : str
+        Top level log directory
+    date : datetime.date
+        Today's date. Used to determine the active log directory
+    file_objects : dict
+        A dictionary with filenames as keys, and another dict as the value.
+        Each of these sub-dictionaries has two keys, "file_object", and
+        "stat_results", with the open file object, and os.stat results as
+        values, respectively. For example::
 
-                {'CH6 T 21-05-27.log':
-                    {'file_object': <_io.TextIOWrapper name='CH6 T 21-05-27.log' mode='r' encoding='UTF-8'>,
-                    'stat_results': os.stat_result(st_mode=33188,
-                                                   st_ino=1456748,
-                                                   st_dev=65024,
-                                                   st_nlink=1,
-                                                   st_uid=1000,
-                                                   st_gid=1000,
-                                                   st_size=11013,
-                                                   st_atime=1622135813,
-                                                   st_mtime=1622135813,
-                                                   st_ctime=1622135813)
-                    }
+            {'CH6 T 21-05-27.log':
+                {'file_object': <_io.TextIOWrapper name='CH6 T 21-05-27.log' mode='r' encoding='UTF-8'>,
+                'stat_results': os.stat_result(st_mode=33188,
+                                               st_ino=1456748,
+                                               st_dev=65024,
+                                               st_nlink=1,
+                                               st_uid=1000,
+                                               st_gid=1000,
+                                               st_size=11013,
+                                               st_atime=1622135813,
+                                               st_mtime=1622135813,
+                                               st_ctime=1622135813)
                 }
+            }
 
-        """
+    """
+    def __init__(self, log_dir):
         self.log_dir = log_dir
         self.date = datetime.date.fromtimestamp(time.time())
         self.file_objects = {}
@@ -146,30 +146,30 @@ class LogTracker:
 
 
 class LogParser:
+    """Log Parsing helper class.
+
+    Knows the internal formats for each log type. Used to loop over all
+    logs tracked by a LogTracker and publish their contents to an OCS Feed.
+
+    Parameters
+    ----------
+    tracker : LogTracker
+        log tracker that contains paths and file objects to parse
+    mode : str
+        Operating mode for the log tracker. Either "follow" or "poll",
+        defaulting to "follow". In "follow" mode the Tracker will read the
+        next line in the file if able to. In "poll" mode stats about the
+        file are used to determine if it was updated since the last read,
+        and if it has been the file is reopened to get the last line. This
+        is more I/O intensive, but is useful in certain configurations.
+    stale_time : int
+        Time in minutes which represents how fresh data in the bluefors
+        logs must be when we open them in order to publish to OCS. This
+        ensures we don't reopen a file much later than when they were
+        collected and publish "stale" data to the OCS live HK system.
+
+    """
     def __init__(self, tracker, mode="follow", stale_time=2):
-        """Log Parsing helper class.
-
-        Knows the internal formats for each log type. Used to loop over all
-        logs tracked by a LogTracker and publish their contents to an OCS Feed.
-
-        Parameters
-        ----------
-        tracker : LogTracker
-            log tracker that contains paths and file objects to parse
-        mode : str
-            Operating mode for the log tracker. Either "follow" or "poll",
-            defaulting to "follow". In "follow" mode the Tracker will read the
-            next line in the file if able to. In "poll" mode stats about the
-            file are used to determine if it was updated since the last read,
-            and if it has been the file is reopened to get the last line. This
-            is more I/O intensive, but is useful in certain configurations.
-        stale_time : int
-            Time in minutes which represents how fresh data in the bluefors
-            logs must be when we open them in order to publish to OCS. This
-            ensures we don't reopen a file much later than when they were
-            collected and publish "stale" data to the OCS live HK system.
-
-        """
         self.log_tracker = tracker
         self.patterns = {'channels': ['v11', 'v2', 'v1', 'turbo1', 'v12', 'v3', 'v10',
                                       'v14', 'v4', 'v13', 'compressor', 'v15', 'v5',

--- a/docs/agents/bluefors_agent.rst
+++ b/docs/agents/bluefors_agent.rst
@@ -118,6 +118,24 @@ Example docker-compose configuration::
     environment:
       LOGLEVEL: "info"
       FRAME_LENGTH: 600
+      STALE_TIME: 2
 
 Depending on how you are running your containers it might be easier to hard
 code the `OCS_CONFIG_DIR` environment variable.
+
+Environment Variables
+^^^^^^^^^^^^^^^^^^^^^
+There are several environment variables that can be used to configure the
+Bluefors Agent container.
+
++--------------+----------------------------------------------------------------+
+| Variable     | Description                                                    |
++==============+================================================================+
+| LOGLEVEL     | Verbosity of the logs.                                         |
++--------------+----------------------------------------------------------------+
+| FRAME_LENGTH | .g3 frame length.                                              |
++--------------+----------------------------------------------------------------+
+| STALE_TIME   | Time limit (in minutes)for newly opened files to be published  |
+|              | to feeds. Data older than this time when read will not be      |
+|              | published.                                                     |
++--------------+----------------------------------------------------------------+

--- a/docs/agents/bluefors_agent.rst
+++ b/docs/agents/bluefors_agent.rst
@@ -11,7 +11,7 @@ logs and passes them to the live monitor and to the OCS housekeeping data
 aggregator.
 
 The Bluefors software must run on a Windows OS. This may make integrating into
-OCS different than on a linux box (where we run in a Docker container)
+OCS different than on a Linux box (where we run in a Docker container)
 depending on your computer configuration.
 
 Running the Bluefors Agent in a Docker container is the recommended
@@ -32,6 +32,11 @@ you have, what kind of hardware you are running on, and whether or not you are
 running Windows virtually. As such, the setup can change significantly based on
 your configuration. We'll try to provide general guidelines for how to setup
 the system.
+
+.. note::
+    If you run Windows 10 in a virtualized environment you might run into
+    difficulty running Docker, depending on what virutalization software you are
+    using and what your hardware supports.
 
 Dependencies
 ````````````
@@ -63,20 +68,11 @@ tools, i.e. Docker for Windows, if possible) is:
 
 .. _`Docker Toolbox`: https://docs.docker.com/toolbox/toolbox_install_windows/
 
-Docker Container on Linux
--------------------------
-If you are running your Windows 10 installation in a virtualized environment
-then you may have difficulty running Docker, depending on what virtualization
-software you are using and what type of CPU you have. In this case we suggest
-you log to directory that is shared with the host and run the bluefors Agent
-docker container on the Linux host. The configuration should be similar to that
-outlined above, but with different paths.
-
 Windows Subsystem for Linux
----------------------------
+```````````````````````````
 Windows 10 has a feature called Windows Subsystem for Linux, which allows you
 to run Linux CLI tools in Windows. This can be used much like you would if you
-were to configure a linux host to run an OCS Agent. While we recommend running
+were to configure a Linux host to run an OCS Agent. While we recommend running
 OCS Agents in Docker containers, this configuration is still possible.
 
 You should refer to the OCS documentation for how to install, but the general
@@ -87,6 +83,22 @@ outline is:
 - Install ocs and socs
 - Configure your ocs-config file and perform the associated setup
 - Start the Bluefors agent and command it to acquire data via an OCS client
+
+Docker Container on Linux
+-------------------------
+In some situations it might be better to run the Agent on Linux. This might be
+because you run Windows within a virtual environment and write the logs to a
+shared filesystem, or if Docker for Windows is difficult to install for
+whatever reason. In this later case, if you sync your logs to a Linux system
+regularly, i.e. at roughly the rate they are written, you can run the Agent on
+that Linux system (or one that also has access to that filesystem.)
+
+In this setup, depending on the syncing mechanism the Agent might need to
+reopen the file regularly. It will grab the latest reading from the logs to
+publish. Since it's possible that this could be quite old in some scenarios the
+timestamp is now checked before publishing. It can be at most ``STALE_TIME``
+minutes old. This defaults to two minutes, but can be set with the
+``STALE_TIME`` environment variable.
 
 Configuration File Examples
 ---------------------------

--- a/docs/agents/bluefors_agent.rst
+++ b/docs/agents/bluefors_agent.rst
@@ -131,6 +131,7 @@ Example docker-compose configuration::
       LOGLEVEL: "info"
       FRAME_LENGTH: 600
       STALE_TIME: 2
+      MODE: "follow"
 
 Depending on how you are running your containers it might be easier to hard
 code the `OCS_CONFIG_DIR` environment variable.
@@ -147,7 +148,30 @@ Bluefors Agent container.
 +--------------+----------------------------------------------------------------+
 | FRAME_LENGTH | .g3 frame length.                                              |
 +--------------+----------------------------------------------------------------+
-| STALE_TIME   | Time limit (in minutes)for newly opened files to be published  |
+| MODE         | File tracking mode, either "follow" or "poll", defaulting to   |
+|              | "poll". In "follow" mode the Tracker will read the next line   |
+|              | in the file if able to. In "poll" mode stats about the file    |
+|              | are used to determine if it was updated since the last read,   |
+|              | and if it has been the file is reopened to get the last line.  |
+|              | This is more I/O intensive, but is useful in certain           |
+|              | configurations.                                                |
++--------------+----------------------------------------------------------------+
+| STALE_TIME   | Time limit (in minutes) for newly opened files to be published |
 |              | to feeds. Data older than this time when read will not be      |
 |              | published.                                                     |
 +--------------+----------------------------------------------------------------+
+
+Agent API
+---------
+
+.. autoclass:: agents.bluefors.bluefors_log_tracker.BlueforsAgent
+    :members:
+
+Supporting API
+--------------
+
+.. autoclass:: agents.bluefors.bluefors_log_tracker.LogTracker
+    :members:
+
+.. autoclass:: agents.bluefors.bluefors_log_tracker.LogParser
+    :members:


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Update the Bluefors Agent to handle a change in inode of logfiles.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
The Bluefors Agent was originally built to run on Docker for Windows. This was because at the time I ran into issues running on Linux and syncing the logs continuously when it came to keeping track of the active log files. This was dependent on the configuration a bit. The Bluefors software writes to simple .csv files on Windows, and I was using a tool called Syncthing to copy them as they were updated to a Linux box. The Linux box was running the Agent, which would keep files open and continously try to `readline()`. On copy the inode changed, and Python lost track of the file. It worked if you followed the files directly on Windows though, so we ended up with the Docker on Windows solution people currently run.

Docker on Windows has been difficult to install at some institutions. This patch adds monitoring of the file inode to the Agent. This should allow the Agent to be run on Linux, and users can then sync the files regularly from Windows for reading (in any of the various ways that you could, assuming you do so at roughly the rate they're written.) If the inode changes (which it will if you have a setup similar to the above), then the Agent will recognize that and reopen the file to grab the last line. There are some protections in place to make sure we're looking at recent data and not something that's stale.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
It's been tested with a Bluefors log simulator that I wrote, both normally (writing and reading directly to the same files) and with an rsync in between -- where I'd write the logs, and rsync them to the location the Agent is monitoring (changing the inode). It works in both situations. I will have Cornell test a development image a bit as well.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] Unless I am preparing a release, I have opened this PR onto the `develop` branch.
