### PR TITLE
Change default port for crossbar used in testing

### DIFF
--- a/tests/config.json
+++ b/tests/config.json
@@ -60,7 +60,7 @@
 		    "type": "web",
                     "endpoint": {
                         "type": "tcp",
-                        "port": 8001
+                        "port": 18001
                     },
 		    "paths": {
 			"ws": {

--- a/tests/default.yaml
+++ b/tests/default.yaml
@@ -1,8 +1,8 @@
 # Site configuration for a fake observatory.
 hub:
 
-  wamp_server: ws://127.0.0.1:8001/ws
-  wamp_http: http://127.0.0.1:8001/call
+  wamp_server: ws://127.0.0.1:18001/ws
+  wamp_http: http://127.0.0.1:18001/call
   wamp_realm: test_realm
   address_root: observatory
   registry_address: observatory.registry

--- a/tests/docker-compose.yml
+++ b/tests/docker-compose.yml
@@ -3,7 +3,7 @@ services:
   crossbar:
     image: simonsobs/ocs-crossbar:v0.7.0-9-g1d136a3-dev
     ports:
-      - "8001:8001"
+      - "18001:18001"
     volumes:
       - ./config.json:/app/crossbar/config.json
     environment:

--- a/tests/integration/test_ls372_agent_integration.py
+++ b/tests/integration/test_ls372_agent_integration.py
@@ -34,7 +34,7 @@ def wait_for_crossbar(session_scoped_container_getter):
 
     while attempts < 6:
         try:
-            code = urllib.request.urlopen("http://localhost:8001/info").getcode()
+            code = urllib.request.urlopen("http://localhost:18001/info").getcode()
         except (URLError, ConnectionResetError):
             print("Crossbar server not online yet, waiting 5 seconds.")
             time.sleep(5)


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Change crossbar port from 8001 to 18001 for running the tests, moving it out of the way of any normally running crossbar server on the system performing the testing.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Fixes #214

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
Run with local testing. Should pass checks here as well.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] Unless I am preparing a release, I have opened this PR onto the `develop` branch.
