### PR TITLE
Create example Agent unit tests

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,5 +1,7 @@
 [run]
-source = socs
+source =
+    socs
+    agents/
 
 omit =
   # omit versioneer

--- a/.coveragerc
+++ b/.coveragerc
@@ -9,5 +9,5 @@ omit =
 
 [paths]
 source =
-  socs/
-  /app/socs/socs/
+  ./
+  /app/socs/

--- a/.github/workflows/develop.yml
+++ b/.github/workflows/develop.yml
@@ -25,7 +25,7 @@ jobs:
 
     - name: Test with pytest within a docker container
       run: |
-        docker run -v $PWD:/coverage --rm socs sh -c "COVERAGE_FILE=/coverage/.coverage.docker python3 -m pytest -p no:wampy --cov /app/socs/socs/ ./tests/"
+        docker run -v $PWD:/coverage --rm socs sh -c "COVERAGE_FILE=/coverage/.coverage.docker python3 -m pytest --cov --cov-config=/app/socs/.coveragerc /app/socs/socs/ ./tests/"
 
     - name: Report test coverage
       env:

--- a/.github/workflows/official-docker-images.yml
+++ b/.github/workflows/official-docker-images.yml
@@ -26,7 +26,7 @@ jobs:
     # Test (already been run by pytest workflow, but they don't take long...)
     - name: Test with pytest wtihin a docker container
       run: |
-        docker run -v $PWD:/coverage --rm socs sh -c "COVERAGE_FILE=/coverage/.coverage.docker python3 -m pytest -p no:wampy --cov /app/socs/socs/ ./tests/"
+        docker run -v $PWD:/coverage --rm socs sh -c "COVERAGE_FILE=/coverage/.coverage.docker python3 -m pytest --cov --cov-config=/app/socs/.coveragerc /app/socs/socs/ ./tests/"
 
     - name: Test documentation build
       run: |

--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -22,7 +22,7 @@ jobs:
 
     - name: Test with pytest wtihin a docker container
       run: |
-        docker run -v $PWD:/coverage --rm socs sh -c "COVERAGE_FILE=/coverage/.coverage.docker python3 -m pytest -p no:wampy --cov /app/socs/socs/ ./tests/"
+        docker run -v $PWD:/coverage --rm socs sh -c "COVERAGE_FILE=/coverage/.coverage.docker python3 -m pytest --cov --cov-config=/app/socs/.coveragerc /app/socs/socs/ ./tests/"
 
     - name: Report test coverage
       env:

--- a/README.rst
+++ b/README.rst
@@ -10,8 +10,8 @@ SOCS - Simons Observatory Control System
     :target: https://socs.readthedocs.io/en/develop/?badge=develop
     :alt: Documentation Status
 
-.. image:: https://coveralls.io/repos/github/simonsobs/socs/badge.svg?branch=travis
-    :target: https://coveralls.io/github/simonsobs/socs?branch=travis
+.. image:: https://coveralls.io/repos/github/simonsobs/socs/badge.svg?branch=develop
+    :target: https://coveralls.io/github/simonsobs/socs?branch=develop
 
 .. image:: https://img.shields.io/badge/dockerhub-latest-blue
     :target: https://hub.docker.com/r/simonsobs/ocs/tags

--- a/agents/lakeshore372/LS372_agent.py
+++ b/agents/lakeshore372/LS372_agent.py
@@ -415,6 +415,7 @@ class LS372_Agent:
                 heater = self.module.still_heater
 
             current_range = heater.get_heater_range()
+            self.log.debug(f"Current heater range: {current_range}")
 
             if params['range'] == current_range:
                 print("Current heater range matches commanded value. Proceeding unchanged.")

--- a/agents/lakeshore372/LS372_agent.py
+++ b/agents/lakeshore372/LS372_agent.py
@@ -375,6 +375,9 @@ class LS372_Agent:
 
                     session.app.publish_to_feed('temperatures', htr_data)
 
+                if params['run_once']:
+                    break
+
         return True, 'Acquisition exited cleanly.'
 
     def stop_acq(self, session, params=None):

--- a/tests/agents/test_bluefors_agent.py
+++ b/tests/agents/test_bluefors_agent.py
@@ -1,0 +1,10 @@
+import sys
+sys.path.insert(0, './agents/bluefors/')
+from bluefors_log_tracker import BlueforsAgent
+
+from unittest import mock
+
+def test_bluefors():
+    mock_agent = mock.MagicMock()
+    agent = BlueforsAgent(mock_agent, './')
+    return agent

--- a/tests/agents/test_ls372_agent.py
+++ b/tests/agents/test_ls372_agent.py
@@ -29,15 +29,16 @@ def mock_failed_connection():
 
 
 @pytest.fixture
-def mock_agent():
+def agent():
     """Test fixture to setup a mocked OCSAgent."""
     mock_agent = mock.MagicMock()
     log = txaio.make_logger()
     txaio.start_logging(level='debug')
     mock_agent.log = log
     log.info('Initialized mock OCSAgent')
+    agent = LS372_Agent(mock_agent, 'mock372', '127.0.0.1')
 
-    return mock_agent
+    return agent
 
 
 # Mock responses from the 372
@@ -89,13 +90,11 @@ def mock_372_msg():
 # Tests
 @mock.patch('socs.Lakeshore.Lakeshore372._establish_socket_connection', mock_connection())
 @mock.patch('socs.Lakeshore.Lakeshore372.LS372.msg', mock_372_msg())
-def test_ls372_init_lakeshore_task(mock_agent):
+def test_ls372_init_lakeshore_task(agent):
     """Run init_lakeshore_task, mocking a connection and the 372 messaging.
     This should be as if the initialization worked without issue.
 
     """
-    agent = LS372_Agent(mock_agent, 'mock372', '127.0.0.1')
-
     mock_app = mock.MagicMock()
     session = OpSession(1, 'init_lakeshore', app=mock_app)
     res = agent.init_lakeshore_task(session, None)
@@ -109,12 +108,10 @@ def test_ls372_init_lakeshore_task(mock_agent):
 
 @mock.patch('socs.Lakeshore.Lakeshore372._establish_socket_connection', mock_connection())
 @mock.patch('socs.Lakeshore.Lakeshore372.LS372.msg', mock_372_msg())
-def test_ls372_init_lakeshore_task_already_initialized(mock_agent):
+def test_ls372_init_lakeshore_task_already_initialized(agent):
     """Initializing an already initialized LS372_Agent should just return True.
 
     """
-    agent = LS372_Agent(mock_agent, 'mock372', '127.0.0.1')
-
     mock_app = mock.MagicMock()
     session = OpSession(1, 'init_lakeshore', app=mock_app)
     agent.init_lakeshore_task(session, None)
@@ -126,13 +123,11 @@ def test_ls372_init_lakeshore_task_already_initialized(mock_agent):
 # If we don't patch the reactor out, it'll mess up pytest when stop is called
 @mock.patch('LS372_agent.reactor', mock.MagicMock())
 @mock.patch('socs.Lakeshore.Lakeshore372.LS372.msg', mock_372_msg())
