### PR TITLE
Only run dummy workflow on PRs not on push

### DIFF
--- a/.github/workflows/skipped-pytest.yml
+++ b/.github/workflows/skipped-pytest.yml
@@ -1,8 +1,7 @@
 name: Run Tests
 
 on:
-  push:
-    branches-ignore: [ develop ]
+  pull_request:
     paths:
       - 'docs/**'
       - '*.rst'


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Title says it all.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Realized in working on https://github.com/simonsobs/socs/pull/287 that the dummy pytest workflow didn't run, even though I thought it should. This lead me to realizing that it shouldn't be the exact inverse of pytest.yaml, it just needs to run on PRs only, which might make it run in the case I'm considering.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
It hasn't been. Yet.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] Unless I am preparing a release, I have opened this PR onto the `develop` branch.
