### PR TITLE
Create integration tests for the LS240 Agent

### DIFF
--- a/socs/Lakeshore/Lakeshore240.py
+++ b/socs/Lakeshore/Lakeshore240.py
@@ -91,7 +91,7 @@ class Module:
             Return response (within timeout) if message is a query.
         """
         if self.simulator:
-            message_string = "{};".format(msg)
+            message_string = "{}".format(msg)
             self.com.send(message_string.encode())
             resp = ''
             if '?' in msg:
@@ -100,7 +100,7 @@ class Module:
 
         else:
             # Writes message
-            message_string = "{}\r\n;".format(msg).encode()
+            message_string = "{}\r\n".format(msg).encode()
 
             # write(message_string)
             self.com.write(message_string)

--- a/socs/testing/device_emulator.py
+++ b/socs/testing/device_emulator.py
@@ -52,7 +52,8 @@ class DeviceEmulator:
         responses (dict): Current set of responses the DeviceEmulator would give
         default_response (str): Default response to send if a command is
             unrecognized. No response is sent and an error message is logged if
-            set to None. Defaults to None.
+            a command is unrecognized and the default response is set to None.
+            Defaults to None.
 
     """
     def __init__(self, responses):
@@ -183,7 +184,8 @@ class DeviceEmulator:
                 until depleted.
             default_response (str): Default response to send if a command is
                 unrecognized. No response is sent and an error message is logged if
-                set to None. Defaults to None.
+                a command is unrecognized and the default response is set to None.
+                Defaults to None.
 
         Examples:
             The given responses might look like::

--- a/socs/testing/device_emulator.py
+++ b/socs/testing/device_emulator.py
@@ -50,10 +50,14 @@ class DeviceEmulator:
 
     Attributes:
         responses (dict): Current set of responses the DeviceEmulator would give
+        default_response (str): Default response to send if a command is
+            unrecognized. No response is sent and an error message is logged if
+            set to None. Defaults to None.
 
     """
     def __init__(self, responses):
         self.responses = responses
+        self.default_response = None
         self._read = True
 
     @staticmethod
@@ -99,6 +103,34 @@ class DeviceEmulator:
         bkg_read = threading.Thread(name='background', target=self._read_serial)
         bkg_read.start()
 
+    def _get_response(self, msg):
+        """Determine the response to a given message.
+
+        Args:
+            msg (str): Command string to get the response for.
+
+        Returns:
+            str: Response string. Will return None if a valid response is not
+                 found.
+
+        """
+        if self.responses is None:
+            return
+
+        if msg not in self.responses and self.default_response is not None:
+            return self.default_response
+
+        try:
+            if isinstance(self.responses[msg], list):
+                response = self.responses[msg].pop(0)
+            else:
+                response = self.responses[msg]
+        except Exception as e:
+            print(f"encountered error {e}")
+            response = None
+
+        return response
+
     def _read_serial(self):
         """Loop until shutdown, reading any commands sent over the relay.
         Respond immediately to a command with the response in self.responses.
@@ -109,21 +141,16 @@ class DeviceEmulator:
         while self._read:
             if self.ser.in_waiting > 0:
                 msg = self.ser.readline().strip().decode('utf-8')
-                print(f"msg={msg}")
+                print(f"msg='{msg}'")
 
-                if self.responses is None:
+                response = self._get_response(msg)
+
+                if response is None:
                     continue
 
-                try:
-                    if isinstance(self.responses[msg], list):
-                        response = self.responses[msg].pop(0)
-                    else:
-                        response = self.responses[msg]
+                print(f"response='{response}'")
+                self.ser.write((response + '\r\n').encode('utf-8'))
 
-                    print(f'response={response}')
-                    self.ser.write((response + '\r\n').encode('utf-8'))
-                except Exception as e:
-                    print(f"encountered error {e}")
             time.sleep(0.01)
 
     def __del__(self):
@@ -146,7 +173,7 @@ class DeviceEmulator:
     def create_tcp_relay(self):
         pass
 
-    def define_responses(self, responses):
+    def define_responses(self, responses, default_response=None):
         """Define what responses are available to reply with on the configured
         communication relay.
 
@@ -154,6 +181,9 @@ class DeviceEmulator:
             responses (dict): Dictionary of commands: response. Values can be a
                 list, in which case the responses in the list are popped and given in order
                 until depleted.
+            default_response (str): Default response to send if a command is
+                unrecognized. No response is sent and an error message is logged if
+                set to None. Defaults to None.
 
         Examples:
             The given responses might look like::
@@ -163,5 +193,7 @@ class DeviceEmulator:
                                  'RDGFIELD?': ['+1.0E-01', '+1.2E-01', '+1.4E-01']}
 
         """
-        print(f'responses set to {responses}')
+        print(f"responses set to {responses}")
         self.responses = responses
+        print(f"default response set to '{default_response}'")
+        self.default_response = default_response

--- a/tests/default.yaml
+++ b/tests/default.yaml
@@ -23,5 +23,12 @@ hosts:
         ['--mode', 'init'],
         ['--sampling-frequency', 1.],
       ]},
+      {'agent-class': 'Lakeshore240Agent',
+       'instance-id': 'LSA240S',
+       'arguments': [['--serial-number', 'LSA240S'],
+                     ['--mode', 'idle'],
+                     ['--port', './responder'],
+                    ]
+      },
     ]
   }