-def test_ls372_init_lakeshore_task_failed_connection(mock_agent):
+def test_ls372_init_lakeshore_task_failed_connection(agent):
     """Leaving off the connection Mock, if the connection fails the init task
     should fail and return False.
 
     """
-    agent = LS372_Agent(mock_agent, 'mock372', '127.0.0.1')
-
     mock_app = mock.MagicMock()
     session = OpSession(1, 'init_lakeshore', app=mock_app)
     res = agent.init_lakeshore_task(session, None)
@@ -143,13 +138,11 @@ def test_ls372_init_lakeshore_task_failed_connection(mock_agent):
 @mock.patch('LS372_agent.reactor', mock.MagicMock())
 @mock.patch('socs.Lakeshore.Lakeshore372._establish_socket_connection', mock_failed_connection())
 @mock.patch('socs.Lakeshore.Lakeshore372.LS372.msg', mock_372_msg())
-def test_ls372_init_lakeshore_task_unhandled_error(mock_agent):
+def test_ls372_init_lakeshore_task_unhandled_error(agent):
     """If we cause an unhandled exception during connection init task should
     also fail and return False.
 
     """
-    agent = LS372_Agent(mock_agent, 'mock372', '127.0.0.1')
-
     mock_app = mock.MagicMock()
     session = OpSession(1, 'init_lakeshore', app=mock_app)
     res = agent.init_lakeshore_task(session, None)
@@ -158,13 +151,11 @@ def test_ls372_init_lakeshore_task_unhandled_error(mock_agent):
 
 @mock.patch('socs.Lakeshore.Lakeshore372._establish_socket_connection', mock_connection())
 @mock.patch('socs.Lakeshore.Lakeshore372.LS372.msg', mock_372_msg())
-def test_ls372_init_lakeshore_task_auto_acquire(mock_agent):
+def test_ls372_init_lakeshore_task_auto_acquire(agent):
     """If we initalize and pass the auto_acquire param, we should expect the
     Agent to make a start call for the acq process, given the params in acq_params.
 
     """
-    agent = LS372_Agent(mock_agent, 'mock372', '127.0.0.1')
-
     mock_app = mock.MagicMock()
     session = OpSession(1, 'init_lakeshore', app=mock_app)
     res = agent.init_lakeshore_task(session, {'auto_acquire': True, 'acq_params': {'test': 1}})
@@ -175,10 +166,8 @@ def test_ls372_init_lakeshore_task_auto_acquire(mock_agent):
 # enable_control_chan
 @mock.patch('socs.Lakeshore.Lakeshore372._establish_socket_connection', mock_connection())
 @mock.patch('socs.Lakeshore.Lakeshore372.LS372.msg', mock_372_msg())
-def test_ls372_enable_control_chan(mock_agent):
+def test_ls372_enable_control_chan(agent):
     """Normal operation of 'enable_control_chan' task."""
-    agent = LS372_Agent(mock_agent, 'mock372', '127.0.0.1')
-
     mock_app = mock.MagicMock()
     session = OpSession(1, 'enable_control_chan', app=mock_app)
 
@@ -192,10 +181,8 @@ def test_ls372_enable_control_chan(mock_agent):
 # disable_control_chan
 @mock.patch('socs.Lakeshore.Lakeshore372._establish_socket_connection', mock_connection())
 @mock.patch('socs.Lakeshore.Lakeshore372.LS372.msg', mock_372_msg())
-def test_ls372_disable_control_chan(mock_agent):
+def test_ls372_disable_control_chan(agent):
     """Normal operation of 'disable_control_chan' task."""
-    agent = LS372_Agent(mock_agent, 'mock372', '127.0.0.1')
-
     mock_app = mock.MagicMock()
     session = OpSession(1, 'disable_control_chan', app=mock_app)
 
@@ -209,10 +196,8 @@ def test_ls372_disable_control_chan(mock_agent):
 # acq
 @mock.patch('socs.Lakeshore.Lakeshore372._establish_socket_connection', mock_connection())
 @mock.patch('socs.Lakeshore.Lakeshore372.LS372.msg', mock_372_msg())
-def test_ls372_acq(mock_agent):
+def test_ls372_acq(agent):
     """Test running the 'acq' Process once."""
-    agent = LS372_Agent(mock_agent, 'mock372', '127.0.0.1')
-
     mock_app = mock.MagicMock()
     session = OpSession(1, 'acq', app=mock_app)
 
@@ -229,10 +214,8 @@ def test_ls372_acq(mock_agent):
 
 @mock.patch('socs.Lakeshore.Lakeshore372._establish_socket_connection', mock_connection())
 @mock.patch('socs.Lakeshore.Lakeshore372.LS372.msg', mock_372_msg())
-def test_ls372_acq_w_control_chan(mock_agent):
+def test_ls372_acq_w_control_chan(agent):
     """Test running the 'acq' Process once with control channel active."""
-    agent = LS372_Agent(mock_agent, 'mock372', '127.0.0.1')
-
     mock_app = mock.MagicMock()
     session = OpSession(1, 'acq', app=mock_app)
 
@@ -252,10 +235,8 @@ def test_ls372_acq_w_control_chan(mock_agent):
 
 @mock.patch('socs.Lakeshore.Lakeshore372._establish_socket_connection', mock_connection())
 @mock.patch('socs.Lakeshore.Lakeshore372.LS372.msg', mock_372_msg())
-def test_ls372_acq_w_sample_heater(mock_agent):
+def test_ls372_acq_w_sample_heater(agent):
     """Test running the 'acq' Process once with sample heater active."""
-    agent = LS372_Agent(mock_agent, 'mock372', '127.0.0.1')
-
     mock_app = mock.MagicMock()
     session = OpSession(1, 'acq', app=mock_app)
 
@@ -270,10 +251,8 @@ def test_ls372_acq_w_sample_heater(mock_agent):
 # stop_acq
 @mock.patch('socs.Lakeshore.Lakeshore372._establish_socket_connection', mock_connection())
 @mock.patch('socs.Lakeshore.Lakeshore372.LS372.msg', mock_372_msg())
-def test_ls372_stop_acq_not_running(mock_agent):
+def test_ls372_stop_acq_not_running(agent):
     """'stop_acq' should return False if acq Process isn't running."""
-    agent = LS372_Agent(mock_agent, 'mock372', '127.0.0.1')
-
     mock_app = mock.MagicMock()
     session = OpSession(1, 'stop_acq', app=mock_app)
 
@@ -286,10 +265,8 @@ def test_ls372_stop_acq_not_running(mock_agent):
 
 @mock.patch('socs.Lakeshore.Lakeshore372._establish_socket_connection', mock_connection())
 @mock.patch('socs.Lakeshore.Lakeshore372.LS372.msg', mock_372_msg())
-def test_ls372_stop_acq_while_running(mock_agent):
+def test_ls372_stop_acq_while_running(agent):
     """'stop_acq' should return True if acq Process is running."""
