### PR TITLE
Update FTS aerotech agent to work with multiple different FTSes

### DIFF
--- a/docs/agents/fts_agent.rst
+++ b/docs/agents/fts_agent.rst
@@ -31,7 +31,7 @@ the available arguments::
         'arguments': [
           ['--ip-address', '192.168.10.13'],
           ['--port', 8000],
-	  ['--config_file', 'fts_config.yaml'],
+          ['--config_file', 'fts_config.yaml'],
           ['--mode', 'acq'],
           ['--sampling_freqency', 1'],
           ]},
@@ -42,10 +42,10 @@ fts-config
 The FTS takes a separate YAML config file to specify some inner paramters. Here
 is an example using all the available arguments.::
 
-	translate: [1, 74.87]
-	limits: [-74.8, 74.8]
-	speed: 10
-	timeout: 10
+    translate: [1, 74.87]
+    limits: [-74.8, 74.8]
+    speed: 10
+    timeout: 10
 
 Example Client
 --------------

--- a/docs/agents/fts_agent.rst
+++ b/docs/agents/fts_agent.rst
@@ -31,9 +31,21 @@ the available arguments::
         'arguments': [
           ['--ip-address', '192.168.10.13'],
           ['--port', 8000],
+	  ['--config_file', 'fts_config.yaml'],
           ['--mode', 'acq'],
           ['--sampling_freqency', 1'],
           ]},
+
+
+fts-config
+``````````
+The FTS takes a separate YAML config file to specify some inner paramters. Here
+is an example using all the available arguments.::
+
+	translate: [1, 74.87]
+	limits: [-74.8, 74.8]
+	speed: 10
+	timeout: 10
 
 Example Client
 --------------


### PR DESCRIPTION
## Description
Updates fts_aerotech_agent to work with an inputted .YAML config file stored in $OCS_CONFIG_DIR. This config includes some FTS-specific parameters which vary depending on the FTS used or the type of data being taken.

## Motivation and Context

Originally the FTS params were hard-coded in before the class definition. Making the params configurable from a YAML file creates flexibility if they need to change and is necessary since we now have two different FTSes in use.

## How Has This Been Tested?

Awhile back I tested the changes in the LATRt test environment and I was able to work both Uchicago's original FTS and the one we were sending to UCSD with this branch. Admittedly I haven't tested this in awhile though and it could be that things are broken with updated socs. And I haven't used any official test suites.


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] Unless I am preparing a release, I have opened this PR onto the `develop` branch.
