### PR TITLE
update LS372 sampling rate

### DIFF
--- a/agents/lakeshore372/LS372_agent.py
+++ b/agents/lakeshore372/LS372_agent.py
@@ -238,7 +238,7 @@ class LS372_Agent:
 
         """
         pm = Pacemaker(10, quantize=True)
-        
+
         with self._acq_proc_lock.acquire_timeout(timeout=0, job='acq') \
              as acq_acquired, \
              self._lock.acquire_timeout(job='acq') as acquired:
@@ -261,7 +261,7 @@ class LS372_Agent:
             self.take_data = True
             while self.take_data:
                 pm.sleep()
-                
+
                 # Relinquish sampling lock occasionally.
                 if time.time() - last_release > 1.:
                     last_release = time.time()

--- a/agents/lakeshore372/LS372_agent.py
+++ b/agents/lakeshore372/LS372_agent.py
@@ -11,7 +11,7 @@ from twisted.internet import reactor
 from socs.Lakeshore.Lakeshore372 import LS372
 
 from ocs import ocs_agent, site_config
-from ocs.ocs_twisted import TimeoutLock
+from ocs.ocs_twisted import TimeoutLock, Pacemaker
 
 
 class YieldingLock:
@@ -237,6 +237,8 @@ class LS372_Agent:
                 }
 
         """
+        pm = Pacemaker(10, quantize=True)
+        
         with self._acq_proc_lock.acquire_timeout(timeout=0, job='acq') \
              as acq_acquired, \
              self._lock.acquire_timeout(job='acq') as acquired:
@@ -258,7 +260,8 @@ class LS372_Agent:
 
             self.take_data = True
             while self.take_data:
-
+                pm.sleep()
+                
                 # Relinquish sampling lock occasionally.
                 if time.time() - last_release > 1.:
                     last_release = time.time()

--- a/socs/Lakeshore/Lakeshore372.py
+++ b/socs/Lakeshore/Lakeshore372.py
@@ -270,10 +270,6 @@ class LS372:
             self.com.send(msg_str)
             resp = ''
 
-        #if 'RDG' in message:
-        #    time.sleep(0.1)  # Instrument sampling rate of 10 readings/s max (pg 34)
-        #else:
-        #    time.sleep(0.061)  # No comms for 61ms after sending message after trial & error (manual says50ms)
         return resp
 
     def get_id(self):

--- a/socs/Lakeshore/Lakeshore372.py
+++ b/socs/Lakeshore/Lakeshore372.py
@@ -258,7 +258,6 @@ class LS372:
             # Try once, if we timeout, try again. Usually gets around single event glitches.
             for attempt in range(2):
                 try:
-                    time.sleep(0.061)
                     resp = str(self.com.recv(4096), 'utf-8').strip()
                     break
                 except socket.timeout:
@@ -271,10 +270,10 @@ class LS372:
             self.com.send(msg_str)
             resp = ''
 
-        if 'RDG' in message:
-            time.sleep(0.1)  # Instrument sampling rate of 10 readings/s max (pg 34)
-        else:
-            time.sleep(0.061)  # No comms for 61ms after sending message after trial & error (manual says50ms)
+        #if 'RDG' in message:
+        #    time.sleep(0.1)  # Instrument sampling rate of 10 readings/s max (pg 34)
+        #else:
+        #    time.sleep(0.061)  # No comms for 61ms after sending message after trial & error (manual says50ms)
         return resp
 
     def get_id(self):

--- a/tests/integration/test_ls372_agent_integration.py
+++ b/tests/integration/test_ls372_agent_integration.py
@@ -119,15 +119,9 @@ def test_ls372_start_acq(wait_for_crossbar, run_agent, client):
     assert resp.status == ocs.OK
     assert resp.session['op_code'] == OpCode.STARTING.value
 
-    # We stopped the process with run_once=True, but that will leave us in the
-    # RUNNING state
     resp = client.acq.status()
-    assert resp.session['op_code'] == OpCode.RUNNING.value
-
-    # Now we request a formal stop, which should put us in STOPPING
-    client.acq.stop()
-    resp = client.acq.status()
-    assert resp.session['op_code'] == OpCode.STOPPING.value
+    assert resp.status == ocs.OK
+    assert resp.session['op_code'] == OpCode.SUCCEEDED.value
 
 
 @pytest.mark.integtest


### PR DESCRIPTION
## Description
Get rid of sleep times in LS372 driver code to increase sampling rate. However, LS372 devices can only readout at a maximum of 10Hz; anything higher and previous points are repeated, so no useful information provided past 10Hz. Implementing Pacemaker in the LS372 agent keeps the device at the maximum sampling rate of 10Hz. 

## Motivation and Context
Initially, LS372's were reading out at ~2Hz (as observed at Princeton). A higher sampling rate was requested. 

## How Has This Been Tested?
Tested on Yale's setup to ensure things don't fail when removing sleep times in driver code. Tested Pacemaker on Yale's setup to ensure 10Hz sampling rate can be deployed. 

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] Unless I am preparing a release, I have opened this PR onto the `develop` branch.