-    agent = LS372_Agent(mock_agent, 'mock372', '127.0.0.1')
-
     mock_app = mock.MagicMock()
     session = OpSession(1, 'stop_acq', app=mock_app)
 
@@ -307,13 +284,11 @@ def test_ls372_stop_acq_while_running(mock_agent):
 # set_heater_range
 @mock.patch('socs.Lakeshore.Lakeshore372._establish_socket_connection', mock_connection())
 @mock.patch('socs.Lakeshore.Lakeshore372.LS372.msg', mock_372_msg())
-def test_ls372_set_heater_range_sample_heater(mock_agent):
+def test_ls372_set_heater_range_sample_heater(agent):
     """Set sample heater to different range than currently set. Normal
     operation.
 
     """
-    agent = LS372_Agent(mock_agent, 'mock372', '127.0.0.1')
-
     mock_app = mock.MagicMock()
     session = OpSession(1, 'set_heater_range', app=mock_app)
 
@@ -327,13 +302,11 @@ def test_ls372_set_heater_range_sample_heater(mock_agent):
 
 @mock.patch('socs.Lakeshore.Lakeshore372._establish_socket_connection', mock_connection())
 @mock.patch('socs.Lakeshore.Lakeshore372.LS372.msg', mock_372_msg())
-def test_ls372_set_heater_range_still_heater(mock_agent):
+def test_ls372_set_heater_range_still_heater(agent):
     """Set still heater to different range than currently set. Normal
     operation.
 
     """
-    agent = LS372_Agent(mock_agent, 'mock372', '127.0.0.1')
-
     mock_app = mock.MagicMock()
     session = OpSession(1, 'set_heater_range', app=mock_app)
 
@@ -347,13 +320,11 @@ def test_ls372_set_heater_range_still_heater(mock_agent):
 
 @mock.patch('socs.Lakeshore.Lakeshore372._establish_socket_connection', mock_connection())
 @mock.patch('socs.Lakeshore.Lakeshore372.LS372.msg', mock_372_msg())
-def test_ls372_set_heater_range_identical_range(mock_agent):
+def test_ls372_set_heater_range_identical_range(agent):
     """Set heater to same range as currently set. Should not change range, just
     return True.
 
     """
-    agent = LS372_Agent(mock_agent, 'mock372', '127.0.0.1')
-
     mock_app = mock.MagicMock()
     session = OpSession(1, 'set_heater_range', app=mock_app)
 
@@ -373,10 +344,8 @@ def test_ls372_set_heater_range_identical_range(mock_agent):
 # set_excitation_mode
 @mock.patch('socs.Lakeshore.Lakeshore372._establish_socket_connection', mock_connection())
 @mock.patch('socs.Lakeshore.Lakeshore372.LS372.msg', mock_372_msg())
-def test_ls372_set_excitation_mode(mock_agent):
+def test_ls372_set_excitation_mode(agent):
     """Normal operation of 'set_excitation_mode' task."""
-    agent = LS372_Agent(mock_agent, 'mock372', '127.0.0.1')
-
     mock_app = mock.MagicMock()
     session = OpSession(1, 'set_excitation_mode', app=mock_app)
 
@@ -391,10 +360,8 @@ def test_ls372_set_excitation_mode(mock_agent):
 # set_excitation
 @mock.patch('socs.Lakeshore.Lakeshore372._establish_socket_connection', mock_connection())
 @mock.patch('socs.Lakeshore.Lakeshore372.LS372.msg', mock_372_msg())
-def test_ls372_set_excitation(mock_agent):
+def test_ls372_set_excitation(agent):
     """Normal operation of 'set_excitation' task."""
-    agent = LS372_Agent(mock_agent, 'mock372', '127.0.0.1')
-
     mock_app = mock.MagicMock()
     session = OpSession(1, 'set_excitation', app=mock_app)
 
@@ -408,10 +375,8 @@ def test_ls372_set_excitation(mock_agent):
 
 @mock.patch('socs.Lakeshore.Lakeshore372._establish_socket_connection', mock_connection())
 @mock.patch('socs.Lakeshore.Lakeshore372.LS372.msg', mock_372_msg())
-def test_ls372_set_excitation_already_set(mock_agent):
+def test_ls372_set_excitation_already_set(agent):
     """Setting to already set excitation value."""
-    agent = LS372_Agent(mock_agent, 'mock372', '127.0.0.1')
-
     mock_app = mock.MagicMock()
     session = OpSession(1, 'set_excitation', app=mock_app)
 
@@ -426,10 +391,8 @@ def test_ls372_set_excitation_already_set(mock_agent):
 # set_pid
 @mock.patch('socs.Lakeshore.Lakeshore372._establish_socket_connection', mock_connection())
 @mock.patch('socs.Lakeshore.Lakeshore372.LS372.msg', mock_372_msg())
-def test_ls372_set_pid(mock_agent):
+def test_ls372_set_pid(agent):
     """Normal operation of 'set_pid' task."""
-    agent = LS372_Agent(mock_agent, 'mock372', '127.0.0.1')
-
     mock_app = mock.MagicMock()
     session = OpSession(1, 'set_pid', app=mock_app)
 
@@ -444,10 +407,8 @@ def test_ls372_set_pid(mock_agent):
 # set_active_channel
 @mock.patch('socs.Lakeshore.Lakeshore372._establish_socket_connection', mock_connection())
 @mock.patch('socs.Lakeshore.Lakeshore372.LS372.msg', mock_372_msg())
-def test_ls372_set_active_channel(mock_agent):
+def test_ls372_set_active_channel(agent):
     """Normal operation of 'set_active_channel' task."""
-    agent = LS372_Agent(mock_agent, 'mock372', '127.0.0.1')
-
     mock_app = mock.MagicMock()
     session = OpSession(1, 'set_active_channel', app=mock_app)
 
@@ -462,10 +423,8 @@ def test_ls372_set_active_channel(mock_agent):
 # set_autoscan
 @mock.patch('socs.Lakeshore.Lakeshore372._establish_socket_connection', mock_connection())
 @mock.patch('socs.Lakeshore.Lakeshore372.LS372.msg', mock_372_msg())
-def test_ls372_set_autoscan_on(mock_agent):
+def test_ls372_set_autoscan_on(agent):
     """Normal operation of 'set_autoscan' task."""
-    agent = LS372_Agent(mock_agent, 'mock372', '127.0.0.1')
-
     mock_app = mock.MagicMock()
     session = OpSession(1, 'set_autoscan', app=mock_app)
 
@@ -479,10 +438,8 @@ def test_ls372_set_autoscan_on(mock_agent):
 
 @mock.patch('socs.Lakeshore.Lakeshore372._establish_socket_connection', mock_connection())
 @mock.patch('socs.Lakeshore.Lakeshore372.LS372.msg', mock_372_msg())
-def test_ls372_set_autoscan_off(mock_agent):
+def test_ls372_set_autoscan_off(agent):
     """Normal operation of 'set_autoscan' task."""
-    agent = LS372_Agent(mock_agent, 'mock372', '127.0.0.1')
-
     mock_app = mock.MagicMock()
     session = OpSession(1, 'set_autoscan', app=mock_app)
 
