### PR TITLE
Add TCP relay to device emulator

### DIFF
--- a/socs/testing/device_emulator.py
+++ b/socs/testing/device_emulator.py
@@ -6,7 +6,7 @@ import pytest
 import threading
 
 
-def create_device_emulator(responses, relay_type='serial'):
+def create_device_emulator(responses, relay_type):
     """Create a device emulator fixture.
 
     This provides a device emulator that can be used to mock a device during

--- a/socs/testing/device_emulator.py
+++ b/socs/testing/device_emulator.py
@@ -1,4 +1,5 @@
 import serial
+import socket
 import time
 import subprocess
 import shutil
@@ -6,7 +7,7 @@ import pytest
 import threading
 
 
-def create_device_emulator(responses, relay_type):
+def create_device_emulator(responses, relay_type, port=9001):
     """Create a device emulator fixture.
 
     This provides a device emulator that can be used to mock a device during
@@ -15,8 +16,9 @@ def create_device_emulator(responses, relay_type):
     Args:
         responses (dict): Dictionary with commands as keys, and responses as
             values. See :class:`.DeviceEmulator` for details.
-        relay_type (str): Currently only 'serial' is implemented. A TCP type
-            will be introduced in future versions.
+        relay_type (str): Communication relay type. Either 'serial' or 'tcp'.
+        port (int): Port for the TCP relay to listen for connections on.
+            Defaults to 9001. Only used if relay_type is 'tcp'.
 
     Returns:
         function:
@@ -24,14 +26,18 @@ def create_device_emulator(responses, relay_type):
             type.
 
     """
-    if relay_type != 'serial':
+    if relay_type not in ['serial', 'tcp']:
         raise NotImplementedError(f"relay_type '{relay_type}' is not" +
                                   "implemented or is an invalid type")
 
     @pytest.fixture()
     def create_device():
         device = DeviceEmulator(responses)
-        device.create_serial_relay()
+
+        if relay_type == 'serial':
+            device.create_serial_relay()
+        elif relay_type == 'tcp':
+            device.create_tcp_relay(port)
 
         yield device
 
@@ -49,16 +55,21 @@ class DeviceEmulator:
             startup, if any.
 
     Attributes:
-        responses (dict): Current set of responses the DeviceEmulator would give
+        responses (dict): Current set of responses the DeviceEmulator would
+            give
         default_response (str): Default response to send if a command is
             unrecognized. No response is sent and an error message is logged if
             a command is unrecognized and the default response is set to None.
             Defaults to None.
+        _type (str): Relay type, either 'serial' or 'tcp'.
+        _read (bool): Used to stop the background reading of data recieved on
+            the relay.
 
     """
     def __init__(self, responses):
         self.responses = responses
         self.default_response = None
+        self._type = None
         self._read = True
 
     @staticmethod
@@ -95,6 +106,7 @@ class DeviceEmulator:
         object within a given test.
 
         """
+        self._type = 'serial'
         self.proc = self._setup_socat()
         self.ser = serial.Serial(
             './internal',
@@ -166,13 +178,66 @@ class DeviceEmulator:
         #print('shutting down background reading')
         self._read = False
         time.sleep(1)
-        #print('shutting down socat relay')
-        self.proc.terminate()
-        out, err = self.proc.communicate()
-        #print(out, err)
+        if self._type == 'serial':
+            #print('shutting down socat relay')
+            self.proc.terminate()
+            out, err = self.proc.communicate()
+            #print(out, err)
 
-    def create_tcp_relay(self):
-        pass
+    def _read_socket(self, port):
+        """Loop until shutdown, reading any commands sent over the relay.
+        Respond immediately to a command with the response in self.responses.
+
+        Args:
+            port (int): Port for the TCP relay to listen for connections on.
+
+        """
+        self._read = True
+
+        # Listen for connections
+        sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+        sock.bind(('127.0.0.1', port))
+        sock.listen(1)
+        print("Device emulator waiting for tcp client connection")
+        conn, client_address = sock.accept()
+        print(f"Client connection made from {client_address}")
+
+        while self._read:
+            msg = conn.recv(4096).strip().decode('utf-8')
+            if msg:
+                print(f"msg='{msg}'")
+
+                response = self._get_response(msg)
+
+                if response is None:
+                    continue
+
+                print(f"response='{response}'")
+                conn.sendall((response).encode('utf-8'))
+
+            time.sleep(0.01)
+
+        conn.close()
+        sock.close()
+
+    def create_tcp_relay(self, port):
+        """Create the TCP relay, emulating a hardware device connected over
+        TCP.
+
+        Creates a thread to read commands sent to the TCP relay in the
+        background. This allows responses to be defined within a test using
+        DeviceEmulator.define_responses() after instantiation of the
+        DeviceEmulator object within a given test.
+
+        Args:
+            port (int): Port for the TCP relay to listen for connections on.
+
+        """
+        self._type = 'tcp'
+        bkg_read = threading.Thread(name='background',
+                                    target=self._read_socket,
+                                    kwargs={'port': port})
+        bkg_read.start()
 
     def define_responses(self, responses, default_response=None):
         """Define what responses are available to reply with on the configured
@@ -180,12 +245,12 @@ class DeviceEmulator:
 
         Args:
             responses (dict): Dictionary of commands: response. Values can be a
-                list, in which case the responses in the list are popped and given in order
-                until depleted.
+                list, in which case the responses in the list are popped and
+                given in order until depleted.
             default_response (str): Default response to send if a command is
