### PR TITLE
Adds filter and downsample to labjack agent

### DIFF
--- a/socs/signal_processing.py
+++ b/socs/signal_processing.py
@@ -1,4 +1,5 @@
 from scipy import signal
+import numpy as np
 
 class FIRFilter:
     """

--- a/socs/signal_processing.py
+++ b/socs/signal_processing.py
@@ -1,0 +1,37 @@
+from scipy import signal
+
+class FIRFilter:
+    """
+    Finite Impact Respone filter that can quickly filter n-dimensional data.
+    This class internally keeps track of the filter delays so that long
+    timestreams can be filtered in chunks without ringing and edge effects.
+    """
+    def __init__(self, b, a, nchans):
+        self.b = b
+        self.a = a
+        self.z = np.zeros((nchans, len(b)-1))
+
+    def lfilt(self, data, in_place=True):
+        n = len(data)
+        if in_place:
+            data[:, :], self.z[:n] = signal.lfilter(
+                self.b, self.a, data, axis=1, zi=self.z[:n])
+        else:
+            _data, self.z[:n] = signal.lfilter(
+                self.b, self.a, data, axis=1, zi=self.z[:n])
+            return _data
+
+    @classmethod
+    def butter_highpass(cls, cutoff, fs, order=5, nchans=1):
+        nyq = 0.5 * fs
+        normal_cutoff = cutoff / nyq
+        b, a = signal.butter(order, normal_cutoff, btype='high', analog=False)
+        return cls(b, a, nchans)
+
+    @classmethod
+    def butter_lowpass(cls, cutoff, fs, order=5, nchans=1):
+        nyq = 0.5 * fs
+        normal_cutoff = cutoff / nyq
+        b, a = signal.butter(order, normal_cutoff, btype='low', analog=False)
+        return cls(b, a, nchans)
+


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
This adds the ability to filter and downsample labjack data before writing to disk. 

## Description
<!--- Describe your changes in detail -->
This adds  a signal processing module with a FIR Filter (used by both this agent and the magpie agent), and a few extra parameters to the labjack agent to enable filtering and downsampling before data is written to disk.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
This is mostly to eliminate aliasing in buttkicker accelerometer tests we've been doing on the SAT and LAT. This will allow us to take data at a much higher sample rate, then apply an anti-aliasing filter in software and downsample so that we are writing data at a semi-reasonable cadence to disk. The data rates we're thinking about is raw sampling rates of about 5-10 kHz (for three channels) being filtered then downsampled to ~400 Hz.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
Will test this on the SAT this week.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] Unless I am preparing a release, I have opened this PR onto the `develop` branch.