@@ -503,10 +460,8 @@ def test_ls372_set_autoscan_off(mock_agent):
 # set_output_mode
 @mock.patch('socs.Lakeshore.Lakeshore372._establish_socket_connection', mock_connection())
 @mock.patch('socs.Lakeshore.Lakeshore372.LS372.msg', mock_372_msg())
-def test_ls372_set_output_mode_still(mock_agent):
+def test_ls372_set_output_mode_still(agent):
     """Normal operation of 'set_output_mode' task for the still heater."""
-    agent = LS372_Agent(mock_agent, 'mock372', '127.0.0.1')
-
     mock_app = mock.MagicMock()
     session = OpSession(1, 'set_output_mode', app=mock_app)
 
@@ -520,10 +475,8 @@ def test_ls372_set_output_mode_still(mock_agent):
 
 @mock.patch('socs.Lakeshore.Lakeshore372._establish_socket_connection', mock_connection())
 @mock.patch('socs.Lakeshore.Lakeshore372.LS372.msg', mock_372_msg())
-def test_ls372_set_output_mode_sample(mock_agent):
+def test_ls372_set_output_mode_sample(agent):
     """Normal operation of 'set_output_mode' task for the sample heater."""
-    agent = LS372_Agent(mock_agent, 'mock372', '127.0.0.1')
-
     mock_app = mock.MagicMock()
     session = OpSession(1, 'set_output_mode', app=mock_app)
 
@@ -538,10 +491,8 @@ def test_ls372_set_output_mode_sample(mock_agent):
 # set_heater_output
 @mock.patch('socs.Lakeshore.Lakeshore372._establish_socket_connection', mock_connection())
 @mock.patch('socs.Lakeshore.Lakeshore372.LS372.msg', mock_372_msg())
-def test_ls372_set_heater_output_still(mock_agent):
+def test_ls372_set_heater_output_still(agent):
     """Normal operation of 'set_heater_output' task for the still heater."""
-    agent = LS372_Agent(mock_agent, 'mock372', '127.0.0.1')
-
     mock_app = mock.MagicMock()
     session = OpSession(1, 'set_heater_output', app=mock_app)
 
@@ -555,10 +506,8 @@ def test_ls372_set_heater_output_still(mock_agent):
 
 @mock.patch('socs.Lakeshore.Lakeshore372._establish_socket_connection', mock_connection())
 @mock.patch('socs.Lakeshore.Lakeshore372.LS372.msg', mock_372_msg())
-def test_ls372_set_heater_output_sample(mock_agent):
+def test_ls372_set_heater_output_sample(agent):
     """Normal operation of 'set_heater_output' task for the sample heater."""
-    agent = LS372_Agent(mock_agent, 'mock372', '127.0.0.1')
-
     mock_app = mock.MagicMock()
     session = OpSession(1, 'set_heater_output', app=mock_app)
 
@@ -573,10 +522,8 @@ def test_ls372_set_heater_output_sample(mock_agent):
 # set_still_output
 @mock.patch('socs.Lakeshore.Lakeshore372._establish_socket_connection', mock_connection())
 @mock.patch('socs.Lakeshore.Lakeshore372.LS372.msg', mock_372_msg())
-def test_ls372_set_still_output(mock_agent):
+def test_ls372_set_still_output(agent):
     """Normal operation of 'set_still_output' task."""
-    agent = LS372_Agent(mock_agent, 'mock372', '127.0.0.1')
-
     mock_app = mock.MagicMock()
     session = OpSession(1, 'set_still_output', app=mock_app)
 
@@ -591,10 +538,8 @@ def test_ls372_set_still_output(mock_agent):
 # get_still_output
 @mock.patch('socs.Lakeshore.Lakeshore372._establish_socket_connection', mock_connection())
 @mock.patch('socs.Lakeshore.Lakeshore372.LS372.msg', mock_372_msg())
-def test_ls372_get_still_output(mock_agent):
+def test_ls372_get_still_output(agent):
     """Normal operation of 'get_still_output' task."""
-    agent = LS372_Agent(mock_agent, 'mock372', '127.0.0.1')
-
     mock_app = mock.MagicMock()
     session = OpSession(1, 'get_still_output', app=mock_app)
 

--- a/tests/agents/test_ls372_agent.py
+++ b/tests/agents/test_ls372_agent.py
@@ -46,8 +46,6 @@ def mock_372_msg():
 
     values = {'*IDN?': 'LSCI,MODEL372,LSA23JD,1.3',
               'SCAN?': '01,1',
-              'SCAN 1,1': '',
-              'SCAN 1,0': '',
               'INSET? A': '0,010,003,00,1',
               'INNAME? A': 'Input A',
               'INTYPE? A': '1,04,0,15,0,2',
@@ -63,19 +61,9 @@ def mock_372_msg():
         values[f'INTYPE? {i}'] = '0,07,1,10,0,1'
         values[f'TLIMIT? {i}'] = '+0000'
 
-    # Channel settings
-    values.update({'INTYPE 1,1,07,1,10,0,1': '',
-                   'INTYPE 1,0,1,1,10,0,1': ''})
-
     # Heaters
     values.update({'RANGE? 0': '0',
-                   'RANGE 0 4': '',
                    'RANGE? 2': '1',
-                   'PID 0,40,2,0': '',
-                   'OUTMODE 2,0,16,1,0,0,001': '',
-                   'OUTMODE 0,0,6,1,0,0,001': '',
-                   'MOUT 2 50': '',
-                   'STILL 50': '',
                    'STILL?': '+10.60',
                    'HTR?': '+00.0005E+00'})
 
@@ -85,8 +73,12 @@ def mock_372_msg():
                    'KRDG? A': '+00.0000E-03',
                    'SRDG? A': '+000.000E+09'})
 
-    # TODO: get any non ? command to return ''
     def side_effect(arg):
+        # All commands just return ''
+        if '?' not in arg:
+            return ''
+
+        # Mocked example query responses
         return values[arg]
 
     mock_msg.side_effect = side_effect

--- a/tests/agents/test_ls372_agent.py
+++ b/tests/agents/test_ls372_agent.py
@@ -2,9 +2,85 @@ import sys
 sys.path.insert(0, './agents/lakeshore372/')
 from LS372_agent import LS372_Agent
 
+from ocs.ocs_agent import OpSession
+
+import pytest
 from unittest import mock
 
-def test_bluefors():
+import txaio
+txaio.use_twisted()
+
+# Mocks and fixtures
+#def mock_connection_send_recv():
+#    mock_con = mock.Mock()
+#    mock_con.send = lambda s: len(s.encode('utf-8'))
+#    mock_con.recv = mock.Mock()
+#
+#    values = {'*IDN?': 'LSCI,MODEL372,LSA23JD,1.3'}
+#    def side_effect(arg):
+#        return values[arg]
+#    mock_con.recv.side_effect = side_effect
+#
+#    return mock_con
+
+def mock_connection():
+    return mock.MagicMock()
+
+@pytest.fixture
+def mock_agent():
+    """Test fixture to setup a mocked OCSAgent."""
     mock_agent = mock.MagicMock()
