### PR TITLE
cpa_agent: Cast port to int before device setup

### DIFF
--- a/agents/cryomech_cpa/cryomech_cpa_agent.py
+++ b/agents/cryomech_cpa/cryomech_cpa_agent.py
@@ -45,7 +45,7 @@ def time_limit(seconds):
 class PTC:
     def __init__(self, ip_address, port=502, timeout=10, fake_errors=False):
         self.ip_address = ip_address
-        self.port = port
+        self.port = int(port)
         self.fake_errors = fake_errors
 
         self.model = None


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

Another quick fix on an Agent. I think what's going on here is some recent (>v0.2.0 and <v0.2.0-216...) change in the argument parsing results in a string for the port number, which prevents successful Agent startup. Now we just make sure to cast it appropriately.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Ran into the issue on Agent startup when updating the TSAT system.

```
I am in charge of device with serial number: CPA1114W2FPCE-191105B
2022-01-25T15:49:42+0000 Using OCS version 0.9.0+14.gfdf3025
2022-01-25T15:49:42+0000 ocs: starting <class 'ocs.ocs_agent.OCSAgent'> @ observatory.cryostat_ptc
2022-01-25T15:49:42+0000 log_file is apparently None
2022-01-25T15:49:42+0000 transport connected
2022-01-25T15:49:42+0000 session joined:
SessionDetails(realm="test_realm",
               session=4931374579346516,
               authid="AC6T-PACS-JA6F-TNW4-HL49-LFGY",
               authrole="iocs_agent",
               authmethod="anonymous",
               authprovider="static",
               authextra={'x_cb_node': '3940a8d086fb-1', 'x_cb_worker': 'worker001', 'x_cb_peer': 'tcp4:172.19.0.1:34582', 'x_cb_pid': 18},
               serializer="cbor.batched",
               transport="websocket",
               resumed=None,
               resumable=None,
               resume_token=None)
2022-01-25T15:49:42+0000 startup-op: launching init
2022-01-25T15:49:42+0000 start called for init
2022-01-25T15:49:42+0000 init:0 Status is now "starting".
2022-01-25T15:49:42+0000 init:0 Status is now "starting".
2022-01-25T15:49:42+0000 init:0 CRASH: [Failure instance: Traceback: <class 'TypeError'>: an integer is required (got type str)
/usr/lib/python3.8/threading.py:932:_bootstrap_inner
/usr/lib/python3.8/threading.py:870:run
/usr/local/lib/python3.8/dist-packages/twisted/_threads/_threadworker.py:47:work
/usr/local/lib/python3.8/dist-packages/twisted/_threads/_team.py:181:doWork
--- <exception caught here> ---
/usr/local/lib/python3.8/dist-packages/twisted/python/threadpool.py:238:inContext
/usr/local/lib/python3.8/dist-packages/twisted/python/threadpool.py:254:<lambda>
/usr/local/lib/python3.8/dist-packages/twisted/python/context.py:118:callWithContext
/usr/local/lib/python3.8/dist-packages/twisted/python/context.py:83:callWithContext
cryomech_cpa_agent.py:248:init
cryomech_cpa_agent.py:56:__init__
]
2022-01-25T15:49:42+0000 init:0 Status is now "done".
```

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
Tested a local image on the TSAT system.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] Unless I am preparing a release, I have opened this PR onto the `develop` branch.