### PR TITLE
Create Lakeshore425 Agent integration tests

### DIFF
--- a/.github/workflows/develop.yml
+++ b/.github/workflows/develop.yml
@@ -9,6 +9,10 @@ jobs:
     runs-on: ubuntu-18.04
 
     steps:
+    - name: Install system packages
+      run: |
+        sudo apt-get install -y socat
+
     - name: Set up Python 3.8 
       uses: actions/setup-python@v2
       with:

--- a/.github/workflows/develop.yml
+++ b/.github/workflows/develop.yml
@@ -6,7 +6,7 @@ on:
 
 jobs:
   build:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-latest
 
     steps:
     - name: Install system packages

--- a/.github/workflows/official-docker-images.yml
+++ b/.github/workflows/official-docker-images.yml
@@ -9,6 +9,10 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
+    - name: Install system packages
+      run: |
+        sudo apt-get install -y socat
+
     - name: Set up Python 3.8 
       uses: actions/setup-python@v2
       with:

--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -7,9 +7,13 @@ on:
 
 jobs:
   build:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-latest
 
     steps:
+    - name: Install system packages
+      run: |
+        sudo apt-get install -y socat
+
     - name: Set up Python 3.8
       uses: actions/setup-python@v2
       with:

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@
 # A container setup with an installation of socs.
 
 # Use the ocs image as a base
-FROM simonsobs/ocs:v0.9.0
+FROM simonsobs/ocs:v0.9.0-14-gfdf3025-dev
 
 # Copy the current directory contents into the container at /app
 COPY . /app/socs/

--- a/socs/testing/device_emulator.py
+++ b/socs/testing/device_emulator.py
@@ -80,7 +80,9 @@ class DeviceEmulator:
 
         This first uses ``socat`` to setup a relay. It then connects to the
         "internal" end of the relay, ready to receive communications sent to the
-        "responder" end of the relay.
+        "responder" end of the relay. This end of the relay is located at
+        ``./responder``. You will need to configure your Agent to use that path for
+        communication.
 
         Next it creates a thread to read commands sent to the serial relay in
         the background. This allows responses to be defined within a test using

--- a/tests/default.yaml
+++ b/tests/default.yaml
@@ -16,5 +16,12 @@ hosts:
                      ['--ip-address', '127.0.0.1'],
                      ['--dwell-time-delay', 0],
                      ['--sample-heater', False]]},
+      {'agent-class': 'Lakeshore425Agent',
+      'instance-id': 'LS425',
+      'arguments': [
+        ['--port', '/home/koopman/port1'],
+        ['--mode', 'acq'],
+        ['--sampling-frequency', 1.],
+      ]},
     ]
   }

--- a/tests/default.yaml
+++ b/tests/default.yaml
@@ -19,8 +19,8 @@ hosts:
       {'agent-class': 'Lakeshore425Agent',
       'instance-id': 'LS425',
       'arguments': [
-        ['--port', '/home/koopman/port1'],
-        ['--mode', 'acq'],
+        ['--port', './responder'],
+        ['--mode', 'init'],
         ['--sampling-frequency', 1.],
       ]},
     ]

--- a/tests/integration/test_ls425_agent_integration.py
+++ b/tests/integration/test_ls425_agent_integration.py
@@ -69,8 +69,7 @@ def test_ls425_start_acq(wait_for_crossbar, responder, run_agent, client):
                  'RDGFIELD?': '+1.0E-01'}
     responder.define_responses(responses)
 
-    client.init_lakeshore()
-    resp = client.acq.start(sample_heater=False, run_once=True)
+    resp = client.acq.start(sampling_frequency=1.0)
     assert resp.status == ocs.OK
     assert resp.session['op_code'] == OpCode.STARTING.value
 

--- a/tests/integration/test_ls425_agent_integration.py
+++ b/tests/integration/test_ls425_agent_integration.py
@@ -72,7 +72,11 @@ def run_agent(cov):
     # report coverage
     agentcov = coverage.data.CoverageData(basename='.coverage.agent')
     agentcov.read()
-    cov.get_data().update(agentcov)
+    try:
+        cov.get_data().update(agentcov)
+    except AttributeError as e:
+        print(f"Encountered error reporting coverage: {e}")
+        print("Did you forget to throw the '--cov' flag?")
 
 
 @pytest.fixture()