+    log = txaio.make_logger()
+    txaio.start_logging(level='debug')
+    mock_agent.log = log
+    log.info('Initialized mock OCSAgent')
+
+    return mock_agent
+
+# Mock responses from the 372
+mock_msg = mock.Mock()
+
+values = {'*IDN?': 'LSCI,MODEL372,LSA23JD,1.3',
+          'SCAN?': '01,1',
+          'INSET? A': '0,010,003,00,1',
+          'INNAME? A': 'Input A',
+          'INTYPE? A': '1,04,0,15,0,2',
+          'TLIMIT? A': '+0000',
+          'OUTMODE? 0': '2,6,1,0,0,001',
+          'HTRSET? 0': '+120.000,8,+0000.00,1',
+          'OUTMODE? 2': '4,16,1,0,0,001',
+          'HTRSET? 2': '+120.000,8,+0000.00,1',
+}
+
+for i in range(1, 17):
+    values[f'INSET? {i}'] = '1,007,003,21,1'
+    values[f'INNAME? {i}'] = f'Channel {i:02}'
+    values[f'INTYPE? {i}'] = '0,07,1,10,0,1'
+    values[f'TLIMIT? {i}'] = '+0000'
+
+def side_effect(arg):
+    return values[arg]
+
+mock_msg.side_effect = side_effect
+
+
+# Tests
+def test_ls372(mock_agent):
     agent = LS372_Agent(mock_agent, 'mock372', '127.0.0.1' )
     return agent
+
+@mock.patch('socs.Lakeshore.Lakeshore372._establish_socket_connection', mock_connection())
+@mock.patch('socs.Lakeshore.Lakeshore372.LS372.msg', mock_msg)
+def test_ls372_init_lakeshore_task(mock_agent):
+    #mock_agent = mock.MagicMock()
+    #log = txaio.make_logger()
+    #txaio.start_logging(level='debug')
+    #mock_agent.log = log
+
+    agent = LS372_Agent(mock_agent, 'mock372', '127.0.0.1' )
+
+    mock_app = mock.MagicMock()
+    session = OpSession(1, 'init_lakeshore', app=mock_app)
+    response = agent.init_lakeshore_task(session, None)
+    print(response)
+    return response

--- a/tests/agents/test_ls372_agent.py
+++ b/tests/agents/test_ls372_agent.py
@@ -10,21 +10,23 @@ from unittest import mock
 import txaio
 txaio.use_twisted()
 
-# Mocks and fixtures
-#def mock_connection_send_recv():
-#    mock_con = mock.Mock()
-#    mock_con.send = lambda s: len(s.encode('utf-8'))
-#    mock_con.recv = mock.Mock()
-#
-#    values = {'*IDN?': 'LSCI,MODEL372,LSA23JD,1.3'}
-#    def side_effect(arg):
-#        return values[arg]
-#    mock_con.recv.side_effect = side_effect
-#
-#    return mock_con
 
+# Mocks and fixtures
 def mock_connection():
+    """Mock a standard connection."""
     return mock.MagicMock()
+
+
+def mock_failed_connection():
+    """Mock an unhandled error during connection.
+
+    Typically a failed connection will raise a ConnectionError, but we want to
+    check unhandled exceptions in the tests too.
+
+    """
+    failed_con = mock.Mock(side_effect=RuntimeError('Unhandled error'))
+    return failed_con
+
 
 @pytest.fixture
 def mock_agent():
@@ -37,50 +39,117 @@ def mock_agent():
 
     return mock_agent
 
+
 # Mock responses from the 372
-mock_msg = mock.Mock()
+def mock_372_msg():
+    mock_msg = mock.Mock()
 
-values = {'*IDN?': 'LSCI,MODEL372,LSA23JD,1.3',
-          'SCAN?': '01,1',
-          'INSET? A': '0,010,003,00,1',
-          'INNAME? A': 'Input A',
-          'INTYPE? A': '1,04,0,15,0,2',
-          'TLIMIT? A': '+0000',
-          'OUTMODE? 0': '2,6,1,0,0,001',
-          'HTRSET? 0': '+120.000,8,+0000.00,1',
-          'OUTMODE? 2': '4,16,1,0,0,001',
-          'HTRSET? 2': '+120.000,8,+0000.00,1',
-}
+    values = {'*IDN?': 'LSCI,MODEL372,LSA23JD,1.3',
+              'SCAN?': '01,1',
+              'INSET? A': '0,010,003,00,1',
+              'INNAME? A': 'Input A',
+              'INTYPE? A': '1,04,0,15,0,2',
+              'TLIMIT? A': '+0000',
+              'OUTMODE? 0': '2,6,1,0,0,001',
+              'HTRSET? 0': '+120.000,8,+0000.00,1',
+              'OUTMODE? 2': '4,16,1,0,0,001',
+              'HTRSET? 2': '+120.000,8,+0000.00,1'}
 
-for i in range(1, 17):
-    values[f'INSET? {i}'] = '1,007,003,21,1'
-    values[f'INNAME? {i}'] = f'Channel {i:02}'
-    values[f'INTYPE? {i}'] = '0,07,1,10,0,1'
-    values[f'TLIMIT? {i}'] = '+0000'
+    for i in range(1, 17):
+        values[f'INSET? {i}'] = '1,007,003,21,1'
+        values[f'INNAME? {i}'] = f'Channel {i:02}'
+        values[f'INTYPE? {i}'] = '0,07,1,10,0,1'
+        values[f'TLIMIT? {i}'] = '+0000'
 
-def side_effect(arg):
-    return values[arg]
+    def side_effect(arg):
+        return values[arg]
 
-mock_msg.side_effect = side_effect
+    mock_msg.side_effect = side_effect
+
+    return mock_msg
 
 
 # Tests
-def test_ls372(mock_agent):
-    agent = LS372_Agent(mock_agent, 'mock372', '127.0.0.1' )
-    return agent
-
 @mock.patch('socs.Lakeshore.Lakeshore372._establish_socket_connection', mock_connection())
-@mock.patch('socs.Lakeshore.Lakeshore372.LS372.msg', mock_msg)
+@mock.patch('socs.Lakeshore.Lakeshore372.LS372.msg', mock_372_msg())
 def test_ls372_init_lakeshore_task(mock_agent):
-    #mock_agent = mock.MagicMock()
-    #log = txaio.make_logger()
-    #txaio.start_logging(level='debug')
-    #mock_agent.log = log
+    """Run init_lakeshore_task, mocking a connection and the 372 messaging.
+    This should be as if the initialization worked without issue.
 
-    agent = LS372_Agent(mock_agent, 'mock372', '127.0.0.1' )
+    """
+    agent = LS372_Agent(mock_agent, 'mock372', '127.0.0.1')
 
     mock_app = mock.MagicMock()
     session = OpSession(1, 'init_lakeshore', app=mock_app)