-                unrecognized. No response is sent and an error message is logged if
-                a command is unrecognized and the default response is set to None.
-                Defaults to None.
+                unrecognized. No response is sent and an error message is
+                logged if a command is unrecognized and the default response is
+                set to None. Defaults to None.
 
         Examples:
             The given responses might look like::

--- a/tests/integration/test_ls240_agent_integration.py
+++ b/tests/integration/test_ls240_agent_integration.py
@@ -21,24 +21,26 @@ wait_for_crossbar = create_crossbar_fixture()
 run_agent = create_agent_runner_fixture(
     '../agents/lakeshore240/LS240_agent.py', 'ls240_agent')
 client = create_client_fixture('LSA240S')
-emulator = create_device_emulator({'*IDN?': 'LSCI,MODEL240,LSA240S,1.3',
-                                   'MODNAME?': 'LSA240S',
-                                   'INTYPE? 1': '1,1,0,0,1,1',
-                                   'INNAME? 1': 'Channel 1',
-                                   'INTYPE? 2': '1,1,0,0,1,1',
-                                   'INNAME? 2': 'Channel 2',
-                                   'INTYPE? 3': '1,1,0,0,1,1',
-                                   'INNAME? 3': 'Channel 3',
-                                   'INTYPE? 4': '1,1,0,0,1,1',
-                                   'INNAME? 4': 'Channel 4',
-                                   'INTYPE? 5': '1,1,0,0,1,1',
-                                   'INNAME? 5': 'Channel 5',
-                                   'INTYPE? 6': '1,1,0,0,1,1',
-                                   'INNAME? 6': 'Channel 6',
-                                   'INTYPE? 7': '1,1,0,0,1,1',
-                                   'INNAME? 7': 'Channel 7',
-                                   'INTYPE? 8': '1,1,0,0,1,1',
-                                   'INNAME? 8': 'Channel 8'})
+
+initial_responses = {'*IDN?': 'LSCI,MODEL240,LSA240S,1.3',
+                     'MODNAME?': 'LSA240S',
+                     'INTYPE? 1': '1,1,0,0,1,1',
+                     'INNAME? 1': 'Channel 1',
+                     'INTYPE? 2': '1,1,0,0,1,1',
+                     'INNAME? 2': 'Channel 2',
+                     'INTYPE? 3': '1,1,0,0,1,1',
+                     'INNAME? 3': 'Channel 3',
+                     'INTYPE? 4': '1,1,0,0,1,1',
+                     'INNAME? 4': 'Channel 4',
+                     'INTYPE? 5': '1,1,0,0,1,1',
+                     'INNAME? 5': 'Channel 5',
+                     'INTYPE? 6': '1,1,0,0,1,1',
+                     'INNAME? 6': 'Channel 6',
+                     'INTYPE? 7': '1,1,0,0,1,1',
+                     'INNAME? 7': 'Channel 7',
+                     'INTYPE? 8': '1,1,0,0,1,1',
+                     'INNAME? 8': 'Channel 8'}
+emulator = create_device_emulator(initial_responses, relay_type='serial')
 
 
 @pytest.mark.integtest

--- a/tests/integration/test_ls425_agent_integration.py
+++ b/tests/integration/test_ls425_agent_integration.py
@@ -32,7 +32,8 @@ run_agent = create_agent_runner_fixture(
 run_agent_acq = create_agent_runner_fixture(
     '../agents/lakeshore425/LS425_agent.py', 'ls425_agent', args=['--mode', 'acq'])
 client = create_client_fixture('LS425')
-emulator = create_device_emulator({'*IDN?': 'LSCI,MODEL425,LSA425T,1.3'})
+emulator = create_device_emulator({'*IDN?': 'LSCI,MODEL425,LSA425T,1.3'},
+                                  relay_type='serial')
 
 
 @pytest.mark.integtest

--- a/tests/test_device_emulator.py
+++ b/tests/test_device_emulator.py
@@ -1,0 +1,29 @@
+import time
+import socket
+import pytest
+
+from socs.testing import device_emulator
+
+
+tcp_emulator = device_emulator.create_device_emulator({'ping': 'pong'},
+                                                      'tcp', 9001)
+
+
+def test_create_device_emulator_invalid_type():
+    with pytest.raises(NotImplementedError):
+        device_emulator.create_device_emulator({}, relay_type='test')
+
+
+def test_create_device_emulator_tcp_relay(tcp_emulator):
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
+        # Connection might not work on first attempt
+        for i in range(5):
+            try:
+                s.connect(('127.0.0.1', 9001))
+                break
+            except ConnectionRefusedError:
+                print("Could not connect, waiting and trying again.")
+                time.sleep(1)
+        s.sendall(b'ping')
+        data = s.recv(1024).decode()
+    assert data == 'pong'


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->
This PR adds the TCP relay to the device emulator, for testing Agents that connect to their associated hardware via TCP.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Many Agents use TCP to connect to their associated hardware. I worked on adding this TCP relay in the context of testing the Pfeiffer TC400 Agent in #149.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
I wrote a couple of simple tests included in this PR, but also I've used this on a branch I'm working on to finish up the work in #149. There I have the device emulator responding with TC400 like responses, emulating connecting to a serial to Ethernet converter.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] Unless I am preparing a release, I have opened this PR onto the `develop` branch.