--- a/tests/integration/test_ls425_agent_integration.py
+++ b/tests/integration/test_ls425_agent_integration.py
@@ -1,0 +1,114 @@
+import os
+import time
+import pytest
+import signal
+import subprocess
+import coverage.data
+import urllib.request
+
+from urllib.error import URLError
+
+from ocs.matched_client import MatchedClient
+
+import ocs
+from ocs.base import OpCode
+
+pytest_plugins = ("docker_compose")
+
+# Set the OCS_CONFIG_DIR so we read the local default.yaml file always
+os.environ['OCS_CONFIG_DIR'] = os.getcwd()
+
+
+# Fixture to wait for crossbar server to be available.
+# Speeds up tests a bit to have this session scoped
+# If tests start interfering with one another this should be changed to
+# "function" scoped and session_scoped_container_getter should be changed to
+# function_scoped_container_getter
+@pytest.fixture(scope="session")
+def wait_for_crossbar(session_scoped_container_getter):
+    """Wait for the crossbar server from docker-compose to become
+    responsive.
+
+    """
+    attempts = 0
+
+    while attempts < 6:
+        try:
+            code = urllib.request.urlopen("http://localhost:8001/info").getcode()
+        except (URLError, ConnectionResetError):
+            print("Crossbar server not online yet, waiting 5 seconds.")
+            time.sleep(5)
+
+        attempts += 1
+
+    assert code == 200
+    print("Crossbar server online.")
+
+
+@pytest.fixture()
+def run_agent(cov):
+    env = os.environ.copy()
+    env['COVERAGE_FILE'] = '.coverage.agent'
+    env['OCS_CONFIG_DIR'] = os.getcwd()
+    agentproc = subprocess.Popen(['coverage', 'run',
+                                  '--rcfile=./.coveragerc',
+                                  '../agents/lakeshore425/LS425_agent.py',
+                                  '--site-file',
+                                  './default.yaml'],
+                                 env=env,
+                                 stdout=subprocess.PIPE,
+                                 stderr=subprocess.PIPE,
+                                 preexec_fn=os.setsid)
+
+    # wait for Agent to connect
+    time.sleep(1)
+
+    yield
+
+    # shutdown Agent
+    agentproc.send_signal(signal.SIGINT)
+    time.sleep(1)
+
+    # report coverage
+    agentcov = coverage.data.CoverageData(basename='.coverage.agent')
+    agentcov.read()
+    cov.get_data().update(agentcov)
+
+
+@pytest.fixture()
+def client():
+    client = MatchedClient('LSASIM')
+    return client
+
+
+@pytest.mark.integtest
+def test_testing(wait_for_crossbar):
+    """Just a quick test to make sure we can bring up crossbar."""
+    assert True
+
+
+@pytest.mark.integtest
+def test_ls425_init_lakeshore(wait_for_crossbar, run_agent, client):
+    resp = client.init_lakeshore()
+    # print(resp)
+    assert resp.status == ocs.OK
+    # print(resp.session)
+    assert resp.session['op_code'] == OpCode.SUCCEEDED.value
+
+
+@pytest.mark.integtest
+def test_ls425_start_acq(wait_for_crossbar, run_agent, client):
+    client.init_lakeshore()
+    resp = client.acq.start(sample_heater=False, run_once=True)
+    assert resp.status == ocs.OK
+    assert resp.session['op_code'] == OpCode.STARTING.value
+
+    # We stopped the process with run_once=True, but that will leave us in the
+    # RUNNING state
+    resp = client.acq.status()
+    assert resp.session['op_code'] == OpCode.RUNNING.value
+
+    # Now we request a formal stop, which should put us in STOPPING
+    client.acq.stop()
+    resp = client.acq.status()
+    assert resp.session['op_code'] == OpCode.STOPPING.value

--- a/tests/integration/test_ls425_agent_integration.py
+++ b/tests/integration/test_ls425_agent_integration.py
@@ -13,76 +13,18 @@ from ocs.matched_client import MatchedClient
 import ocs
 from ocs.base import OpCode
 
+from integration.util import (
+    create_agent_runner_fixture,
+    create_client_fixture,
+    create_crossbar_fixture
+)
+
 pytest_plugins = ("docker_compose")
 
