### PR TITLE
Pin docutils and add readthedocs config file

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -1,6 +1,10 @@
 version: 2
 
+sphinx:
+    configuration: docs/conf.py
+
 python:
-   install:
-   - requirements: docs/requirements.txt
-   - requirements: requirements.txt
+    version: 3.7
+    install:
+    - requirements: docs/requirements.txt
+    - requirements: requirements.txt

--- a/README.rst
+++ b/README.rst
@@ -70,10 +70,12 @@ be considered unstable.
 
 Documentation
 -------------
-The SOCS documentation can be built using sphinx once you have performed the
-installation::
+The SOCS documentation can be built using Sphinx. There is a separate
+``requirements.txt`` file in the ``docs/`` directory to install Sphinx and any
+additional documentation dependencies::
 
   cd docs/
+  pip3 install -r requirements.txt
   make html
 
 You can then open ``docs/_build/html/index.html`` in your preferred web

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,1 +1,3 @@
-docutils<0.18
+sphinx==4.2.0
+sphinx_rtd_theme==1.0.0
+sphinx-argparse==0.3.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -19,7 +19,7 @@ pysnmp
 pysmi
 
 # Docs
-sphinx_rtd_theme
+# see docs/requirements.txt
 
 # testing
 pytest


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
A recent update in docutils breaks builds on readthedocs. This is the suggested
work around from [1].

[1] - https://github.com/readthedocs/readthedocs.org/issues/8616

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
A fresh build of the docs on the `develop` branch fails: https://readthedocs.org/projects/socs/builds/15099682/

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
This PR will test the build in the checks below.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] Unless I am preparing a release, I have opened this PR onto the `develop` branch.
