### PR TITLE
changes monitor to use Feed.enforce_field_name_rules

### DIFF
--- a/agents/pysmurf_monitor/pysmurf_monitor.py
+++ b/agents/pysmurf_monitor/pysmurf_monitor.py
@@ -7,8 +7,7 @@ import argparse
 from twisted.internet.protocol import DatagramProtocol
 from twisted.internet import reactor
 
-from ocs.agent.aggregator import Provider
-from ocs import ocs_agent, site_config
+from ocs import ocs_agent, site_config, ocs_feed
 
 from socs.db.suprsync import SupRsyncFilesManager, create_file
 
@@ -141,7 +140,7 @@ class PysmurfMonitor(DatagramProtocol):
             val = data['payload']['value']
             val_type = data['payload']['type']
 
-            field_name = Provider._enforce_field_name_rules(path)
+            field_name = ocs_feed.Feed.enforce_field_name_rules(path)
             feed_name = f'{stream_id}_meta'
 
             if feed_name not in self.agent.feeds:


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Pysmurf monitor used to use the old `Provider._enforce_field_name_rules`, but that was recently moved to the  OCS Feed class. This updates the pysmurf-monitor function call.

## Description
<!--- Describe your changes in detail -->
Update the pysmurf-monitor function call of enforce_field_name_rules.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
See above.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
Technically not going to be able to test until Monday, but this seems pretty straightforward.... or I can wait until I actually test it.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [] I have updated the documentation accordingly.
- [ ] Unless I am preparing a release, I have opened this PR onto the `develop` branch.