-# Set the OCS_CONFIG_DIR so we read the local default.yaml file always
-os.environ['OCS_CONFIG_DIR'] = os.getcwd()
-
-
-# Fixture to wait for crossbar server to be available.
-# Speeds up tests a bit to have this session scoped
-# If tests start interfering with one another this should be changed to
-# "function" scoped and session_scoped_container_getter should be changed to
-# function_scoped_container_getter
-@pytest.fixture(scope="session")
-def wait_for_crossbar(session_scoped_container_getter):
-    """Wait for the crossbar server from docker-compose to become
-    responsive.
-
-    """
-    attempts = 0
-
-    while attempts < 6:
-        try:
-            code = urllib.request.urlopen("http://localhost:8001/info").getcode()
-        except (URLError, ConnectionResetError):
-            print("Crossbar server not online yet, waiting 5 seconds.")
-            time.sleep(5)
-
-        attempts += 1
-
-    assert code == 200
-    print("Crossbar server online.")
-
-
-@pytest.fixture()
-def run_agent(cov):
-    env = os.environ.copy()
-    env['COVERAGE_FILE'] = '.coverage.agent'
-    env['OCS_CONFIG_DIR'] = os.getcwd()
-    agentproc = subprocess.Popen(['coverage', 'run',
-                                  '--rcfile=./.coveragerc',
-                                  '../agents/lakeshore425/LS425_agent.py',
-                                  '--site-file',
-                                  './default.yaml'],
-                                 env=env,
-                                 stdout=subprocess.PIPE,
-                                 stderr=subprocess.PIPE,
-                                 preexec_fn=os.setsid)
-
-    # wait for Agent to connect
-    time.sleep(1)
-
-    yield
-
-    # shutdown Agent
-    agentproc.send_signal(signal.SIGINT)
-    time.sleep(1)
-
-    # report coverage
-    agentcov = coverage.data.CoverageData(basename='.coverage.agent')
-    agentcov.read()
-    try:
-        cov.get_data().update(agentcov)
-    except AttributeError as e:
-        print(f"Encountered error reporting coverage: {e}")
-        print("Did you forget to throw the '--cov' flag?")
-
-
-@pytest.fixture()
-def client():
-    client = MatchedClient('LS425')
-    return client
+wait_for_crossbar = create_crossbar_fixture()
+run_agent = create_agent_runner_fixture(
+    '../agents/lakeshore425/LS425_agent.py', 'ls425_agent')
+client = create_client_fixture('LS425')
 
 
 @pytest.mark.integtest

--- a/tests/integration/test_ls425_agent_integration.py
+++ b/tests/integration/test_ls425_agent_integration.py
@@ -26,6 +26,8 @@ pytest_plugins = ("docker_compose")
 wait_for_crossbar = create_crossbar_fixture()
 run_agent = create_agent_runner_fixture(
     '../agents/lakeshore425/LS425_agent.py', 'ls425_agent')
+run_agent_acq = create_agent_runner_fixture(
+    '../agents/lakeshore425/LS425_agent.py', 'ls425_agent', args=['--mode', 'acq'])
 client = create_client_fixture('LS425')
 responder = create_responder_fixture({'*IDN?': 'LSCI,MODEL425,4250022,1.0'})
 
@@ -43,6 +45,22 @@ def test_ls425_init_lakeshore(wait_for_crossbar, responder, run_agent, client):
     assert resp.status == ocs.OK
     # print(resp.session)
     assert resp.session['op_code'] == OpCode.SUCCEEDED.value
+
+
+@pytest.mark.integtest
+def test_ls425_auto_start_acq(wait_for_crossbar, responder, run_agent_acq, client):
+    resp = client.init_lakeshore.status()
+    #print(resp)
+    assert resp.status == ocs.OK
+    #print(resp.session)
+    assert resp.session['op_code'] == OpCode.SUCCEEDED.value
+
+    time.sleep(3)
+    resp = client.acq.status()
+    #print(resp)
+    assert resp.status == ocs.OK
+    #print(resp.session)
+    assert resp.session['op_code'] == OpCode.RUNNING.value
 
 
 @pytest.mark.integtest

--- a/tests/integration/test_ls425_agent_integration.py
+++ b/tests/integration/test_ls425_agent_integration.py
@@ -81,7 +81,7 @@ def run_agent(cov):
 
 @pytest.fixture()
 def client():
-    client = MatchedClient('LSASIM')
+    client = MatchedClient('LS425')
     return client
 
 

