### PR TITLE
Ls372 control

### DIFF
--- a/agents/lakeshore372/LS372_agent.py
+++ b/agents/lakeshore372/LS372_agent.py
@@ -832,12 +832,17 @@ class LS372_Agent:
 
         return True, "Current still output is {}".format(still_output)
 
+    @ocs_agent.param('channel', cast=int, check=lambda x: 0 <= x <= 16)
     def set_input_channel(self, session, params):
-        """
-        Set the input channel for the sample heater, for use in PID.
+        """set_input_channel(channel)
 
-        :param params: dict with "channel" key for Heater.set_input_channel()
-        :type params: dict
+        **Task** - Sets the input channel for the sample heater to use in the PID.
+
+        Parameters:
+            channel (int):
+                Channel to for the sample heater to use in the PID. This must
+                be an integer in the range [0, 16], where 0 is the control
+                channel and 1-16 is the corresponding channel in the scanner.
         """
 
         with self._acq_proc_lock.acquire_timeout(1, job='set_input_channel') as acquired:

--- a/socs/Lakeshore/Lakeshore372.py
+++ b/socs/Lakeshore/Lakeshore372.py
@@ -1522,7 +1522,10 @@ class Heater:
         :param _input: specifies which input or channel to control from
         :type _input: str or int
         """
-        assert int(_input) in range(17) or _input == "A", f"{_input} not a valid input/channel"
+        assert int(_input) in range(17), f"{_input} not a valid input/channel"
+
+        if int(_input) == 0:
+            _input = 'A'
 
         resp = self.get_output_mode()
         resp[1] = str(_input)


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Updates from ls372-control dev-docker at UCSD. Adds task to set PID input channel, and allows you to use the control channel as PID input. 

## Description
<!--- Describe your changes in detail -->
This PR includes some changes made by Jake that are required for the control channel to be read out correctly, and to be used for the PID input. I mostly just took these out of the dev-docker that was being used at UCSD, made sure the blocking structure was correct, and added the ocs_param decorator. This version is currently being mounted into the docker we're running on k2so, so we will see over the next week or so whether there are any problems with it.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
We want to be able to PID based on the control channel, and eliminate any ninja agents on the k2so system

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
Currently running on gir

<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] Unless I am preparing a release, I have opened this PR onto the `develop` branch.
