### PR TITLE
Fix testing docs API autodoc

### DIFF
--- a/socs/testing/device_emulator.py
+++ b/socs/testing/device_emulator.py
@@ -109,7 +109,7 @@ class DeviceEmulator:
         while self._read:
             if self.ser.in_waiting > 0:
                 msg = self.ser.readline().strip().decode('utf-8')
-                print(f"{msg=}")
+                print(f"msg={msg}")
 
                 if self.responses is None:
                     continue
@@ -120,7 +120,7 @@ class DeviceEmulator:
                     else:
                         response = self.responses[msg]
 
-                    print(f'{response=}')
+                    print(f'response={response}')
                     self.ser.write((response + '\r\n').encode('utf-8'))
                 except Exception as e:
                     print(f"encountered error {e}")


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
This removes some f-string syntactic sugar that I used in this module.

I forget where I picked it up, but pretty sure this is a 3.10 feature. I shouldn't have used it. It's causing the docs build to fail silently on the autodoc of this module.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
I noticed these were broken today.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
Tested a hidden build on rtd.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] Unless I am preparing a release, I have opened this PR onto the `develop` branch.