--- a/tests/integration/test_ls425_agent_integration.py
+++ b/tests/integration/test_ls425_agent_integration.py
@@ -32,7 +32,7 @@ run_agent = create_agent_runner_fixture(
 run_agent_acq = create_agent_runner_fixture(
     '../agents/lakeshore425/LS425_agent.py', 'ls425_agent', args=['--mode', 'acq'])
 client = create_client_fixture('LS425')
-emulator = create_device_emulator({'*IDN?': 'LSCI,MODEL425,4250022,1.0'})
+emulator = create_device_emulator({'*IDN?': 'LSCI,MODEL425,LSA425T,1.3'})
 
 
 @pytest.mark.integtest
@@ -68,7 +68,7 @@ def test_ls425_auto_start_acq(wait_for_crossbar, emulator, run_agent_acq, client
 
 @pytest.mark.integtest
 def test_ls425_start_acq(wait_for_crossbar, emulator, run_agent, client):
-    responses = {'*IDN?': 'LSCI,MODEL425,4250022,1.0',
+    responses = {'*IDN?': 'LSCI,MODEL425,LSA425T,1.3',
                  'RDGFIELD?': '+1.0E-01'}
     emulator.define_responses(responses)
 
@@ -94,7 +94,7 @@ def test_ls425_start_acq(wait_for_crossbar, emulator, run_agent, client):
 
 @pytest.mark.integtest
 def test_ls425_operational_status(wait_for_crossbar, emulator, run_agent, client):
-    responses = {'OPST?': '001'}
+    responses = {'OPST?': '132'}
     emulator.define_responses(responses)
 
     resp = client.operational_status()

--- a/tests/integration/test_ls425_agent_integration.py
+++ b/tests/integration/test_ls425_agent_integration.py
@@ -13,9 +13,12 @@ from ocs.matched_client import MatchedClient
 import ocs
 from ocs.base import OpCode
 
-from integration.util import (
+from ocs.testing import (
     create_agent_runner_fixture,
     create_client_fixture,
+)
+
+from integration.util import (
     create_crossbar_fixture
 )
 

--- a/tests/integration/test_ls425_agent_integration.py
+++ b/tests/integration/test_ls425_agent_integration.py
@@ -19,7 +19,7 @@ from integration.util import (
     create_crossbar_fixture
 )
 
-from integration.responder import create_responder_fixture
+from socs.testing.device_emulator import create_device_emulator
 
 pytest_plugins = ("docker_compose")
 
@@ -29,7 +29,7 @@ run_agent = create_agent_runner_fixture(
 run_agent_acq = create_agent_runner_fixture(
     '../agents/lakeshore425/LS425_agent.py', 'ls425_agent', args=['--mode', 'acq'])
 client = create_client_fixture('LS425')
-responder = create_responder_fixture({'*IDN?': 'LSCI,MODEL425,4250022,1.0'})
+emulator = create_device_emulator({'*IDN?': 'LSCI,MODEL425,4250022,1.0'})
 
 
 @pytest.mark.integtest
@@ -39,7 +39,7 @@ def test_testing(wait_for_crossbar):
 
 
 @pytest.mark.integtest
-def test_ls425_init_lakeshore(wait_for_crossbar, responder, run_agent, client):
+def test_ls425_init_lakeshore(wait_for_crossbar, emulator, run_agent, client):
     resp = client.init_lakeshore()
     # print(resp)
     assert resp.status == ocs.OK
@@ -48,7 +48,7 @@ def test_ls425_init_lakeshore(wait_for_crossbar, responder, run_agent, client):
 
 
 @pytest.mark.integtest
-def test_ls425_auto_start_acq(wait_for_crossbar, responder, run_agent_acq, client):
+def test_ls425_auto_start_acq(wait_for_crossbar, emulator, run_agent_acq, client):
     resp = client.init_lakeshore.status()
     #print(resp)
     assert resp.status == ocs.OK
@@ -64,10 +64,10 @@ def test_ls425_auto_start_acq(wait_for_crossbar, responder, run_agent_acq, clien
 
 
 @pytest.mark.integtest
-def test_ls425_start_acq(wait_for_crossbar, responder, run_agent, client):
+def test_ls425_start_acq(wait_for_crossbar, emulator, run_agent, client):
     responses = {'*IDN?': 'LSCI,MODEL425,4250022,1.0',
                  'RDGFIELD?': '+1.0E-01'}
-    responder.define_responses(responses)
+    emulator.define_responses(responses)
 
     resp = client.acq.start(sampling_frequency=1.0)
     assert resp.status == ocs.OK
@@ -90,9 +90,9 @@ def test_ls425_start_acq(wait_for_crossbar, responder, run_agent, client):
 
 
 @pytest.mark.integtest
-def test_ls425_operational_status(wait_for_crossbar, responder, run_agent, client):
+def test_ls425_operational_status(wait_for_crossbar, emulator, run_agent, client):
     responses = {'OPST?': '001'}
-    responder.define_responses(responses)
+    emulator.define_responses(responses)
 
     resp = client.operational_status()
     assert resp.status == ocs.OK
@@ -100,10 +100,10 @@ def test_ls425_operational_status(wait_for_crossbar, responder, run_agent, clien
 
 
 @pytest.mark.integtest
-def test_ls425_zero_calibration(wait_for_crossbar, responder, run_agent, client):
+def test_ls425_zero_calibration(wait_for_crossbar, emulator, run_agent, client):
     responses = {'ZCLEAR': '',
                  'ZPROBE': ''}
-    responder.define_responses(responses)
+    emulator.define_responses(responses)
 
     resp = client.zero_calibration()
     assert resp.status == ocs.OK
@@ -111,10 +111,10 @@ def test_ls425_zero_calibration(wait_for_crossbar, responder, run_agent, client)
 
 
 @pytest.mark.integtest
-def test_ls425_any_command(wait_for_crossbar, responder, run_agent, client):
+def test_ls425_any_command(wait_for_crossbar, emulator, run_agent, client):
     responses = {'UNIT 2': '',
                  'UNIT?': '2'}
-    responder.define_responses(responses)
+    emulator.define_responses(responses)
 
     # Send a command that doesn't expect a response
     resp = client.any_command(command="UNIT 2")

--- a/tests/integration/util.py
+++ b/tests/integration/util.py
@@ -81,10 +81,10 @@ def create_crossbar_fixture():
     # If tests start interfering with one another this should be changed to
     # "function" scoped and session_scoped_container_getter should be changed to
     # function_scoped_container_getter
-    # @pytest.fixture(scope="session")
-    # def wait_for_crossbar(session_scoped_container_getter):
-    @pytest.fixture(scope="function")
-    def wait_for_crossbar(function_scoped_container_getter):
+    # @pytest.fixture(scope="function")
+    # def wait_for_crossbar(function_scoped_container_getter):
+    @pytest.fixture(scope="session")
+    def wait_for_crossbar(session_scoped_container_getter):
         """Wait for the crossbar server from docker-compose to become
         responsive.
 

--- a/tests/integration/util.py
+++ b/tests/integration/util.py
@@ -1,0 +1,137 @@
+import os
+import time
+import pytest
+import signal
+import subprocess
+import coverage.data
+import urllib.request
+import docker
+
+from urllib.error import URLError
+
+from ocs.ocs_client import OCSClient
+
+# this is directly from upstream, but isn't exposed in the ocs package itself
+def create_agent_runner_fixture(agent_path, agent_name, args=None):
+    """Create a pytest fixture for running a given OCS Agent.
+
+    Parameters:
+        agent_path (str): Relative path to Agent,
+            i.e. '../agents/fake_data/fake_data_agent.py'
+        agent_name (str): Short, unique name for the agent
+
+    """
+    @pytest.fixture()
+    def run_agent(cov):
+        env = os.environ.copy()
+        env['COVERAGE_FILE'] = f'.coverage.agent.{agent_name}'
+        env['OCS_CONFIG_DIR'] = os.getcwd()
+        cmd = ['coverage', 'run',
+               '--rcfile=./.coveragerc',
+               agent_path,
+               '--site-file',
+               './default.yaml']
+        if args is not None:
+            cmd.extend(args)
+        agentproc = subprocess.Popen(cmd,
+                                     env=env,
+                                     stdout=subprocess.PIPE,
+                                     stderr=subprocess.PIPE,
+                                     preexec_fn=os.setsid)
+
+        # wait for Agent to connect
+        time.sleep(1)
+
+        yield
+
+        # shutdown Agent
+        agentproc.send_signal(signal.SIGINT)
+        time.sleep(1)
+
+        # report coverage
+        agentcov = coverage.data.CoverageData(
+            basename=f'.coverage.agent.{agent_name}')
+        agentcov.read()
+        # protect against missing --cov flag
+        if cov is not None:
+            cov.get_data().update(agentcov)
+
+    return run_agent
+
+
+def _check_crossbar_connection():
+    attempts = 0
+
+    while attempts < 6:
+        try:
+            code = urllib.request.urlopen("http://localhost:18001/info").getcode()
+        except (URLError, ConnectionResetError):
+            print("Crossbar server not online yet, waiting 5 seconds.")
+            time.sleep(5)
+
+        attempts += 1
+
+    assert code == 200
+    print("Crossbar server online.")
+
+
+def create_crossbar_fixture():
+    # Fixture to wait for crossbar server to be available.
+    # Speeds up tests a bit to have this session scoped
+    # If tests start interfering with one another this should be changed to
+    # "function" scoped and session_scoped_container_getter should be changed to
+    # function_scoped_container_getter
+    # @pytest.fixture(scope="session")
+    # def wait_for_crossbar(session_scoped_container_getter):
+    @pytest.fixture(scope="function")
+    def wait_for_crossbar(function_scoped_container_getter):
+        """Wait for the crossbar server from docker-compose to become
+        responsive.
+
+        """
+        _check_crossbar_connection()
+
+    return wait_for_crossbar
+
+
+def restart_crossbar():
+    """Restart the crossbar server and wait for it to come back online."""
+    client = docker.from_env()
+    crossbar_container = client.containers.get('ocs-tests-crossbar')
+    crossbar_container.restart()
+    _check_crossbar_connection()
+
+
+def create_client_fixture(instance_id, timeout=30):
+    """Create the fixture that provides tests a Client object.
+
+    Parameters:
+        instance_id (str): Agent instance-id to connect the Client to
+        timeout (int): Approximate timeout in seconds for the connection.
+            Connection attempts will be made X times, with a 1 second pause
+            between attempts. This is useful if it takes some time for the
+            Agent to start accepting connections, which varies depending on the
+            Agent.
+
+    """
+    @pytest.fixture()
+    def client_fixture():
+        # Set the OCS_CONFIG_DIR so we read the local default.yaml file
+        os.environ['OCS_CONFIG_DIR'] = os.getcwd()
+        print(os.environ['OCS_CONFIG_DIR'])
+        attempts = 0
+
+        while attempts < timeout:
+            try:
+                client = OCSClient(instance_id)
+                break
+            except RuntimeError as e:
+                print(f"Caught error: {e}")
+                print("Attempting to reconnect.")
+
+            time.sleep(1)
+            attempts += 1
+
+        return client
+
+    return client_fixture

--- a/tests/integration/util.py
+++ b/tests/integration/util.py
@@ -1,79 +1,11 @@
-import os
 import time
 import pytest
-import signal
-import subprocess
-import coverage.data
 import urllib.request
 import docker
 
 from urllib.error import URLError
 
-from ocs.ocs_client import OCSClient
-
-# this is directly from upstream, but isn't exposed in the ocs package itself
-def create_agent_runner_fixture(agent_path, agent_name, args=None):
-    """Create a pytest fixture for running a given OCS Agent.
-
-    Parameters:
-        agent_path (str): Relative path to Agent,
-            i.e. '../agents/fake_data/fake_data_agent.py'
-        agent_name (str): Short, unique name for the agent
-
-    """
-    @pytest.fixture()
-    def run_agent(cov):
-        env = os.environ.copy()
-        env['COVERAGE_FILE'] = f'.coverage.agent.{agent_name}'
-        env['OCS_CONFIG_DIR'] = os.getcwd()
-        cmd = ['coverage', 'run',
-               '--rcfile=./.coveragerc',
-               agent_path,
-               '--site-file',
-               './default.yaml']
-        if args is not None:
-            cmd.extend(args)
-        agentproc = subprocess.Popen(cmd,
-                                     env=env,
-                                     stdout=subprocess.PIPE,
-                                     stderr=subprocess.PIPE,
-                                     preexec_fn=os.setsid)
-
-        # wait for Agent to connect
-        time.sleep(1)
-
-        yield
-
-        # shutdown Agent
-        agentproc.send_signal(signal.SIGINT)
-        time.sleep(1)
-
-        # report coverage
-        agentcov = coverage.data.CoverageData(
-            basename=f'.coverage.agent.{agent_name}')
-        agentcov.read()
-        # protect against missing --cov flag
-        if cov is not None:
-            cov.get_data().update(agentcov)
-
-    return run_agent
-
-
-def _check_crossbar_connection():
-    attempts = 0
-
-    while attempts < 6:
-        try:
-            code = urllib.request.urlopen("http://localhost:18001/info").getcode()
-        except (URLError, ConnectionResetError):
-            print("Crossbar server not online yet, waiting 5 seconds.")
-            time.sleep(5)
-
-        attempts += 1
-
-    assert code == 200
-    print("Crossbar server online.")
-
+from ocs.testing import check_crossbar_connection
 
 def create_crossbar_fixture():
     # Fixture to wait for crossbar server to be available.
@@ -89,7 +21,7 @@ def create_crossbar_fixture():
         responsive.
 
         """
-        _check_crossbar_connection()
+        check_crossbar_connection()
 
     return wait_for_crossbar
 
@@ -99,39 +31,4 @@ def restart_crossbar():
     client = docker.from_env()
     crossbar_container = client.containers.get('ocs-tests-crossbar')
     crossbar_container.restart()
-    _check_crossbar_connection()
-
-
-def create_client_fixture(instance_id, timeout=30):
-    """Create the fixture that provides tests a Client object.
-
-    Parameters:
-        instance_id (str): Agent instance-id to connect the Client to
-        timeout (int): Approximate timeout in seconds for the connection.
-            Connection attempts will be made X times, with a 1 second pause
-            between attempts. This is useful if it takes some time for the
-            Agent to start accepting connections, which varies depending on the
-            Agent.
-
-    """
-    @pytest.fixture()
-    def client_fixture():
-        # Set the OCS_CONFIG_DIR so we read the local default.yaml file
-        os.environ['OCS_CONFIG_DIR'] = os.getcwd()
-        print(os.environ['OCS_CONFIG_DIR'])
-        attempts = 0
-
-        while attempts < timeout:
-            try:
-                client = OCSClient(instance_id)
-                break
-            except RuntimeError as e:
-                print(f"Caught error: {e}")
-                print("Attempting to reconnect.")
-
-            time.sleep(1)
-            attempts += 1
-
-        return client
-
-    return client_fixture
+    check_crossbar_connection()

--- a/tests/integration/util.py
+++ b/tests/integration/util.py
@@ -1,18 +1,14 @@
-import time
 import pytest
-import urllib.request
-import docker
-
-from urllib.error import URLError
 
 from ocs.testing import check_crossbar_connection
+
 
 def create_crossbar_fixture():
     # Fixture to wait for crossbar server to be available.
     # Speeds up tests a bit to have this session scoped
     # If tests start interfering with one another this should be changed to
-    # "function" scoped and session_scoped_container_getter should be changed to
-    # function_scoped_container_getter
+    # "function" scoped and session_scoped_container_getter should be changed
+    # to function_scoped_container_getter
     # @pytest.fixture(scope="function")
     # def wait_for_crossbar(function_scoped_container_getter):
     @pytest.fixture(scope="session")
@@ -24,11 +20,3 @@ def create_crossbar_fixture():
         check_crossbar_connection()
 
     return wait_for_crossbar
-
-
-def restart_crossbar():
-    """Restart the crossbar server and wait for it to come back online."""
-    client = docker.from_env()
-    crossbar_container = client.containers.get('ocs-tests-crossbar')
-    crossbar_container.restart()
-    check_crossbar_connection()


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
This creates integration tests for the Lakeshore425 Agent, using the new `DeviceEmulator`. This runs the LS425 Agent directly, mocking communication with a device via the `DeviceEmulator`.

This makes use of some newly moved upstream testing tools in ocs, so I've also bumped the ocs base image version in the `Dockerfile` here.

@ykyohei You might be interested in this, so I've added you as a reviewer. The one "response" from the Lakeshore425 that I'm a little unsure I'm representing realistically is the response to `OPST?`. Is `001` a realistic response from the device?

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
I wrote these (and the `DeviceEmulator`) while working on issues that came up during #225.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
Tested locally, and now in the CI pipeline.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] Unless I am preparing a release, I have opened this PR onto the `develop` branch.
