### PR TITLE
Fix flaky ls372 acq test

### DIFF
--- a/tests/integration/test_ls372_agent_integration.py
+++ b/tests/integration/test_ls372_agent_integration.py
@@ -119,6 +119,7 @@ def test_ls372_start_acq(wait_for_crossbar, run_agent, client):
     assert resp.status == ocs.OK
     assert resp.session['op_code'] == OpCode.STARTING.value
 
+    client.acq.wait()
     resp = client.acq.status()
     assert resp.status == ocs.OK
     assert resp.session['op_code'] == OpCode.SUCCEEDED.value


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
This test occasionally would fail due to it taking longer than typical to run through the acq process. Add a wait to ensure it's done before checking the OpCode. This is fine since we're in the test mode "run_once".

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
On the recent merge to develop the first run failed with:
```
============================= test session starts ==============================
platform linux -- Python 3.8.12, pytest-7.0.0, pluggy-1.0.0
rootdir: /home/runner/work/socs/socs/tests, configfile: pytest.ini
plugins: docker-compose-3.2.1, dependency-0.5.1, cov-3.0.0, twisted-1.13.4, order-1.0.1
collected 91 items / 64 deselected / 27 selected

integration/test_ls372_agent_integration.py ....F...............         [ 74%]
integration/test_ls425_agent_integration.py .......                      [100%]

=================================== FAILURES ===================================
_____________________________ test_ls372_start_acq _____________________________

wait_for_crossbar = None, run_agent = None
client = <ocs.matched_client.MatchedClient object at 0x7efea4a87070>

    @pytest.mark.integtest
    def test_ls372_start_acq(wait_for_crossbar, run_agent, client):
        client.init_lakeshore()
        resp = client.acq.start(sample_heater=False, run_once=True)
        assert resp.status == ocs.OK
        assert resp.session['op_code'] == OpCode.STARTING.value

        resp = client.acq.status()
        assert resp.status == ocs.OK
>       assert resp.session['op_code'] == OpCode.SUCCEEDED.value
E       assert 3 == 5
E        +  where 5 = <OpCode.SUCCEEDED: 5>.value
E        +    where <OpCode.SUCCEEDED: 5> = OpCode.SUCCEEDED

integration/test_ls372_agent_integration.py:124: AssertionError
```

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
Run locally. We'll see output in this PR's tests as well.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] Unless I am preparing a release, I have opened this PR onto the `develop` branch.