-    response = agent.init_lakeshore_task(session, None)
-    print(response)
-    return response
+    res = agent.init_lakeshore_task(session, None)
+
+    print(res)
+    print(agent.initialized)
+    print(session.encoded())
+    assert agent.initialized is True
+    assert res[0] is True
+
+
+@mock.patch('socs.Lakeshore.Lakeshore372._establish_socket_connection', mock_connection())
+@mock.patch('socs.Lakeshore.Lakeshore372.LS372.msg', mock_372_msg())
+def test_ls372_init_lakeshore_task_already_initialized(mock_agent):
+    """Initializing an already initialized LS372_Agent should just return True.
+
+    """
+    agent = LS372_Agent(mock_agent, 'mock372', '127.0.0.1')
+
+    mock_app = mock.MagicMock()
+    session = OpSession(1, 'init_lakeshore', app=mock_app)
+    agent.init_lakeshore_task(session, None)
+    res = agent.init_lakeshore_task(session, None)
+    assert agent.initialized is True
+    assert res[0] is True
+
+
+# If we don't patch the reactor out, it'll mess up pytest when stop is called
+@mock.patch('LS372_agent.reactor', mock.MagicMock())
+@mock.patch('socs.Lakeshore.Lakeshore372.LS372.msg', mock_372_msg())
+def test_ls372_init_lakeshore_task_failed_connection(mock_agent):
+    """Leaving off the connection Mock, if the connection fails the init task
+    should fail and return False.
+
+    """
+    agent = LS372_Agent(mock_agent, 'mock372', '127.0.0.1')
+
+    mock_app = mock.MagicMock()
+    session = OpSession(1, 'init_lakeshore', app=mock_app)
+    res = agent.init_lakeshore_task(session, None)
+    assert res[0] is False
+
+
+# If we don't patch the reactor out, it'll mess up pytest when stop is called
+@mock.patch('LS372_agent.reactor', mock.MagicMock())
+@mock.patch('socs.Lakeshore.Lakeshore372._establish_socket_connection', mock_failed_connection())
+@mock.patch('socs.Lakeshore.Lakeshore372.LS372.msg', mock_372_msg())
+def test_ls372_init_lakeshore_task_unhandled_error(mock_agent):
+    """If we cause an unhandled exception during connection init task should
+    also fail and return False.
+
+    """
+    agent = LS372_Agent(mock_agent, 'mock372', '127.0.0.1')
+
+    mock_app = mock.MagicMock()
+    session = OpSession(1, 'init_lakeshore', app=mock_app)
+    res = agent.init_lakeshore_task(session, None)
+    assert res[0] is False
+
+
+@mock.patch('socs.Lakeshore.Lakeshore372._establish_socket_connection', mock_connection())
+@mock.patch('socs.Lakeshore.Lakeshore372.LS372.msg', mock_372_msg())
+def test_ls372_init_lakeshore_task_auto_acquire(mock_agent):
+    """If we initalize and pass the auto_acquire param, we should expect the
+    Agent to make a start call for the acq process, given the params in acq_params.
+
+    """
+    agent = LS372_Agent(mock_agent, 'mock372', '127.0.0.1')
+
+    mock_app = mock.MagicMock()
+    session = OpSession(1, 'init_lakeshore', app=mock_app)
+    res = agent.init_lakeshore_task(session, {'auto_acquire': True, 'acq_params': {'test': 1}})
+    assert res[0] is True
+    agent.agent.start.assert_called_once_with('acq', {'test': 1})

--- a/tests/agents/test_ls372_agent.py
+++ b/tests/agents/test_ls372_agent.py
@@ -28,6 +28,14 @@ def mock_failed_connection():
     return failed_con
 
 
+def create_session(op_name):
+    """Create an OpSession with a mocked app for testing."""
+    mock_app = mock.MagicMock()
+    session = OpSession(1, op_name, app=mock_app)
+
+    return session
+
+
 @pytest.fixture
 def agent():
     """Test fixture to setup a mocked OCSAgent."""
@@ -95,8 +103,7 @@ def test_ls372_init_lakeshore_task(agent):
     This should be as if the initialization worked without issue.
 
     """
-    mock_app = mock.MagicMock()
-    session = OpSession(1, 'init_lakeshore', app=mock_app)
+    session = create_session('init_lakeshore')
     res = agent.init_lakeshore_task(session, None)
 
     print(res)
@@ -112,8 +119,7 @@ def test_ls372_init_lakeshore_task_already_initialized(agent):
     """Initializing an already initialized LS372_Agent should just return True.
 
     """
-    mock_app = mock.MagicMock()
-    session = OpSession(1, 'init_lakeshore', app=mock_app)
+    session = create_session('init_lakeshore')
     agent.init_lakeshore_task(session, None)
     res = agent.init_lakeshore_task(session, None)
     assert agent.initialized is True
@@ -128,8 +134,7 @@ def test_ls372_init_lakeshore_task_failed_connection(agent):
     should fail and return False.
 
     """
-    mock_app = mock.MagicMock()
-    session = OpSession(1, 'init_lakeshore', app=mock_app)
+    session = create_session('init_lakeshore')
     res = agent.init_lakeshore_task(session, None)
     assert res[0] is False
 
@@ -143,8 +148,7 @@ def test_ls372_init_lakeshore_task_unhandled_error(agent):
     also fail and return False.
 
     """
-    mock_app = mock.MagicMock()
-    session = OpSession(1, 'init_lakeshore', app=mock_app)
+    session = create_session('init_lakeshore')
     res = agent.init_lakeshore_task(session, None)
     assert res[0] is False
 
@@ -156,8 +160,7 @@ def test_ls372_init_lakeshore_task_auto_acquire(agent):
     Agent to make a start call for the acq process, given the params in acq_params.
 
     """
-    mock_app = mock.MagicMock()
-    session = OpSession(1, 'init_lakeshore', app=mock_app)
+    session = create_session('init_lakeshore')
     res = agent.init_lakeshore_task(session, {'auto_acquire': True, 'acq_params': {'test': 1}})
     assert res[0] is True
     agent.agent.start.assert_called_once_with('acq', {'test': 1})
@@ -168,8 +171,7 @@ def test_ls372_init_lakeshore_task_auto_acquire(agent):
 @mock.patch('socs.Lakeshore.Lakeshore372.LS372.msg', mock_372_msg())
 def test_ls372_enable_control_chan(agent):
     """Normal operation of 'enable_control_chan' task."""
-    mock_app = mock.MagicMock()
-    session = OpSession(1, 'enable_control_chan', app=mock_app)
+    session = create_session('enable_control_chan')
 
     # Have to init before running anything else
     agent.init_lakeshore_task(session, None)
@@ -183,8 +185,7 @@ def test_ls372_enable_control_chan(agent):
 @mock.patch('socs.Lakeshore.Lakeshore372.LS372.msg', mock_372_msg())
 def test_ls372_disable_control_chan(agent):
     """Normal operation of 'disable_control_chan' task."""
-    mock_app = mock.MagicMock()
-    session = OpSession(1, 'disable_control_chan', app=mock_app)
+    session = create_session('disable_control_chan')
 
     # Have to init before running anything else
     agent.init_lakeshore_task(session, None)
