### PR TITLE
Replace --auto-acquire with --mode in 372 Agent

### DIFF
--- a/agents/lakeshore372/LS372_agent.py
+++ b/agents/lakeshore372/LS372_agent.py
@@ -989,7 +989,6 @@ def make_parser(parser=None):
     pgroup = parser.add_argument_group('Agent Options')
     pgroup.add_argument('--ip-address')
     pgroup.add_argument('--serial-number')
-    pgroup.add_argument('--mode')
     pgroup.add_argument('--fake-data', type=int, default=0,
                         help='Set non-zero to fake data, without hardware.')
     pgroup.add_argument('--dwell-time-delay', type=int, default=0,
@@ -1001,8 +1000,9 @@ def make_parser(parser=None):
                               second if it is set longer than a channel's dwell\
                               time. This ensures at least one second of data\
                               collection at the end of a scan.")
-    pgroup.add_argument('--auto-acquire', action='store_true',
-                        help='Automatically start data acquisition on startup')
+    pgroup.add_argument('--mode', type=str, default='acq',
+                        choices=['idle', 'init', 'acq'],
+                        help="Starting action for the Agent.")
     pgroup.add_argument('--sample-heater', type=bool, default=False,
                         help='Record sample heater output during acquisition.')
     pgroup.add_argument('--enable-control-chan', action='store_true',
@@ -1023,7 +1023,10 @@ if __name__ == '__main__':
 
     # Automatically acquire data if requested (default)
     init_params = False
-    if args.auto_acquire:
+    if args.mode == 'init':
+        init_params = {'auto_acquire': False,
+                       'acq_params': {'sample_heater': args.sample_heater}}
+    elif args.mode == 'acq':
         init_params = {'auto_acquire': True,
                        'acq_params': {'sample_heater': args.sample_heater}}
 

--- a/docs/agents/lakeshore372.rst
+++ b/docs/agents/lakeshore372.rst
@@ -34,7 +34,7 @@ configuration block::
    'arguments': [['--serial-number', 'LSA22YG'],
                  ['--ip-address', '10.10.10.2'],
                  ['--dwell-time-delay', 0],
-                 ['--auto-acquire'],
+                 ['--mode', 'acq'],
                  ['--sample-heater', False],
                  ['--enable-control-chan']]},
 

--- a/tests/default.yaml
+++ b/tests/default.yaml
@@ -15,7 +15,8 @@ hosts:
        'arguments': [['--serial-number', 'LSASIM'],
                      ['--ip-address', '127.0.0.1'],
                      ['--dwell-time-delay', 0],
-                     ['--sample-heater', False]]},
+                     ['--sample-heater', False],
+                     ['--mode', 'init']]},
       {'agent-class': 'Lakeshore425Agent',
       'instance-id': 'LS425',
       'arguments': [


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->
This matches the 240 Agent, allows slightly more control, and now defaults to acquiring data. The problem with the old flag was that if it was missing from a config file the Agent wouldn't start acquiring. Acquire by default is a requested feature and should be the default.

This will require some updates to user configs if they've updated socs since --auto-acquire was implemented, we should warn about that in the release notes. (I'm planning on making a long over-due release of socs after this is merged.)

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
When users would update they'd typically be missing this flag, would not see data in Grafana, and would report the Agent as broken and downgrade. We should acquire by default.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
Tested locally with the integration tests.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] Unless I am preparing a release, I have opened this PR onto the `develop` branch.
