### PR TITLE
pip install socs directly from socs repo in pysmurf-controller image

### DIFF
--- a/agents/pysmurf_controller/Dockerfile
+++ b/agents/pysmurf_controller/Dockerfile
@@ -3,9 +3,7 @@ FROM simonsobs/sodetlib:v0.3.0-101-gccbc921
 WORKDIR /app
 
 # SOCS installation
-RUN git clone https://github.com/simonsobs/socs.git \
-    && pip3 install -r socs/requirements.txt \
-    && pip3 install -e socs
+RUN python3 -m pip install -e git+https://github.com/simonsobs/socs.git#egg=socs
 
 ENV OCS_CONFIG_DIR /config
 

--- a/agents/pysmurf_controller/Dockerfile
+++ b/agents/pysmurf_controller/Dockerfile
@@ -3,7 +3,7 @@ FROM simonsobs/sodetlib:v0.3.0-101-gccbc921
 WORKDIR /app
 
 # SOCS installation
-RUN python3 -m pip install -e git+https://github.com/simonsobs/socs.git#egg=socs
+RUN python3 -m pip install --src=/app/ -e git+https://github.com/simonsobs/socs.git#egg=socs
 
 ENV OCS_CONFIG_DIR /config
 


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->
This effectively replaces installing dependencies via requirements.txt with those specified in setup.py. This avoids installing so3g, which we don't need here, and which doesn't support python3.6, which is what the sodetlib image is on.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
#257 added so3g to the requirements file, which [broke](https://github.com/simonsobs/socs/runs/5305731607?check_suite_focus=true) the pysmurf-controller image build.

```
Collecting so3g (from -r socs/requirements/testing.txt (line 6))
  Could not find a version that satisfies the requirement so3g (from -r socs/requirements/testing.txt (line 6)) (from versions: )
No matching distribution found for so3g (from -r socs/requirements/testing.txt (line 6))
The command '/bin/sh -c git clone https://github.com/simonsobs/socs.git     && pip3 install -r socs/requirements.txt     && pip3 install -e socs' returned a non-zero code: 1
Service 'ocs-pysmurf-agent' failed to build : Build failed
```

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
I'm able to build the image locally now, however it would be good to test it runs alright on a system.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] Unless I am preparing a release, I have opened this PR onto the `develop` branch.