--- a/tests/integration/test_ls240_agent_integration.py
+++ b/tests/integration/test_ls240_agent_integration.py
@@ -1,0 +1,114 @@
+import time
+import pytest
+
+import ocs
+from ocs.base import OpCode
+
+from ocs.testing import (
+    create_agent_runner_fixture,
+    create_client_fixture,
+)
+
+from integration.util import (
+    create_crossbar_fixture
+)
+
+from socs.testing.device_emulator import create_device_emulator
+
+pytest_plugins = ("docker_compose")
+
+wait_for_crossbar = create_crossbar_fixture()
+run_agent = create_agent_runner_fixture(
+    '../agents/lakeshore240/LS240_agent.py', 'ls240_agent')
+client = create_client_fixture('LSA240S')
+emulator = create_device_emulator({'*IDN?': 'LSCI,MODEL240,LSA240S,1.3',
+                                   'MODNAME?': 'LSA240S',
+                                   'INTYPE? 1': '1,1,0,0,1,1',
+                                   'INNAME? 1': 'Channel 1',
+                                   'INTYPE? 2': '1,1,0,0,1,1',
+                                   'INNAME? 2': 'Channel 2',
+                                   'INTYPE? 3': '1,1,0,0,1,1',
+                                   'INNAME? 3': 'Channel 3',
+                                   'INTYPE? 4': '1,1,0,0,1,1',
+                                   'INNAME? 4': 'Channel 4',
+                                   'INTYPE? 5': '1,1,0,0,1,1',
+                                   'INNAME? 5': 'Channel 5',
+                                   'INTYPE? 6': '1,1,0,0,1,1',
+                                   'INNAME? 6': 'Channel 6',
+                                   'INTYPE? 7': '1,1,0,0,1,1',
+                                   'INNAME? 7': 'Channel 7',
+                                   'INTYPE? 8': '1,1,0,0,1,1',
+                                   'INNAME? 8': 'Channel 8'})
+
+
+@pytest.mark.integtest
+def test_ls240_init_lakeshore(wait_for_crossbar, emulator, run_agent, client):
+    resp = client.init_lakeshore()
+    print(resp)
+    assert resp.status == ocs.OK
+    print(resp.session)
+    assert resp.session['op_code'] == OpCode.SUCCEEDED.value
+
+
+@pytest.mark.integtest
+def test_ls240_start_acq(wait_for_crossbar, emulator, run_agent, client):
+    client.init_lakeshore()
+
+    responses = {'*IDN?': 'LSCI,MODEL240,LSA240S,1.3',
+                 'KRDG? 1': '+1.0E-03',
+                 'SRDG? 1': '+1.0E+03',
+                 'KRDG? 2': '+1.0E-03',
+                 'SRDG? 2': '+1.0E+03',
+                 'KRDG? 3': '+1.0E-03',
+                 'SRDG? 3': '+1.0E+03',
+                 'KRDG? 4': '+1.0E-03',
+                 'SRDG? 4': '+1.0E+03',
+                 'KRDG? 5': '+1.0E-03',
+                 'SRDG? 5': '+1.0E+03',
+                 'KRDG? 6': '+1.0E-03',
+                 'SRDG? 6': '+1.0E+03',
+                 'KRDG? 7': '+1.0E-03',
+                 'SRDG? 7': '+1.0E+03',
+                 'KRDG? 8': '+1.0E-03',
+                 'SRDG? 8': '+1.0E+03'}
+    emulator.define_responses(responses)
+
+    resp = client.acq.start(sampling_frequency=1.0)
+    assert resp.status == ocs.OK
+    assert resp.session['op_code'] == OpCode.STARTING.value
+
+    # We stopped the process with run_once=True, but that will leave us in the
+    # RUNNING state
+    resp = client.acq.status()
+    assert resp.session['op_code'] == OpCode.RUNNING.value
+
+    # Now we request a formal stop, which should put us in STOPPING
+    client.acq.stop()
+    # this is so we get through the acq loop and actually get a stop command in
+    # TODO: get sleep_time in the acq process to be small for testing
+    time.sleep(3)
+    resp = client.acq.status()
+    print(resp)
+    print(resp.session)
+    assert resp.session['op_code'] in [OpCode.STOPPING.value,
+                                       OpCode.SUCCEEDED.value]
+
+
+@pytest.mark.integtest
+def test_ls240_set_values(wait_for_crossbar, emulator, run_agent, client):
+    client.init_lakeshore()
+
+    responses = {'INNAME 1,Channel 01': '',
+                 'INTYPE 1,1,1,0,0,1,1': ''}
+    emulator.define_responses(responses)
+
+    resp = client.set_values(channel=1,
+                             sensor=1,
+                             auto_range=1,
+                             range=0,
+                             current_reversal=0,
+                             units=1,
+                             enabled=1,
+                             name="Channel 01")
+    assert resp.status == ocs.OK
+    assert resp.session['op_code'] == OpCode.SUCCEEDED.value


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Create integration tests for all of the LS240 Agent's Tasks/Processes. In doing so I removed a trailing semi-colon that has been included in commands sent to the 240. This can be used as a delimiter to send multiple commands at once, but we aren't doing that, so for consistency with other Lakeshore device code in socs I've removed it.

I also added a feature to the Device Emulator which allows you to set a default response to get back if the command is unrecognized, this is convenient here when sending lots of commands (i.e. not queries) where we would expect to just get back empty strings.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Expanding test coverage. Also, this is the only other Agent that communicates over serial, and after getting the Device Emulator written I wanted to write tests for it. https://github.com/simonsobs/socs/pull/232 also would have been caught earlier had we had this testing in place.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
I've run the tests locally. I've also tested a local build of the 240 Agent image with actual hardware, just to double check that the trailing semi-colon change didn't affect anything.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] Unless I am preparing a release, I have opened this PR onto the `develop` branch.