### PR TITLE
Enforce ordering of tests for spt3g dependency check

### DIFF
--- a/.github/workflows/develop.yml
+++ b/.github/workflows/develop.yml
@@ -49,7 +49,7 @@ jobs:
 
     - name: Test with spt3g dependent tests wtihin a docker container
       run: |
-        docker run -v $PWD:/coverage --rm -w="/app/socs/tests/" socs sh -c "COVERAGE_FILE=/coverage/.coverage.docker python3 -m pytest --cov -m 'spt3g'"
+        docker run -v $PWD:/coverage --rm -w="/app/socs/tests/" socs sh -c "COVERAGE_FILE=/coverage/.coverage.docker python3 -m pytest --cov --order-dependencies -m 'spt3g'"
 
     # Integration Tests
     - name: Build images for integration tests

--- a/.github/workflows/official-docker-images.yml
+++ b/.github/workflows/official-docker-images.yml
@@ -49,7 +49,7 @@ jobs:
 
     - name: Test with spt3g dependent tests wtihin a docker container
       run: |
-        docker run -v $PWD:/coverage --rm -w="/app/socs/tests/" socs sh -c "COVERAGE_FILE=/coverage/.coverage.docker python3 -m pytest --cov -m 'spt3g'"
+        docker run -v $PWD:/coverage --rm -w="/app/socs/tests/" socs sh -c "COVERAGE_FILE=/coverage/.coverage.docker python3 -m pytest --cov --order-dependencies -m 'spt3g'"
 
     # Integration Tests
     - name: Build images for integration tests

--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -46,7 +46,7 @@ jobs:
 
     - name: Test with spt3g dependent tests wtihin a docker container
       run: |
-        docker run -v $PWD:/coverage --rm -w="/app/socs/tests/" socs sh -c "COVERAGE_FILE=/coverage/.coverage.docker python3 -m pytest --cov -m 'spt3g'"
+        docker run -v $PWD:/coverage --rm -w="/app/socs/tests/" socs sh -c "COVERAGE_FILE=/coverage/.coverage.docker python3 -m pytest --cov --order-dependencies -m 'spt3g'"
 
     # Integration Tests
     - name: Build images for integration tests

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -17,6 +17,8 @@ services:
   ocs-lakeshore372-agent:
     image: "ocs-lakeshore372-agent"
     build: ./agents/lakeshore372/
+    depends_on:
+      - "socs"
 
   # --------------------------------------------------------------------------
   # The Lakeshore 370 Agent
@@ -24,6 +26,8 @@ services:
   ocs-lakeshore370-agent:
     image: "ocs-lakeshore370-agent"
     build: ./agents/lakeshore370/
+    depends_on:
+      - "socs"
 
   # --------------------------------------------------------------------------
   # The Lakeshore 240 Agent
@@ -31,6 +35,8 @@ services:
   ocs-lakeshore240-agent:
     image: "ocs-lakeshore240-agent"
     build: ./agents/lakeshore240/
+    depends_on:
+      - "socs"
 
   # --------------------------------------------------------------------------
   # The Lakeshore 336 Agent
@@ -38,6 +44,8 @@ services:
   ocs-lakeshore336-agent:
     image: "ocs-lakeshore336-agent"
     build: ./agents/lakeshore336/
+    depends_on:
+      - "socs"
 
   # --------------------------------------------------------------------------
   # The Pysmurf Controller Agent
@@ -52,6 +60,8 @@ services:
   ocs-pysmurf-monitor-agent:
     image: "ocs-pysmurf-monitor-agent"
     build: ./agents/pysmurf_monitor/
+    depends_on:
+      - "socs"
 
   # --------------------------------------------------------------------------
   # The Pysmurf Archiver Agent
@@ -59,6 +69,8 @@ services:
   ocs-pysmurf-archiver-agent:
     image: "ocs-pysmurf-archiver-agent"
     build: ./agents/pysmurf_archiver/
+    depends_on:
+      - "socs"
 
   # --------------------------------------------------------------------------
   # Smurf stream simulator agent
@@ -66,6 +78,8 @@ services:
   ocs-smurf-stream-sim-agent:
     image: "ocs-smurf-stream-sim"
     build: ./agents/smurf_stream_simulator/
+    depends_on:
+      - "socs"
 
   # --------------------------------------------------------------------------
   # SMuRF timestream aggregator
@@ -73,6 +87,8 @@ services:
   ocs-smurf-recorder:
     image: "ocs-smurf-recorder"
     build: ./agents/smurf_recorder/
