### PR TITLE
Fix npy extension issue

### DIFF
--- a/agents/pysmurf_monitor/pysmurf_monitor.py
+++ b/agents/pysmurf_monitor/pysmurf_monitor.py
@@ -173,6 +173,8 @@ class PysmurfMonitor(DatagramProtocol):
                 archive_name = meta.get('archive_name', 'smurf')
                 try:
                     local_path = meta['path']
+                    if (meta['format']  == 'npy') and (not meta['path'].endswith('.npy')):
+                        local_path += '.npy'
                     remote_path = create_remote_path(meta, archive_name)
 
                     # Only delete files that are in timestamped directories

--- a/agents/pysmurf_monitor/pysmurf_monitor.py
+++ b/agents/pysmurf_monitor/pysmurf_monitor.py
@@ -172,9 +172,9 @@ class PysmurfMonitor(DatagramProtocol):
                 # archive_name to "timestreams"
                 archive_name = meta.get('archive_name', 'smurf')
                 try:
-                    local_path = meta['path']
                     if (meta['format']  == 'npy') and (not meta['path'].endswith('.npy')):
-                        local_path += '.npy'
+                        meta['path'] += '.npy'
+                    local_path = meta['path']
                     remote_path = create_remote_path(meta, archive_name)
 
                     # Only delete files that are in timestamped directories


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
This should fix a small bug in the pysmurf-monitor where numpy files that were registered without the `.npy` extension were not being added to the database correctly. This is because numpy will automatically add that extension if it doesn't exist, meaning the registered file path is not the same as the real file path.

The monitor used to catch this and fix it, but looks like I missed that when I was restructuring the agent. This adds it back.

## Description
<!--- Describe your changes in detail -->
Catches for npy files without the .npy extension.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
We need to archive tunefiles

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
Not tested yet, but can test later this week on k2so (or maybe @kmharrington can test before then?)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] Unless I am preparing a release, I have opened this PR onto the `develop` branch.
