### PR TITLE
Scpi psu monitor update

### DIFF
--- a/agents/scpi_psu/scpi_psu_agent.py
+++ b/agents/scpi_psu/scpi_psu_agent.py
@@ -57,18 +57,17 @@ class ScpiPsuAgent:
             Args:
                 wait (float, optional):
                     time to wait between measurements [seconds].
-                    
-                channels (integer list, optional):
-                    channels to monitor [monitors all channels by default]
+                channels (list[int], optional):
+                    channels to monitor. [1, 2, 3] by default.
         """
         if params is None:
             params = {}
 
         wait_time = params.get('wait', 1)
-        channels = params.get('channels', [1,2,3])
-        
+        channels = params.get('channels', [1, 2, 3])
+
         self.monitor = True
-        
+
         while self.monitor:
             with self.lock.acquire_timeout(1) as acquired:
                 if acquired:

--- a/agents/scpi_psu/scpi_psu_agent.py
+++ b/agents/scpi_psu/scpi_psu_agent.py
@@ -57,14 +57,18 @@ class ScpiPsuAgent:
             Args:
                 wait (float, optional):
                     time to wait between measurements [seconds].
+                    
+                channels (integer list, optional):
+                    channels to monitor [monitors all channels by default]
         """
         if params is None:
             params = {}
 
         wait_time = params.get('wait', 1)
-
+        channels = params.get('channels', [1,2,3])
+        
         self.monitor = True
-
+        
         while self.monitor:
             with self.lock.acquire_timeout(1) as acquired:
                 if acquired:
@@ -74,7 +78,7 @@ class ScpiPsuAgent:
                         'data': {}
                     }
 
-                    for chan in [1, 2, 3]:
+                    for chan in channels:
                         data['data']["Voltage_{}".format(chan)] = self.psu.get_volt(chan)
                         data['data']["Current_{}".format(chan)] = self.psu.get_curr(chan)
 


### PR DESCRIPTION

Added ability to monitor subset of channels
<!--- Provide a general summary of your changes in the Title above -->

## Description
I added a line to parse the parameters of the start_monitor function for a list of specific channels to monitor, instead of the function monitoring all channels only. By default, if no channels are specified, the function works in the same way it did before the change.
<!--- Describe your changes in detail -->

## Motivation and Context
In some circumstances, trying to monitor all channels will crash the agent because the psu won't respond to messages requesting the voltage/current on that channel. This causes the socket to timeout on the socket.read() call in the PrologixInterface class. This occurred when one channel on the psu was set to "in series" mode. By allowing the user to specify which channels to monitor, we can avoid this problem by just not monitoring the problem channel. 
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
This was tested using a local image in the UCSD lab. I tested monitoring a single channel.
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] Unless I am preparing a release, I have opened this PR onto the `develop` branch.