+    depends_on:
+      - "socs"
 
   # --------------------------------------------------------------------------
   # The Bluefors log tracking Agent
@@ -80,6 +96,8 @@ services:
   ocs-bluefors-agent:
     image: "ocs-bluefors-agent"
     build: ./agents/bluefors/
+    depends_on:
+      - "socs"
 
   # --------------------------------------------------------------------------
   # Power Supply control Agent
@@ -87,6 +105,8 @@ services:
   ocs-scpi-psu-agent:
     image: "ocs-scpi-psu-agent"
     build: ./agents/scpi_psu/
+    depends_on:
+      - "socs"
 
   # --------------------------------------------------------------------------
   # Cryomech CPA compressor log agent
@@ -94,6 +114,8 @@ services:
   ocs-cryomech-cpa-agent:
     image: "ocs-cryomech-cpa-agent"
     build: ./agents/cryomech_cpa/
+    depends_on:
+      - "socs"
 
   # --------------------------------------------------------------------------
   # LabJack Agent
@@ -101,6 +123,8 @@ services:
   ocs-labjack-agent:
     image: "ocs-labjack-agent"
     build: ./agents/labjack/
+    depends_on:
+      - "socs"
     
   # --------------------------------------------------------------------------
   # Pfeiffer tpg366 agent
@@ -108,6 +132,8 @@ services:
   ocs-pfeiffer-tpg366-agent:
     image: "ocs-pfeiffer-tpg366-agent"
     build: ./agents/pfeiffer_tpg366/
+    depends_on:
+      - "socs"
     
   # --------------------------------------------------------------------------
   # Synaccess power strip agent
@@ -115,6 +141,8 @@ services:
   ocs-synaccess-agent:
     image: "ocs-synaccess-agent"
     build: ./agents/synacc/
+    depends_on:
+      - "socs"
 
   # --------------------------------------------------------------------------
   # Meinberg M1000
@@ -122,6 +150,8 @@ services:
   ocs-meinberg-m1000-agent:
     image: "ocs-meinberg-m1000-agent"
     build: ./agents/meinberg_m1000/
+    depends_on:
+      - "socs"
 
   # -------------------------------------------------------------------------
   # SMuRF Crate Monitor
@@ -129,6 +159,8 @@ services:
   ocs-smurf-crate-monitor:
     image: "ocs-smurf-crate-monitor"
     build: ./agents/smurf_crate_monitor/
+    depends_on:
+      - "socs"
 
   # --------------------------------------------------------------------------
   # Tektronix3021c
@@ -136,6 +168,8 @@ services:
   ocs-tektronix3021c-agent:
     image: "ocs-tektronix3021c-agent"
     build: ./agents/tektronix3021c/
+    depends_on:
+      - "socs"
 
   # --------------------------------------------------------------------------
   # CHWP Encoder BBB agent
@@ -143,6 +177,8 @@ services:
   ocs-hwpbbb-agent:
     image: "ocs-hwpbbb-agent"
     build: ./agents/chwp/
+    depends_on:
+      - "socs"
 
   # --------------------------------------------------------------------------
   # SOCS Simulators
@@ -154,7 +190,11 @@ services:
   ocs-lakeshore240-simulator:
     image: "ocs-lakeshore240-simulator"
     build: ./simulators/lakeshore240/
+    depends_on:
+      - "socs"
 
   ocs-lakeshore372-simulator:
     image: "ocs-lakeshore372-simulator"
     build: ./simulators/lakeshore372/
+    depends_on:
+      - "socs"

--- a/requirements.txt
+++ b/requirements.txt
@@ -26,3 +26,4 @@ pytest
 pytest-cov
 pytest-docker-compose
 pytest-dependency
+pytest-order


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
This PR introduces the pytest-order plugin in order to make sure that the spt3g import test runs first when running spt3g dependent tests. This ensures that those tests are not skipped, which happens if the spt3g import test isn't run first. This seems to happen randomly, which caused an unexpected coverage drop on https://github.com/simonsobs/socs/pull/220.

While testing locally I noticed that the docker-compose doesn't mark the Agent images as dependent on the socs image. I've added that here as well.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Fixing random coverage drop seen in https://github.com/simonsobs/socs/pull/220 caused by inconsistent test ordering (ideally tests don't have an order dependence, but since we're checking for an imported package and using the result with pytest-dependency, we do have this requirement.) This can be removed once so3g becomes pip installable, as we won't need this dependency test anymore.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
Was tested locally and in the CI workflow. Coverage is restored.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] Unless I am preparing a release, I have opened this PR onto the `develop` branch.
