### PR TITLE
Replace ls372 simulator with device emulator in integration tests

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -47,10 +47,6 @@ jobs:
         docker-compose build socs
 
     # Integration Tests
-    - name: Build images for integration tests
-      run: |
-        docker-compose build ocs-lakeshore372-simulator
-
     - name: Run integration tests
       working-directory: ./tests
       run: |

--- a/.github/workflows/develop.yml
+++ b/.github/workflows/develop.yml
@@ -52,10 +52,6 @@ jobs:
         docker-compose build socs
 
     # Integration Tests
-    - name: Build images for integration tests
-      run: |
-        docker-compose build ocs-lakeshore372-simulator
-
     - name: Run integration tests
       working-directory: ./tests
       run: |

--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -49,10 +49,6 @@ jobs:
         docker-compose build socs
 
     # Integration Tests
-    - name: Build images for integration tests
-      run: |
-        docker-compose build ocs-lakeshore372-simulator
-
     - name: Run integration tests
       working-directory: ./tests
       run: |

--- a/tests/default.yaml
+++ b/tests/default.yaml
@@ -16,7 +16,7 @@ hosts:
                      ['--ip-address', '127.0.0.1'],
                      ['--dwell-time-delay', 0],
                      ['--sample-heater', False],
-                     ['--mode', 'init']]},
+                     ['--mode', 'idle']]},
       {'agent-class': 'Lakeshore425Agent',
       'instance-id': 'LS425',
       'arguments': [

--- a/tests/docker-compose.yml
+++ b/tests/docker-compose.yml
@@ -8,8 +8,3 @@ services:
       - ./config.json:/app/crossbar/config.json
     environment:
          - PYTHONUNBUFFERED=1
-
-  ocs-LS372:
-    image: ocs-lakeshore372-simulator
-    ports:
-      - "7777:7777"

--- a/tests/integration/test_ls372_agent_integration.py
+++ b/tests/integration/test_ls372_agent_integration.py
@@ -7,6 +7,8 @@ from ocs.testing import create_agent_runner_fixture, create_client_fixture
 
 from integration.util import create_crossbar_fixture
 
+from socs.testing.device_emulator import create_device_emulator
+
 pytest_plugins = ("docker_compose")
 
 # Set the OCS_CONFIG_DIR so we read the local default.yaml file always
@@ -19,6 +21,40 @@ run_agent = create_agent_runner_fixture(
 client = create_client_fixture('LSASIM')
 wait_for_crossbar = create_crossbar_fixture()
 
+def build_init_responses():
+    values = {'*IDN?': 'LSCI,MODEL372,LSASIM,1.3',
+              'SCAN?': '01,1',
+              'INSET? A': '0,010,003,00,1',
+              'INNAME? A': 'Input A',
+              'INTYPE? A': '1,04,0,15,0,2',
+              'TLIMIT? A': '+0000',
+              'OUTMODE? 0': '2,6,1,0,0,001',
+              'HTRSET? 0': '+120.000,8,+0000.00,1',
+              'OUTMODE? 2': '4,16,1,0,0,001',
+              'HTRSET? 2': '+120.000,8,+0000.00,1'}
+
+    for i in range(1, 17):
+        values[f'INSET? {i}'] = '1,007,003,21,1'
+        values[f'INNAME? {i}'] = f'Channel {i:02}'
+        values[f'INTYPE? {i}'] = '0,07,1,10,0,1'
+        values[f'TLIMIT? {i}'] = '+0000'
+
+    # Heaters
+    values.update({'RANGE? 0': '0',
+                   'RANGE? 2': '1',
+                   'STILL?': '+10.60',
+                   'HTR?': '+00.0005E+00'})
+
+    # Senor readings
+    values.update({'KRDG? 1': '+293.873E+00',
+                   'SRDG? 1': '+108.278E+00',
+                   'KRDG? A': '+00.0000E-03',
+                   'SRDG? A': '+000.000E+09'})
+
+    return values
+
+emulator = create_device_emulator(build_init_responses(), relay_type='tcp', port=7777)
+
 
 @pytest.mark.integtest
 def test_testing(wait_for_crossbar):
@@ -27,7 +63,7 @@ def test_testing(wait_for_crossbar):
 
 
 @pytest.mark.integtest
-def test_ls372_init_lakeshore(wait_for_crossbar, run_agent, client):
+def test_ls372_init_lakeshore(wait_for_crossbar, emulator, run_agent, client):
     resp = client.init_lakeshore()
     # print(resp)
     assert resp.status == ocs.OK
@@ -36,7 +72,7 @@ def test_ls372_init_lakeshore(wait_for_crossbar, run_agent, client):
 
 
 @pytest.mark.integtest
-def test_ls372_enable_control_chan(wait_for_crossbar, run_agent, client):
+def test_ls372_enable_control_chan(wait_for_crossbar, emulator, run_agent, client):
     client.init_lakeshore()
     resp = client.enable_control_chan()
     assert resp.status == ocs.OK
@@ -44,7 +80,7 @@ def test_ls372_enable_control_chan(wait_for_crossbar, run_agent, client):
 
 
 @pytest.mark.integtest
-def test_ls372_disable_control_chan(wait_for_crossbar, run_agent, client):
+def test_ls372_disable_control_chan(wait_for_crossbar, emulator, run_agent, client):
     client.init_lakeshore()
     resp = client.disable_control_chan()
     assert resp.status == ocs.OK
@@ -52,7 +88,7 @@ def test_ls372_disable_control_chan(wait_for_crossbar, run_agent, client):
 
 
 @pytest.mark.integtest
-def test_ls372_start_acq(wait_for_crossbar, run_agent, client):
+def test_ls372_start_acq(wait_for_crossbar, emulator, run_agent, client):
     client.init_lakeshore()
     resp = client.acq.start(sample_heater=False, run_once=True)
     assert resp.status == ocs.OK
@@ -65,7 +101,7 @@ def test_ls372_start_acq(wait_for_crossbar, run_agent, client):
 
 
 @pytest.mark.integtest
-def test_ls372_set_heater_range(wait_for_crossbar, run_agent, client):
+def test_ls372_set_heater_range(wait_for_crossbar, emulator, run_agent, client):
     client.init_lakeshore()
     resp = client.set_heater_range(range=1e-3, heater='sample', wait=0)
     assert resp.status == ocs.OK
@@ -73,7 +109,7 @@ def test_ls372_set_heater_range(wait_for_crossbar, run_agent, client):
 
 
 @pytest.mark.integtest
-def test_ls372_set_excitation_mode(wait_for_crossbar, run_agent, client):
+def test_ls372_set_excitation_mode(wait_for_crossbar, emulator, run_agent, client):
     client.init_lakeshore()
     resp = client.set_excitation_mode(channel=1, mode='current')
     assert resp.status == ocs.OK
@@ -81,7 +117,7 @@ def test_ls372_set_excitation_mode(wait_for_crossbar, run_agent, client):
 
 
 @pytest.mark.integtest
-def test_ls372_set_excitation(wait_for_crossbar, run_agent, client):
+def test_ls372_set_excitation(wait_for_crossbar, emulator, run_agent, client):
     client.init_lakeshore()
     resp = client.set_excitation(channel=1, value=1e-9)
     assert resp.status == ocs.OK
@@ -89,17 +125,16 @@ def test_ls372_set_excitation(wait_for_crossbar, run_agent, client):
 
 
 @pytest.mark.integtest
-def test_ls372_get_excitation(wait_for_crossbar, run_agent, client):
+def test_ls372_get_excitation(wait_for_crossbar, emulator, run_agent, client):
     client.init_lakeshore()
-    client.set_excitation(channel=1, value=1e-9)
     resp = client.get_excitation(channel=1)
     assert resp.status == ocs.OK
     assert resp.session['op_code'] == OpCode.SUCCEEDED.value
-    assert resp.session['data']['excitation'] == 1e-9
+    assert resp.session['data']['excitation'] == 2e-3
 
 
 @pytest.mark.integtest
-def test_ls372_set_resistance_range(wait_for_crossbar, run_agent, client):
+def test_ls372_set_resistance_range(wait_for_crossbar, emulator, run_agent, client):
     client.init_lakeshore()
     resp = client.set_resistance_range(channel=1, resistance_range=2)
     assert resp.status == ocs.OK
@@ -107,17 +142,17 @@ def test_ls372_set_resistance_range(wait_for_crossbar, run_agent, client):
 
 
 @pytest.mark.integtest
-def test_ls372_get_resistance_range(wait_for_crossbar, run_agent, client):
+def test_ls372_get_resistance_range(wait_for_crossbar, emulator, run_agent, client):
     client.init_lakeshore()
     client.set_resistance_range(channel=1, resistance_range=2)
     resp = client.get_resistance_range(channel=1)
     assert resp.status == ocs.OK
     assert resp.session['op_code'] == OpCode.SUCCEEDED.value
-    assert resp.session['data']['resistance_range'] == 2
+    assert resp.session['data']['resistance_range'] == 63.2
 
 
 @pytest.mark.integtest
-def test_ls372_set_dwell(wait_for_crossbar, run_agent, client):
+def test_ls372_set_dwell(wait_for_crossbar, emulator, run_agent, client):
     client.init_lakeshore()
     resp = client.set_dwell(channel=1, dwell=3)
     assert resp.status == ocs.OK
@@ -125,17 +160,16 @@ def test_ls372_set_dwell(wait_for_crossbar, run_agent, client):
 
 
 @pytest.mark.integtest
-def test_ls372_get_dwell(wait_for_crossbar, run_agent, client):
+def test_ls372_get_dwell(wait_for_crossbar, emulator, run_agent, client):
     client.init_lakeshore()
-    client.set_dwell(channel=1, dwell=3)
     resp = client.get_dwell(channel=1)
     assert resp.status == ocs.OK
     assert resp.session['op_code'] == OpCode.SUCCEEDED.value
-    assert resp.session['data']['dwell_time'] == 3
+    assert resp.session['data']['dwell_time'] == 7
 
 
 @pytest.mark.integtest
-def test_ls372_set_pid(wait_for_crossbar, run_agent, client):
+def test_ls372_set_pid(wait_for_crossbar, emulator, run_agent, client):
     client.init_lakeshore()
     resp = client.set_pid(P=40, I=2, D=0)
     assert resp.status == ocs.OK
@@ -143,7 +177,7 @@ def test_ls372_set_pid(wait_for_crossbar, run_agent, client):
 
 
 @pytest.mark.integtest
-def test_ls372_set_active_channel(wait_for_crossbar, run_agent, client):
+def test_ls372_set_active_channel(wait_for_crossbar, emulator, run_agent, client):
     client.init_lakeshore()
     resp = client.set_active_channel(channel=1)
     assert resp.status == ocs.OK
@@ -151,7 +185,7 @@ def test_ls372_set_active_channel(wait_for_crossbar, run_agent, client):
 
 
 @pytest.mark.integtest
-def test_ls372_set_autoscan(wait_for_crossbar, run_agent, client):
+def test_ls372_set_autoscan(wait_for_crossbar, emulator, run_agent, client):
     client.init_lakeshore()
     resp = client.set_autoscan(autoscan=True)
     assert resp.status == ocs.OK
@@ -159,7 +193,7 @@ def test_ls372_set_autoscan(wait_for_crossbar, run_agent, client):
 
 
 @pytest.mark.integtest
-def test_ls372_set_output_mode(wait_for_crossbar, run_agent, client):
+def test_ls372_set_output_mode(wait_for_crossbar, emulator, run_agent, client):
     client.init_lakeshore()
     resp = client.set_output_mode(heater='still', mode='Off')
     assert resp.status == ocs.OK
@@ -167,7 +201,7 @@ def test_ls372_set_output_mode(wait_for_crossbar, run_agent, client):
 
 
 @pytest.mark.integtest
-def test_ls372_set_heater_output(wait_for_crossbar, run_agent, client):
+def test_ls372_set_heater_output(wait_for_crossbar, emulator, run_agent, client):
     client.init_lakeshore()
     resp = client.set_heater_output(heater='still', output=50)
     assert resp.status == ocs.OK
@@ -175,7 +209,7 @@ def test_ls372_set_heater_output(wait_for_crossbar, run_agent, client):
 
 
 @pytest.mark.integtest
-def test_ls372_set_still_output(wait_for_crossbar, run_agent, client):
+def test_ls372_set_still_output(wait_for_crossbar, emulator, run_agent, client):
     client.init_lakeshore()
     resp = client.set_still_output(output=50)
     assert resp.status == ocs.OK
@@ -183,7 +217,7 @@ def test_ls372_set_still_output(wait_for_crossbar, run_agent, client):
 
 
 @pytest.mark.integtest
-def test_ls372_get_still_output(wait_for_crossbar, run_agent, client):
+def test_ls372_get_still_output(wait_for_crossbar, emulator, run_agent, client):
     client.init_lakeshore()
     resp = client.get_still_output()
     assert resp.status == ocs.OK


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
This replaces the use of the Lakeshore 372 simulator docker container with the socs device emulator fixture for the Lakeshore 372 Agent's integration tests. This will likely resolve the flaky tests we see in those integration tests.

Small coverage reduction due to starting on 'idle', rather than on 'init'.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Fixes #256.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
I've run the modified tests locally.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] Unless I am preparing a release, I have opened this PR onto the `develop` branch.
