### PR TITLE
Configure pre-commit

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,0 +1,10 @@
+[flake8]
+max_line_length = 80
+ignore = E501
+in-place = true
+recursive = true
+aggressive = 2
+exclude =
+    agents/meinberg_m1000/mibs/MBG-SNMP-LTNG-MIB.py
+    agents/meinberg_m1000/mibs/SNMPv2-MIB.py
+    agents/meinberg_m1000/mibs/MBG-SNMP-ROOT-MIB.py

--- a/.github/workflows/develop.yml
+++ b/.github/workflows/develop.yml
@@ -7,6 +7,8 @@ on:
       - 'docs/**'
       - '*.rst'
       - '*.md'
+      - '.flake8'
+      - '.pre-commit-config.yaml'
 
 jobs:
   test:

--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -7,6 +7,8 @@ on:
       - 'docs/**'
       - '*.rst'
       - '*.md'
+      - '.flake8'
+      - '.pre-commit-config.yaml'
   workflow_call:
 
 jobs:

--- a/.github/workflows/skipped-pytest.yml
+++ b/.github/workflows/skipped-pytest.yml
@@ -6,6 +6,8 @@ on:
       - 'docs/**'
       - '*.rst'
       - '*.md'
+      - '.flake8'
+      - '.pre-commit-config.yaml'
 
 jobs:
   test:

--- a/.github/workflows/skipped-test-build.yml
+++ b/.github/workflows/skipped-test-build.yml
@@ -6,6 +6,8 @@ on:
       - 'docs/**'
       - '*.rst'
       - '*.md'
+      - '.flake8'
+      - '.pre-commit-config.yaml'
 
 jobs:
   build:

--- a/.github/workflows/test-build.yml
+++ b/.github/workflows/test-build.yml
@@ -6,6 +6,8 @@ on:
       - 'docs/**'
       - '*.rst'
       - '*.md'
+      - '.flake8'
+      - '.pre-commit-config.yaml'
 
 jobs:
   build:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,16 @@
+repos:
+-   repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v2.3.0
+    hooks:
+    -   id: check-ast
+    -   id: check-yaml
+    -   id: end-of-file-fixer
+    -   id: trailing-whitespace
+-   repo: https://github.com/pre-commit/mirrors-autopep8
+    rev: v1.6.0
+    hooks:
+    -   id: autopep8
+-   repo: https://github.com/pycqa/flake8
+    rev: 4.0.1
+    hooks:
+    -   id: flake8

--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -53,3 +53,69 @@ Development Guide
 Contributors should follow the recommendations made in the `SO Developer Guide`_.
 
 .. _SO Developer Guide: https://simons1.princeton.edu/docs/so_dev_guide/
+
+pre-commit
+``````````
+As a way to enforce development guide recommendations we have configured
+`pre-commit`_.  While not required (yet), it is highly recommended you use this
+tool when contributing to socs. It will save both you and the reviewers time
+when submitting pull requests.
+
+You should set this up before making and commiting your changes. To do so make
+sure the ``pre-commit`` package is installed (it is in ``requirements.txt``)::
+
+    $ pip install -r requirements.txt
+
+Then run::
+
+    $ pre-commit install
+
+This will install the configured git hooks and any dependencies. Now, whenever
+you commit the hooks will run. If there are issues you will see them in the
+output. This may automatically make changes to your staged files.  These
+changes will be unstaged and need to be reviewed (typically with a ``git
+diff``), restaged, and recommitted. For example, if you have trailing
+whitespace on a line, pre-commit will prevent the commit and remove the
+whitespace. You will then stage the new changes with another ``git add <file>``
+and then re-run the commit. Here is the expected git output for this example:
+
+.. code-block::
+
+    $ vim demo.py
+    $ git status
+    On branch koopman/test-pre-commit
+    Changes not staged for commit:
+      (use "git add <file>..." to update what will be committed)
+      (use "git restore <file>..." to discard changes in working directory)
+        modified:   demo.py
+
+    no changes added to commit (use "git add" and/or "git commit -a")
+    $ git add demo.py
+    $ git commit
+    Check python ast.........................................................Passed
+    Fix End of Files.........................................................Passed
+    Trim Trailing Whitespace.................................................Failed
+    - hook id: trailing-whitespace
+    - exit code: 1
+    - files were modified by this hook
+
+    Fixing demo/demo.py
+
+    $ git status
+    On branch koopman/test-pre-commit
+    Changes to be committed:
+      (use "git restore --staged <file>..." to unstage)
+        modified:   demo.py
+
+    Changes not staged for commit:
+      (use "git add <file>..." to update what will be committed)
+      (use "git restore <file>..." to discard changes in working directory)
+        modified:   demo.py
+    $ git add -u
+    $ git commit
+
+**Note:** This is a new tool to this repo, and the flake8 output might still be
+somewhat strict. If there are warnings that you think should be ignored, please
+bring this up for discussion in a new issue.
+
+.. _pre-commit: https://pre-commit.com/


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
This PR configures [pre-commit](https://pre-commit.com/) to run a few different hooks. The base hooks, provided by pre-commit (with descriptions from https://pre-commit.com/hooks.html):

- check-ast - simply checks whether the files parse as valid python.
- check-yaml - checks yaml files for parseable syntax.
- end-of-file-fixer - ensures that a file is either empty, or ends with one newline.
- trailing-whitespace - trims trailing whitespace.

Additional hooks (from external plugins):
- autopep8 - runs [autopep8](https://github.com/hhatto/autopep8), which automatically formats Python code to conform to [PEP8](https://peps.python.org/pep-0008/).
- flake8 - runs [flake8](https://github.com/PyCQA/flake8), catching any linting that autopep8 doesn't auto-format.

As is in this PR, this is not required for developers who do not wish to use it. However I do think we should encourage its use.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
The base hooks seem sensible, ensuring python and yaml are valid, enforcing proper ends to files, and trimming whitespace (which often sneaks in).

As for the additional hooks, I'm often running flake8, but sometimes forget to. This ensures I won't forget. autopep8 I found recently, and I have found it to be very time saving when working with code that has a lot of the smaller PEP8 inconsistencies, i.e. missing whitespace, lines too long, etc. It's a quick way to make the code more readable, and to clear up the output of flake8 for the more important things that it catches.

The configuration of flake8/autopep8 are both done in the `.flake8` configuration. And this is very minimally configured at the moment. I expect, as I use this to update this configuration to ignore simpler flake8 codes that we don't care to enforce.

Eventually, and if usage proves...useful, I would like to move to using [pre-commit.ci](https://pre-commit.ci/), which would automatically run `pre-commit` on modified files in each PR. If changes are needed, i.e. it trims some whitespace in your commits, it'll make them and commit them automatically.

I'm not doing this yet, as it forces the usage on everyone, and at the moment it looks like that also means it'll run on all files in the repository and try to fix them. We have a lot of clean up to do before we can do that though.

For my own reference later, [this post](https://stackoverflow.com/a/67611150) describes the choices to run pre-commit automatically, stating that a github action for running is no longer encouraged for new usage. However, [this issue](https://github.com/pre-commit/action/issues/7) describes how to have pre-commit only run on changed files, not all files, when modifications are needed. I haven't found that functionality in pre-commit.ci yet, so if that is used, I think we have to clean things up first.

I'd be curious to hear thoughts from @mhasself and @jlashner on this. I know we discussed auto-formatters before and decided against it. However, autopep8 has again been pretty useful to me recently, and isn't as strict as say using [black](https://github.com/psf/black). 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
I've run `pre-commit` locally on the repo.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] Unless I am preparing a release, I have opened this PR onto the `develop` branch.