@@ -198,8 +199,7 @@ def test_ls372_disable_control_chan(agent):
 @mock.patch('socs.Lakeshore.Lakeshore372.LS372.msg', mock_372_msg())
 def test_ls372_acq(agent):
     """Test running the 'acq' Process once."""
-    mock_app = mock.MagicMock()
-    session = OpSession(1, 'acq', app=mock_app)
+    session = create_session('acq')
 
     # Have to init before running anything else
     agent.init_lakeshore_task(session, None)
@@ -216,8 +216,7 @@ def test_ls372_acq(agent):
 @mock.patch('socs.Lakeshore.Lakeshore372.LS372.msg', mock_372_msg())
 def test_ls372_acq_w_control_chan(agent):
     """Test running the 'acq' Process once with control channel active."""
-    mock_app = mock.MagicMock()
-    session = OpSession(1, 'acq', app=mock_app)
+    session = create_session('acq')
 
     # Have to init before running anything else
     agent.init_lakeshore_task(session, None)
@@ -237,8 +236,7 @@ def test_ls372_acq_w_control_chan(agent):
 @mock.patch('socs.Lakeshore.Lakeshore372.LS372.msg', mock_372_msg())
 def test_ls372_acq_w_sample_heater(agent):
     """Test running the 'acq' Process once with sample heater active."""
-    mock_app = mock.MagicMock()
-    session = OpSession(1, 'acq', app=mock_app)
+    session = create_session('acq')
 
     # Have to init before running anything else
     agent.init_lakeshore_task(session, None)
@@ -253,8 +251,7 @@ def test_ls372_acq_w_sample_heater(agent):
 @mock.patch('socs.Lakeshore.Lakeshore372.LS372.msg', mock_372_msg())
 def test_ls372_stop_acq_not_running(agent):
     """'stop_acq' should return False if acq Process isn't running."""
-    mock_app = mock.MagicMock()
-    session = OpSession(1, 'stop_acq', app=mock_app)
+    session = create_session('stop_acq')
 
     # Have to init before running anything else
     agent.init_lakeshore_task(session, None)
@@ -267,8 +264,7 @@ def test_ls372_stop_acq_not_running(agent):
 @mock.patch('socs.Lakeshore.Lakeshore372.LS372.msg', mock_372_msg())
 def test_ls372_stop_acq_while_running(agent):
     """'stop_acq' should return True if acq Process is running."""
-    mock_app = mock.MagicMock()
-    session = OpSession(1, 'stop_acq', app=mock_app)
+    session = create_session('stop_acq')
 
     # Have to init before running anything else
     agent.init_lakeshore_task(session, None)
@@ -289,8 +285,7 @@ def test_ls372_set_heater_range_sample_heater(agent):
     operation.
 
     """
-    mock_app = mock.MagicMock()
-    session = OpSession(1, 'set_heater_range', app=mock_app)
+    session = create_session('set_heater_range')
 
     # Have to init before running anything else
     agent.init_lakeshore_task(session, None)
@@ -307,8 +302,7 @@ def test_ls372_set_heater_range_still_heater(agent):
     operation.
 
     """
-    mock_app = mock.MagicMock()
-    session = OpSession(1, 'set_heater_range', app=mock_app)
+    session = create_session('set_heater_range')
 
     # Have to init before running anything else
     agent.init_lakeshore_task(session, None)
@@ -325,8 +319,7 @@ def test_ls372_set_heater_range_identical_range(agent):
     return True.
 
     """
-    mock_app = mock.MagicMock()
-    session = OpSession(1, 'set_heater_range', app=mock_app)
+    session = create_session('set_heater_range')
 
     # Have to init before running anything else
     agent.init_lakeshore_task(session, None)
@@ -346,8 +339,7 @@ def test_ls372_set_heater_range_identical_range(agent):
 @mock.patch('socs.Lakeshore.Lakeshore372.LS372.msg', mock_372_msg())
 def test_ls372_set_excitation_mode(agent):
     """Normal operation of 'set_excitation_mode' task."""
-    mock_app = mock.MagicMock()
-    session = OpSession(1, 'set_excitation_mode', app=mock_app)
+    session = create_session('set_excitation_mode')
 
     # Have to init before running anything else
     agent.init_lakeshore_task(session, None)
@@ -362,8 +354,7 @@ def test_ls372_set_excitation_mode(agent):
 @mock.patch('socs.Lakeshore.Lakeshore372.LS372.msg', mock_372_msg())
 def test_ls372_set_excitation(agent):
     """Normal operation of 'set_excitation' task."""
-    mock_app = mock.MagicMock()
-    session = OpSession(1, 'set_excitation', app=mock_app)
+    session = create_session('set_excitation')
 
     # Have to init before running anything else
     agent.init_lakeshore_task(session, None)
@@ -377,8 +368,7 @@ def test_ls372_set_excitation(agent):
 @mock.patch('socs.Lakeshore.Lakeshore372.LS372.msg', mock_372_msg())
 def test_ls372_set_excitation_already_set(agent):
     """Setting to already set excitation value."""
-    mock_app = mock.MagicMock()
-    session = OpSession(1, 'set_excitation', app=mock_app)
+    session = create_session('set_excitation')
 
     # Have to init before running anything else
     agent.init_lakeshore_task(session, None)
@@ -393,8 +383,7 @@ def test_ls372_set_excitation_already_set(agent):
 @mock.patch('socs.Lakeshore.Lakeshore372.LS372.msg', mock_372_msg())
 def test_ls372_set_pid(agent):
     """Normal operation of 'set_pid' task."""
-    mock_app = mock.MagicMock()
-    session = OpSession(1, 'set_pid', app=mock_app)
+    session = create_session('set_pid')
 
     # Have to init before running anything else
     agent.init_lakeshore_task(session, None)
@@ -409,8 +398,7 @@ def test_ls372_set_pid(agent):
 @mock.patch('socs.Lakeshore.Lakeshore372.LS372.msg', mock_372_msg())
 def test_ls372_set_active_channel(agent):
     """Normal operation of 'set_active_channel' task."""
-    mock_app = mock.MagicMock()
-    session = OpSession(1, 'set_active_channel', app=mock_app)
+    session = create_session('set_active_channel')
 
     # Have to init before running anything else
     agent.init_lakeshore_task(session, None)
@@ -425,8 +413,7 @@ def test_ls372_set_active_channel(agent):
 @mock.patch('socs.Lakeshore.Lakeshore372.LS372.msg', mock_372_msg())
 def test_ls372_set_autoscan_on(agent):
     """Normal operation of 'set_autoscan' task."""
-    mock_app = mock.MagicMock()
-    session = OpSession(1, 'set_autoscan', app=mock_app)
+    session = create_session('set_autoscan')
 
     # Have to init before running anything else
     agent.init_lakeshore_task(session, None)
@@ -440,8 +427,7 @@ def test_ls372_set_autoscan_on(agent):
 @mock.patch('socs.Lakeshore.Lakeshore372.LS372.msg', mock_372_msg())
 def test_ls372_set_autoscan_off(agent):
     """Normal operation of 'set_autoscan' task."""
-    mock_app = mock.MagicMock()
-    session = OpSession(1, 'set_autoscan', app=mock_app)
+    session = create_session('set_autoscan')
 
     # Have to init before running anything else
     agent.init_lakeshore_task(session, None)
@@ -462,8 +448,7 @@ def test_ls372_set_autoscan_off(agent):
 @mock.patch('socs.Lakeshore.Lakeshore372.LS372.msg', mock_372_msg())
 def test_ls372_set_output_mode_still(agent):
     """Normal operation of 'set_output_mode' task for the still heater."""
-    mock_app = mock.MagicMock()
-    session = OpSession(1, 'set_output_mode', app=mock_app)
+    session = create_session('set_output_mode')
 
     # Have to init before running anything else
     agent.init_lakeshore_task(session, None)
@@ -477,8 +462,7 @@ def test_ls372_set_output_mode_still(agent):
 @mock.patch('socs.Lakeshore.Lakeshore372.LS372.msg', mock_372_msg())
 def test_ls372_set_output_mode_sample(agent):
     """Normal operation of 'set_output_mode' task for the sample heater."""
-    mock_app = mock.MagicMock()
-    session = OpSession(1, 'set_output_mode', app=mock_app)
+    session = create_session('set_output_mode')
 
     # Have to init before running anything else
     agent.init_lakeshore_task(session, None)
@@ -493,8 +477,7 @@ def test_ls372_set_output_mode_sample(agent):
 @mock.patch('socs.Lakeshore.Lakeshore372.LS372.msg', mock_372_msg())
 def test_ls372_set_heater_output_still(agent):
     """Normal operation of 'set_heater_output' task for the still heater."""
-    mock_app = mock.MagicMock()
-    session = OpSession(1, 'set_heater_output', app=mock_app)
+    session = create_session('set_heater_output')
 
     # Have to init before running anything else
     agent.init_lakeshore_task(session, None)
@@ -508,8 +491,7 @@ def test_ls372_set_heater_output_still(agent):
 @mock.patch('socs.Lakeshore.Lakeshore372.LS372.msg', mock_372_msg())
 def test_ls372_set_heater_output_sample(agent):
     """Normal operation of 'set_heater_output' task for the sample heater."""
-    mock_app = mock.MagicMock()
-    session = OpSession(1, 'set_heater_output', app=mock_app)
+    session = create_session('set_heater_output')
 
     # Have to init before running anything else
     agent.init_lakeshore_task(session, None)
@@ -524,8 +506,7 @@ def test_ls372_set_heater_output_sample(agent):
 @mock.patch('socs.Lakeshore.Lakeshore372.LS372.msg', mock_372_msg())
 def test_ls372_set_still_output(agent):
     """Normal operation of 'set_still_output' task."""
-    mock_app = mock.MagicMock()
-    session = OpSession(1, 'set_still_output', app=mock_app)
+    session = create_session('set_still_output')
 
     # Have to init before running anything else
     agent.init_lakeshore_task(session, None)
@@ -540,8 +521,7 @@ def test_ls372_set_still_output(agent):
 @mock.patch('socs.Lakeshore.Lakeshore372.LS372.msg', mock_372_msg())
 def test_ls372_get_still_output(agent):
     """Normal operation of 'get_still_output' task."""
-    mock_app = mock.MagicMock()
-    session = OpSession(1, 'get_still_output', app=mock_app)
+    session = create_session('get_still_output')
 
     # Have to init before running anything else
     agent.init_lakeshore_task(session, None)

--- a/tests/agents/test_ls372_agent.py
+++ b/tests/agents/test_ls372_agent.py
@@ -1,0 +1,10 @@
+import sys
+sys.path.insert(0, './agents/lakeshore372/')
+from LS372_agent import LS372_Agent
+
+from unittest import mock
+
+def test_bluefors():
+    mock_agent = mock.MagicMock()
+    agent = LS372_Agent(mock_agent, 'mock372', '127.0.0.1' )
+    return agent


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Testing that Agents still function after changes are made is difficult without hardware access, which may be limited by local availability or if hardware is currently in use. This is an attempt to demonstrate unit testing and test coverage on an Agent, mocking the communication layer and returning example responses from a device. This should allow for rapid testing of the Agent Task/Process functionality without access to hardware.

This isn't, however, a full test of Agent functionality, nor is it any sort of integration testing of an Agent on an active OCS network. This would not catch errors related to Agent startup, or errors on the Client side -- particularly anything related to improper parameters being passed to a task/process, as ParamErrors are raised on the client side start call.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
We need a process for validating Agent functionality. This is one step towards being able to do that without actually needing hardware access.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
Tests can be run from the root of the repo with:
```
$ python3 -m pytest
======================================== test session starts ========================================
platform linux -- Python 3.9.6, pytest-6.2.4, py-1.10.0, pluggy-0.13.1
rootdir: /home/koopman/git/socs, configfile: pytest.ini
plugins: dependency-0.5.1, twisted-1.13.4, env-0.6.2, docker-compose-3.2.0, cov-2.10.1
collected 50 items                                                                                  

tests/agents/test_bluefors_agent.py .                                                         [  2%]
tests/agents/test_ls372_agent.py ............................                                 [ 58%]
tests/agents/test_smurf_recorder.py .....................                                     [100%]

========================================= warnings summary ==========================================
../../.local/lib/python3.9/site-packages/flatbuffers/compat.py:19
  /home/koopman/.local/lib/python3.9/site-packages/flatbuffers/compat.py:19: DeprecationWarning: the imp module is deprecated in favour of importlib; see the module's documentation for alternative uses
    import imp

-- Docs: https://docs.pytest.org/en/stable/warnings.html

----------- coverage: platform linux, python 3.9.6-final-0 -----------
Name                                      Stmts   Miss  Cover
-------------------------------------------------------------
agents/bluefors/bluefors_log_tracker.py     200    151    24%
agents/lakeshore372/LS372_agent.py          393    139    65%
agents/ocs_plugin_so.py                       5      5     0%
socs/Lakeshore/Lakeshore240.py              226    226     0%
socs/Lakeshore/Lakeshore370.py              637    637     0%
socs/Lakeshore/Lakeshore372.py              693    363    48%
socs/Lakeshore/__init__.py                    0      0   100%
socs/__init__.py                              3      0   100%
socs/agent/__init__.py                        0      0   100%
socs/agent/prologix_interface.py             28     28     0%
socs/agent/scpi_psu_driver.py                47     47     0%
socs/agent/smurf_recorder.py                184     34    82%
socs/agent/tektronix3021c_driver.py           8      8     0%
socs/snmp.py                                 23     23     0%
socs/util.py                                 18     18     0%
-------------------------------------------------------------
TOTAL                                      2465   1679    32%

=================================== 50 passed, 1 warning in 4.19s ===================================
2021-09-22T10:33:31-0400 Main loop terminated.

```

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] Unless I am preparing a release, I have opened this PR onto the `develop` branch.
