### PR TITLE
DLM agent

### DIFF
--- a/agents/sorenson_dlm/Dockerfile
+++ b/agents/sorenson_dlm/Dockerfile
@@ -7,11 +7,11 @@ FROM socs:latest
 
 # Set the working directory to registry directory
 
-WORKDIR /app/socs/agents/sorenson-dlm/
+WORKDIR /app/socs/agents/sorenson_dlm/
 
 # Copy this agent into the app/socs/agents directory
 
-COPY . /app/socs/agents/sorenson-dlm/
+COPY . /app/socs/agents/sorenson_dlm/
 
 # Run agent on container startup
 

--- a/agents/sorenson_dlm/Dockerfile
+++ b/agents/sorenson_dlm/Dockerfile
@@ -1,6 +1,6 @@
-# SOCS PTC Agent
+# SOCS DLM Agent
 
-# SOCS Agent container for interacting with PTC over ethernet
+# SOCS Agent container for interacting with DLM over ethernet
 # Use socs base image
 
 FROM socs:latest

--- a/agents/sorenson_dlm/Dockerfile
+++ b/agents/sorenson_dlm/Dockerfile
@@ -1,0 +1,21 @@
+# SOCS PTC Agent
+
+# SOCS Agent container for interacting with PTC over ethernet
+# Use socs base image
+
+FROM socs:latest
+
+# Set the working directory to registry directory
+
+WORKDIR /app/socs/agents/sorenson-dlm/
+
+# Copy this agent into the app/socs/agents directory
+
+COPY . /app/socs/agents/sorenson-dlm/
+
+# Run agent on container startup
+
+ENTRYPOINT ["python3", "-u", "dlm__agent.py"]
+
+CMD ["--site-hub=ws://sisock-crossbar:8001/ws", \
+     "--site-http=http://sisock-crossbar:8001/call"]

--- a/agents/sorenson_dlm/Dockerfile
+++ b/agents/sorenson_dlm/Dockerfile
@@ -15,7 +15,7 @@ COPY . /app/socs/agents/sorenson_dlm/
 
 # Run agent on container startup
 
-ENTRYPOINT ["python3", "-u", "dlm_agent.py"]
+ENTRYPOINT ["dumb-init","python3", "-u", "dlm_agent.py"]
 
-CMD ["--site-hub=ws://sisock-crossbar:8001/ws", \
-     "--site-http=http://sisock-crossbar:8001/call"]
+CMD ["--site-hub=ws://crossbar:8001/ws", \
+     "--site-http=http://crossbar:8001/call"]

--- a/agents/sorenson_dlm/Dockerfile
+++ b/agents/sorenson_dlm/Dockerfile
@@ -15,7 +15,7 @@ COPY . /app/socs/agents/sorenson-dlm/
 
 # Run agent on container startup
 
-ENTRYPOINT ["python3", "-u", "dlm__agent.py"]
+ENTRYPOINT ["python3", "-u", "dlm_agent.py"]
 
 CMD ["--site-hub=ws://sisock-crossbar:8001/ws", \
      "--site-http=http://sisock-crossbar:8001/call"]

--- a/agents/sorenson_dlm/dlm_agent.py
+++ b/agents/sorenson_dlm/dlm_agent.py
@@ -2,20 +2,17 @@
 # Tanay Bhandarkar, Jack Orlowski-Scherer
 import time
 import socket
-import numpy as np
-from contextlib import contextmanager
 from ocs import site_config, ocs_agent
-from ocs.ocs_twisted import TimeoutLock
+from ocs.ocs_twisted import TimeoutLock, Pacemaker
 
 
 class DLM:
-    def __init__(self, ip_address='10.10.10.21', port=9221, timeout=10):
+    def __init__(self, ip_address, port=9221, timeout=10):
         self.ip_address = ip_address
         self.port = port
         self.comm = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
         self.comm.connect((self.ip_address, self.port))
         self.comm.settimeout(timeout)
-        self.volt_prot = None
 
     def send_msg(self, cmd):
         """
@@ -86,12 +83,15 @@ class DLM:
 
 
 class DLMAgent:
-    '''
-    TO DO:
-    set_current_and_voltage (simulatneously set current and voltage,
-    not sure if needed)
+    """ Agent to connect to a Sorenson DLM power supply via ethernet.
+    
+    Args:
+        ip_address: str
+            IP address of the DLM
+        port: int
+            Port number for DLM; default is 9221
 
-    '''
+    """
 
     def __init__(self, agent, ip_address, port, f_sample=2.5):
         self.active = True
@@ -100,41 +100,60 @@ class DLMAgent:
         self.lock = TimeoutLock()
         self.f_sample = f_sample
         self.take_data = False
-        self.over_volt = 0
-        self.dlm = DLM(ip_address, int(port))
+        self.over_volt = 0.
+
+        try:
+            self.dlm = DLM(ip_address, int(port))
+        except socket.timeout as e:
+            self.log.error("DLM power supply has timed out"
+                    + f"during connect with error {e}")
+            return False, "Timeout"
+
         agg_params = {'frame length': 60, }
         self.agent.register_feed('voltages',
                                  record=True,
                                  agg_params=agg_params,
                                  buffer_time=1)
 
-    def start_acq(self, session, params=None):
-        '''
+    def acq(self, session, params=None):
+        """acq("wait=1, test_mode=False)
         Get voltage and current values from the sorenson, publishes them to
         the feed
 
         Args:
-            sampling_frequency: defaults to 2.5Hz
-        '''
+            sampling_frequency: float
+                defaults to 2.5Hz
+        """
         if params is None:
             params = {}
-
+        
+        
         f_sample = params.get('sampling_frequency')
         if f_sample is None:
             f_sample = self.f_sample
-
-        sleep_time = 1. / f_sample - 0.01
+        if f_sample % 1 == 0:
+            pm = Pacemaker(f_sample, True)
+        else:
+            pm = Pacemaker(f_sample)
+        wait_time = 1 / f_sample
         with self.lock.acquire_timeout(timeout=0, job='init') as acquired:
             # Locking mechanism stops code from proceeding if no lock acquired
+            pm.sleep()
             if not acquired:
                 self.log.warn("Could not start init because {} is already running".format(self.lock.job))
                 return False, "Could not acquire lock."
 
             session.set_status('running')
-
+            last_release = time.time()
             self.take_data = True
 
             while self.take_data:
+                # About every second, release and acquire the lock
+                if time.time() - last_release > 1.:
+                    last_release = time.time()
+                    if not self.lock.release_and_acquire(timeout=10):
+                        print(f"Could not re-acquire lock now held by {self.lock.job}.")
+                        return False
                 data = {
                     'timestamp': time.time(),
                     'block_name': 'voltages',
@@ -142,31 +161,34 @@ class DLMAgent:
                 }
                 voltage_reading = self.dlm.read_voltage()
                 current_reading = self.dlm.read_current()
-                print('Voltage: {}'.format(voltage_reading))
-                print('Current: {}'.format(current_reading))
-                data['data']["voltage"] = np.float(voltage_reading)
-                data['data']["current"] = np.float(current_reading)
+                self.log.debug('Voltage: {}'.format(voltage_reading))
+                self.log.debug('Current: {}'.format(current_reading))
+
+                data['data']["voltage"] = float(voltage_reading)
+                data['data']["current"] = float(current_reading)
 
                 self.agent.publish_to_feed('voltages', data)
-                time.sleep(sleep_time)
+                time.sleep(wait_time)
 
             self.agent.feeds['voltages'].flush_buffer()
         return True, 'Acquistion exited cleanly'
-
+    
+    @ocs_agent.param('voltage', default=0., type=float, check=lambda V: 0 <= V <= 300)
     def set_voltage(self, session, params=None):
-        """
+        """set_voltage(voltage=None)
+
         Sets voltage of power supply:
         Args:
             voltage (float): Voltage to set.
 
-        Examples:
+        Examples::
             Example of a client, setting the current to 1V:
 
                 client.set_voltage(voltage = 1.)
 
         """
 
-        with self.lock.acquire_timeout(timeout=0, job='init') as acquired:
+        with self.lock.acquire_timeout(timeout=3, job='init') as acquired:
             if acquired:
                 if self.over_volt == 0:
                     return False, 'Over voltage protection not set'
@@ -180,41 +202,44 @@ class DLMAgent:
         return True, 'Set voltage to {}'.format(params['voltage'])
 
     def set_over_volt(self, session, params=None):
-        """
-        Sets over voltage protection of power supply:
+        """set_over_volt(over_volt=None)
+
+        Sets over voltage protection of power supply.
+
         Args:
             over_volt (int): Over voltage protection to set
 
-        Examples:
+        Examples::
             Example of a client, setting the overvoltage protection to 10V:
 
                 client.set_over_volt(over_volt = 10.)
 
         """
 
-        with self.lock.acquire_timeout(timeout=0, job='init') as acquired:
+        with self.lock.acquire_timeout(timeout=3, job='init') as acquired:
             if acquired:
-                print("ACQUIRED", params)
                 self.dlm.set_overv_prot(params['over_volt'])
                 self.over_volt = float(params['over_volt'])
             else:
                 return False, 'Could not acquire lock'
         return True, 'Set over voltage protection to {}'.format(params['over_volt'])
-
+    
+    @ocs_agent.param('current', default=0., type=float, check=lambda I: 0 <= I <= 2)
     def set_current(self, session, params=None):
-        """
+        """set_current(current=None)
+
         Sets current of power supply:
         Args:
             current (float): Current to set.
 
-        Examples:
+        Examples::
             Example of a client, setting the current to 1A:
 
                 client.set_current(current = 1.)
 
         """
 
-        with self.lock.acquire_timeout(timeout=0, job='init') as acquired:
+        with self.lock.acquire_timeout(timeout=3, job='init') as acquired:
             if acquired:
                 if self.over_volt == 0:
                     return False, 'Over voltage protection not set'
@@ -227,17 +252,32 @@ class DLMAgent:
 
         return True, 'Set current to {}'.format(params['current'])
 
-    def stop_acq(self, session, params=None):
-        '''
+    def _stop_acq(self, session, params=None):
+        """
         End voltage data acquisition
-        '''
+        """
         if self.take_data:
             self.take_data = False
             return True, 'requested to stop taking data.'
         else:
             return False, 'acq is not currently running'
 
+def make_parser(parser=None):
+    """Build the argument parser for the Agent. Allows sphinx to automatically
+    build documentation based on this function.
+    """
+    if parser is None:
+        parser = argparse.ArgumentParser()
 
+    pgroup = parser.add_argument_group('Agent Options')
+    pgroup.add_argument('--ip-address', type=str, help="Serial-to-ethernet "
+                        + "converter ip address")
+    pgroup.add_argument('--port-number', type=int, help="Serial-to-ethernet "
+                        + "converter port")
+    pgroup.add_argument('--mode', type=str, help="Set to acq to run acq on "
+                        + "startup")
+
+    return parser
 if __name__ == '__main__':
     parser = site_config.add_arguments()
 
@@ -251,9 +291,9 @@ if __name__ == '__main__':
     site_config.reparse_args(args, 'DLMAgent')
     agent, runner = ocs_agent.init_site_agent(args)
     DLM_agent = DLMAgent(agent, args.ip_address, args.port)
-    agent.register_process('acq', DLM_agent.start_acq,
-                           DLM_agent.stop_acq, startup=True)
+    agent.register_process('acq', DLM_agent.acq,
+                           DLM_agent._stop_acq, startup=True)
     agent.register_task('set_voltage', DLM_agent.set_voltage)
-    agent.register_task('close', DLM_agent.stop_acq)
+    agent.register_task('close', DLM_agent._stop_acq)
     agent.register_task('set_over_volt', DLM_agent.set_over_volt)
     runner.run(agent, auto_reconnect=True)

--- a/agents/sorenson_dlm/dlm_agent.py
+++ b/agents/sorenson_dlm/dlm_agent.py
@@ -226,7 +226,7 @@ class DLMAgent:
                 return False, 'Could not acquire lock'
         return True, 'Set over voltage protection to {}'.format(params['over_volt'])
 
-    @ocs_agent.param('current', default=0., type=float, check=lambda I: 0 <= I <= 2)
+    @ocs_agent.param('current', default=0., type=float, check=lambda x: 0 <= x <= 2)
     def set_current(self, session, params=None):
         """set_current(current=None)
 

--- a/agents/sorenson_dlm/dlm_agent.py
+++ b/agents/sorenson_dlm/dlm_agent.py
@@ -2,6 +2,7 @@
 # Tanay Bhandarkar, Jack Orlowski-Scherer
 import time
 import socket
+import argparse
 from ocs import site_config, ocs_agent
 from ocs.ocs_twisted import TimeoutLock, Pacemaker
 

--- a/agents/sorenson_dlm/dlm_agent.py
+++ b/agents/sorenson_dlm/dlm_agent.py
@@ -136,7 +136,6 @@ class DLMAgent:
             pm = Pacemaker(f_sample, True)
         else:
             pm = Pacemaker(f_sample)
-        wait_time = 1 / f_sample
         with self.lock.acquire_timeout(timeout=0, job='init') as acquired:
             # Locking mechanism stops code from proceeding if no lock acquired
             pm.sleep()
@@ -319,7 +318,8 @@ def make_parser(parser=None):
                         + "converter ip address")
     pgroup.add_argument('--port', type=int, help="Serial-to-ethernet "
                         + "converter port")
-
+    pgroup.add_argument('--mode', default='acq',
+                        choices=['idel', 'acq', 'acq_reg'])
     return parser
 
 
@@ -327,6 +327,15 @@ if __name__ == '__main__':
     parser = make_parser()
     args = site_config.parse_args(agent_class='DLMAgent',
                                   parser=parser)
+    # Automatically acquire data if request (default)
+    init_params = False
+    if args.mode == 'init':
+        init_params = {'auto_acquire': False,
+                       'acq_params': {},
+                       'configfile': args.configfile}
+    elif args.mode == 'acq':
+        init_params = {'auto_acquire': True,
+                       'acq_params': {}}
 
     agent, runner = ocs_agent.init_site_agent(args)
     DLM_agent = DLMAgent(agent, args.ip_address, args.port)

--- a/agents/sorenson_dlm/dlm_agent.py
+++ b/agents/sorenson_dlm/dlm_agent.py
@@ -93,7 +93,7 @@ class DLMAgent:
 
     '''
 
-    def __init__(self, agent, ip_address , port, f_sample=2.5):
+    def __init__(self, agent, ip_address, port, f_sample=2.5):
         self.active = True
         self.agent = agent
         self.log = agent.log
@@ -123,7 +123,7 @@ class DLMAgent:
         if f_sample is None:
             f_sample = self.f_sample
 
-        sleep_time = 1./f_sample - 0.01
+        sleep_time = 1. / f_sample - 0.01
         with self.lock.acquire_timeout(timeout=0, job='init') as acquired:
             # Locking mechanism stops code from proceeding if no lock acquired
             if not acquired:
@@ -158,7 +158,7 @@ class DLMAgent:
         Sets voltage of power supply:
         Args:
             voltage (float): Voltage to set.
-        
+
         Examples:
             Example of a client, setting the current to 1V:
 

--- a/agents/sorenson_dlm/dlm_agent.py
+++ b/agents/sorenson_dlm/dlm_agent.py
@@ -12,12 +12,14 @@ from ocs import site_config, ocs_agent
 from ocs.ocs_twisted import TimeoutLock
 
 class DLM:
-    def __init__(self, ip_address, port=502, timeout=10):
+    def __init__(self, ip_address = '10.10.10.21', port = 9221, timeout = 10):
         self.ip_address = ip_address
         self.port = port
         self.comm = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
         self.comm.connect((self.ip_address, self.port))
         self.comm.settimeout(timeout)
+        self.volt_prot = None
+    
     def get_data(self):
         """
         Gets the raw data from the ptc and returns it in a usable format. 
@@ -27,3 +29,92 @@ class DLM:
         brd = self.breakdownReplyData(data)
             
         return brd    
+    
+    def send_msg(self, cmd):
+        """
+        Sends a message to the DLM. OPC? causes the DLM to wait for the previous command to complete to being the next
+        """
+        msg = str(cmd) + ';OPC?\r\n'
+        self.comm.send(msg.encode('ASCII'))
+
+    def rec_msg(self):
+        """
+        Waits for a message from the DLM, typically as a result of a querry, and returns it
+        """
+        dataStr = self.comm.recv(1024).decode('ASCII')
+        return dataStr.strip()
+
+    def set_overv_prot(self, voltage):
+        """
+        Sets the overvoltage protection
+        """
+        send_msg(self, '*CLS')
+        send_msg(self, '*RST')
+        #TODO Figure out voltage formating: i.e. all voltage variables of the form 1.0? Also, check how DLM returns values and make sure check works
+        send_msg(self, 'SOUR:VOLT:PROT {}'.format(voltage))
+        
+        send_msg(self, 'SOUR:VOLT:PROT?')
+        ovp = rec_msg(self)
+        if ovp != voltage:
+            print("Error: Over voltage protection not set to requested value")
+            return
+        
+        send_msg(self, 'STAT:PROT:ENABLE 8')
+        send_msg(self, 'STAT:PROT:ENABLE?')
+        enb = rec_msg(self)
+        #TODO check that message returns string
+        if enb != '8':
+            print('Error: Over voltage protection failed to enable')
+            return    
+
+        send_msg(self, 'STAT:PROT:EVENT?')
+        event = rec_msg(self)
+        #TODO check that message returns string
+        if event != '0':
+            print('Error: Over voltage already tripped')
+            return
+
+def sendmsg(s, cmd):
+    msg = str(cmd) + '; OPC?\r\n'
+    s.send(msg.encode('ASCII'))
+
+def recmsg(s):
+    dataStr = s.recv(1024).decode('ASCII')    
+    return dataStr.strip()    
+
+comm = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+comm.connect(('10.10.10.21', 9221))
+comm.settimeout(10)
+
+sendmsg(comm, '*CLS')
+sendmsg(comm, '*RST')
+sendmsg(comm, 'SOUR:VOLT:PROT 100.0')    
+sendmsg(comm, 'SOUR:CURR 1.0')
+sendmsg(comm, 'SOUR:VOLT 2.0')
+#sendmsg(comm, 'DISP:VIEW METER1')
+#sendmsg(comm, 'SOUR:CURR?')
+sendmsg(comm, 'SOUR:VOLT?')
+
+msg = recmsg(comm)
+print(msg)
+
+sendmsg(comm, 'SOUR:CURR 0.0')
+sendmsg(comm, 'SOUR:VOLT 0.0')
+sendmsg(comm, 'SOUR:VOLT?')
+
+msg = recmsg(comm)
+print(msg)
+
+
+comm.close()
+"""
+msg = '*CLS\n'
+#comm.send(msg.encode())
+comm.sendall(msg.encode('ASCII'))
+msg = 'SYST:ERR?\n'
+#comm.send(msg.encode())
+comm.sendall(msg.encode('ASCII'))
+status = comm.recv(4096).decode('ASCII')
+
+print(status)
+"""

--- a/agents/sorenson_dlm/dlm_agent.py
+++ b/agents/sorenson_dlm/dlm_agent.py
@@ -85,7 +85,7 @@ class DLM:
 
 class DLMAgent:
     """ Agent to connect to a Sorenson DLM power supply via ethernet.
-    
+
     Args:
         ip_address: str
             IP address of the DLM
@@ -107,7 +107,7 @@ class DLMAgent:
             self.dlm = DLM(ip_address, int(port))
         except socket.timeout as e:
             self.log.error("DLM power supply has timed out"
-                    + f"during connect with error {e}")
+                           + f"during connect with error {e}")
             return False, "Timeout"
 
         agg_params = {'frame length': 60, }
@@ -127,8 +127,7 @@ class DLMAgent:
         """
         if params is None:
             params = {}
-        
-        
+
         f_sample = params.get('sampling_frequency')
         if f_sample is None:
             f_sample = self.f_sample
@@ -173,7 +172,7 @@ class DLMAgent:
 
             self.agent.feeds['voltages'].flush_buffer()
         return True, 'Acquistion exited cleanly'
-    
+
     @ocs_agent.param('voltage', default=0., type=float, check=lambda V: 0 <= V <= 300)
     def set_voltage(self, session, params=None):
         """set_voltage(voltage=None)
@@ -224,7 +223,7 @@ class DLMAgent:
             else:
                 return False, 'Could not acquire lock'
         return True, 'Set over voltage protection to {}'.format(params['over_volt'])
-    
+
     @ocs_agent.param('current', default=0., type=float, check=lambda I: 0 <= I <= 2)
     def set_current(self, session, params=None):
         """set_current(current=None)
@@ -263,6 +262,7 @@ class DLMAgent:
         else:
             return False, 'acq is not currently running'
 
+
 def make_parser(parser=None):
     """Build the argument parser for the Agent. Allows sphinx to automatically
     build documentation based on this function.
@@ -279,6 +279,8 @@ def make_parser(parser=None):
                         + "startup")
 
     return parser
+
+
 if __name__ == '__main__':
     parser = site_config.add_arguments()
 

--- a/agents/sorenson_dlm/dlm_agent.py
+++ b/agents/sorenson_dlm/dlm_agent.py
@@ -1,0 +1,29 @@
+#script to log and control the Sorenson DLM power supply, for heaters
+
+import sys, os
+import binascii
+import time
+import struct
+import socket
+import signal
+import errno
+from contextlib import contextmanager
+from ocs import site_config, ocs_agent
+from ocs.ocs_twisted import TimeoutLock
+
+class DLM:
+    def __init__(self, ip_address, port=502, timeout=10):
+        self.ip_address = ip_address
+        self.port = port
+        self.comm = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+        self.comm.connect((self.ip_address, self.port))
+        self.comm.settimeout(timeout)
+    def get_data(self):
+        """
+        Gets the raw data from the ptc and returns it in a usable format. 
+        """
+        self.comm.sendall(self.buildRegistersQuery()) 
+        data = self.comm.recv(1024)
+        brd = self.breakdownReplyData(data)
+            
+        return brd    

--- a/agents/sorenson_dlm/dlm_agent.py
+++ b/agents/sorenson_dlm/dlm_agent.py
@@ -277,7 +277,6 @@ class DLMAgent:
             self.log.info("DLM already initialized Returning...")
             return True, "Already initialized"
 
-        
         with self._lock.acquire_timeout(job='init') as acquired1, \
                 self._acq_proc_lock.acquire_timeout(timeout=0., job='init') \
                 as acquired2:
@@ -291,7 +290,6 @@ class DLMAgent:
                 return False, "Could not acquire lock"
         session.set_status('running')
 
-        
         # Start data acquisition if requested
         if params.get('auto_acquire', False):
             self.agent.start('acq', params.get('acq_params', None))
@@ -328,7 +326,7 @@ def make_parser(parser=None):
 if __name__ == '__main__':
     parser = make_parser()
     args = site_config.parse_args(agent_class='DLMAgent',
-                                  parser=parser)  
+                                  parser=parser)
 
     agent, runner = ocs_agent.init_site_agent(args)
     DLM_agent = DLMAgent(agent, args.ip_address, args.port)

--- a/agents/sorenson_dlm/dlm_agent.py
+++ b/agents/sorenson_dlm/dlm_agent.py
@@ -157,7 +157,13 @@ class DLMAgent:
         """
         Sets voltage of power supply:
         Args:
-            voltage (int): Voltage to set.
+            voltage (float): Voltage to set.
+        
+        Examples:
+            Example of a client, setting the current to 1V:
+
+                client.set_voltage(voltage = 1.)
+
         """
 
         with self.lock.acquire_timeout(timeout=0, job='init') as acquired:
@@ -178,6 +184,12 @@ class DLMAgent:
         Sets over voltage protection of power supply:
         Args:
             over_volt (int): Over voltage protection to set
+
+        Examples:
+            Example of a client, setting the overvoltage protection to 10V:
+
+                client.set_over_volt(over_volt = 10.)
+
         """
 
         with self.lock.acquire_timeout(timeout=0, job='init') as acquired:
@@ -193,7 +205,13 @@ class DLMAgent:
         """
         Sets current of power supply:
         Args:
-            current (int): Current to set.
+            current (float): Current to set.
+
+        Examples:
+            Example of a client, setting the current to 1A:
+
+                client.set_current(current = 1.)
+
         """
 
         with self.lock.acquire_timeout(timeout=0, job='init') as acquired:

--- a/agents/sorenson_dlm/dlm_agent.py
+++ b/agents/sorenson_dlm/dlm_agent.py
@@ -84,7 +84,7 @@ class DLM:
 
 
 class DLMAgent:
-    """ Agent to connect to a Sorenson DLM power supply via ethernet.
+    """Agent to connect to a Sorenson DLM power supply via ethernet.
 
     Args:
         ip_address: str
@@ -117,9 +117,10 @@ class DLMAgent:
                                  buffer_time=1)
 
     def acq(self, session, params=None):
-        """acq("wait=1, test_mode=False)
-        Get voltage and current values from the sorenson, publishes them to
-        the feed
+        """acq(sampling_frequency=2.5)
+
+        **Process** - Get voltage and current values from the sorenson,
+        publishes them to the feed.
 
         Args:
             sampling_frequency: float
@@ -177,12 +178,13 @@ class DLMAgent:
     def set_voltage(self, session, params=None):
         """set_voltage(voltage=None)
 
-        Sets voltage of power supply:
+        **Task** - Sets voltage of power supply.
+
         Args:
             voltage (float): Voltage to set.
 
-        Examples::
-            Example of a client, setting the current to 1V:
+        Examples:
+            Example of a client, setting the current to 1V::
 
                 client.set_voltage(voltage = 1.)
 
@@ -204,13 +206,13 @@ class DLMAgent:
     def set_over_volt(self, session, params=None):
         """set_over_volt(over_volt=None)
 
-        Sets over voltage protection of power supply.
+        **Task** - Sets over voltage protection of power supply.
 
         Args:
             over_volt (int): Over voltage protection to set
 
-        Examples::
-            Example of a client, setting the overvoltage protection to 10V:
+        Examples:
+            Example of a client, setting the overvoltage protection to 10V::
 
                 client.set_over_volt(over_volt = 10.)
 
@@ -228,12 +230,13 @@ class DLMAgent:
     def set_current(self, session, params=None):
         """set_current(current=None)
 
-        Sets current of power supply:
+        **Task** - Sets current of power supply.
+
         Args:
             current (float): Current to set.
 
-        Examples::
-            Example of a client, setting the current to 1A:
+        Examples:
+            Example of a client, setting the current to 1A::
 
                 client.set_current(current = 1.)
 

--- a/agents/sorenson_dlm/dlm_agent.py
+++ b/agents/sorenson_dlm/dlm_agent.py
@@ -69,8 +69,24 @@ class DLM:
         """
         Reads output  voltage
         """
-        sendmsg(comm, 'SOUR:VOLT?')
-        msg = rec_msg(comm)
+        sendmsg(self.comm, 'SOUR:VOLT?')
+        msg = rec_msg(self.comm)
+        return msg
+
+    def read_current(self):
+        """
+        Reads output current
+        """
+        sendmsg(self.comm, 'MEAS:CURR?')
+        msg = rec_msg(self.comm)
+        return msg
+
+    def sys_err_check(self):
+        """
+        Queries sytem error and returns error byte
+        """
+        sendmsg(self.comm, 'SYST:ERR?')
+        msg=rec_msg(self.comm)
         return msg
 
 
@@ -80,6 +96,9 @@ class DLMAgent:
     start_acq function
     set_voltage function
     set_voltage_protection function
+    set_current_fuction
+    set_current_and_voltage??? (simulatneously set current and voltage, not sure if needed)
+    
     ???
     '''
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -227,3 +227,12 @@ services:
     build: ./simulators/lakeshore372/
     depends_on:
       - "socs"
+
+  # --------------------------------------------------------------------------
+  # Sorenson DLM Power Supply
+  # --------------------------------------------------------------------------
+  ocs-dlm-agent:
+    image: "ocs-dlm-agent"
+    build: ./agents/sorenson_dlm/
+    depends_on:
+      - "socs"

--- a/docs/agents/sorenson_dlm.rst
+++ b/docs/agents/sorenson_dlm.rst
@@ -2,14 +2,13 @@
 
 .. _sorenson_dlm:
 
-==============
+==================
 Sorenson DLM Agent
-==============
+==================
 
-# A brief description of the Agent.
 The Sorenson DLM is a 300V/2A single channel power supply, with over-voltage
 protection. The DLM agent communicates with the power supply, reading out
-voltage and current values, and defining tasks used to set voltages and
+voltage and current values, and defines tasks used to set voltages and
 currents.
 
 .. argparse::
@@ -18,11 +17,6 @@ currents.
    :prog: dlm_agent.py
 
 
-Dependencies
-------------
-
-# Any external dependencies for agent. Omit if there are none, or they are
-# included in the main requirements.txt file.
 
 Configuration File Examples
 ---------------------------
@@ -34,31 +28,25 @@ OCS Site Config
 ````````````````
 
 An example site-config-file block::
-      # DLM Agent
       {'agent-class': 'DLMAgent',
         'instance-id': 'dlm',
-        'arguments':[
-          ['--ip-address', '10.10.10.21'],
-          ['--mode','acq' ],
-          ['--port','9221'],]},
+        'arguments' :[['--ip-address', '10.10.10.21'],
+                      ['--mode', 'acq'],
+                      ['--port', '9221'],]},
 
 Docker Compose
 ``````````````
 
 An example docker-compose configuration::
-  # --------------------------------------------------------------------------
-  # OCS - DLM
-  # --------------------------------------------------------------------------
   ocs-dlm:
-    #<<: *log-options
-    image: simonsobs/cs-dlm-agent:latest
+    image: simonsobs/ocs-dlm-agent:latest
     hostname: ocs-docker
     network_mode: "host"
     volumes:
       - ${OCS_CONFIG_DIR}:/config
-      - /home/ocs:/home/ocs
     command:
       - "--instance-id=dlm"
+
 
 Description
 -----------
@@ -69,36 +57,30 @@ requires both an output voltage value and an output current value. You can also
 set an upper-bound on the voltage output for safety purposees (overvoltage
 setting).
 
-Subsection
-``````````
-
-# Use subsections where appropriate.
 
 Agent API
 ---------
 
-# Autoclass the Agent, this is for users to reference when writing clients.
 
-.. autoclass:: agents.dlm.dlm_agent.DLMAgent
+.. autoclass:: agents.sorenson_dlm.dlm_agent.DLMAgent
     :members:
 
 Example Clients
 ---------------
+The following client sets the output voltage and current to 1V and 1A, respectively::
 
-# The following client sets the output voltage and current to 1V and 1A, respectively::
+        from ocs.ocs_client import OCSClient
 
-        from ocs.matched_client import MatchedClient
-
-        mc = MatchedClient('dlm')
+        client = OCSClient('dlm')
 
         #Stop data acquisition
-        mc.close()
+        client.close()
 
         #Set overvoltage protection
-        mc.set_over_volt(over_volt=1.)
+        client.set_over_volt(over_volt=1.)
         #Set DLM Voltage
-        mc.set_voltage(voltage = 1.)
-        mc.set_current(current = 1.)
+        client.set_voltage(voltage = 1.)
+        client.set_current(current = 1.)
 
         #Re-start data acq
-        mc.acq.start()
+        client.acq.start()

--- a/docs/agents/sorenson_dlm.rst
+++ b/docs/agents/sorenson_dlm.rst
@@ -12,9 +12,9 @@ voltage and current values, and defines tasks used to set voltages and
 currents.
 
 .. argparse::
-   :module: ../agents/sorenson_dlm/dlm_agent.py
+   :filename: ../agents/sorenson_dlm/dlm_agent.py
    :func: make_parser
-   :prog: dlm_agent.py
+   :prog: python3 dlm_agent.py
 
 
 
@@ -28,9 +28,10 @@ OCS Site Config
 ````````````````
 
 An example site-config-file block::
+
       {'agent-class': 'DLMAgent',
         'instance-id': 'dlm',
-        'arguments' :[['--ip-address', '10.10.10.21'],
+        'arguments': [['--ip-address', '10.10.10.21'],
                       ['--mode', 'acq'],
                       ['--port', '9221'],]},
 
@@ -38,6 +39,7 @@ Docker Compose
 ``````````````
 
 An example docker-compose configuration::
+
   ocs-dlm:
     image: simonsobs/ocs-dlm-agent:latest
     hostname: ocs-docker

--- a/docs/agents/sorenson_dlm.rst
+++ b/docs/agents/sorenson_dlm.rst
@@ -1,0 +1,104 @@
+.. highlight:: rst
+
+.. _sorenson_dlm:
+
+==============
+Sorenson DLM Agent
+==============
+
+# A brief description of the Agent.
+The Sorenson DLM is a 300V/2A single channel power supply, with over-voltage
+protection. The DLM agent communicates with the power supply, reading out
+voltage and current values, and defining tasks used to set voltages and
+currents.
+
+.. argparse::
+   :module: ../agents/sorenson_dlm/dlm_agent.py
+   :func: make_parser
+   :prog: dlm_agent.py
+
+
+Dependencies
+------------
+
+# Any external dependencies for agent. Omit if there are none, or they are
+# included in the main requirements.txt file.
+
+Configuration File Examples
+---------------------------
+
+Below are configuration examples for the ocs config file and for running the
+Agent in a docker container.
+
+OCS Site Config
+````````````````
+
+An example site-config-file block::
+      # DLM Agent
+      {'agent-class': 'DLMAgent',
+        'instance-id': 'dlm',
+        'arguments':[
+          ['--ip-address', '10.10.10.21'],
+          ['--mode','acq' ],
+          ['--port','9221'],]},
+
+Docker Compose
+``````````````
+
+An example docker-compose configuration::
+  # --------------------------------------------------------------------------
+  # OCS - DLM
+  # --------------------------------------------------------------------------
+  ocs-dlm:
+    #<<: *log-options
+    image: simonsobs/cs-dlm-agent:latest
+    hostname: ocs-docker
+    network_mode: "host"
+    volumes:
+      - ${OCS_CONFIG_DIR}:/config
+      - /home/ocs:/home/ocs
+    command:
+      - "--instance-id=dlm"
+
+Description
+-----------
+
+The Sorenson DLM is a power supply; depending on the model you own, the voltage
+and current limits will differ. In order to apply an output voltage, the DLM
+requires both an output voltage value and an output current value. You can also
+set an upper-bound on the voltage output for safety purposees (overvoltage
+setting).
+
+Subsection
+``````````
+
+# Use subsections where appropriate.
+
+Agent API
+---------
+
+# Autoclass the Agent, this is for users to reference when writing clients.
+
+.. autoclass:: agents.dlm.dlm_agent.DLMAgent
+    :members:
+
+Example Clients
+---------------
+
+# The following client sets the output voltage and current to 1V and 1A, respectively::
+
+        from ocs.matched_client import MatchedClient
+
+        mc = MatchedClient('dlm')
+
+        #Stop data acquisition
+        mc.close()
+
+        #Set overvoltage protection
+        mc.set_over_volt(over_volt=1.)
+        #Set DLM Voltage
+        mc.set_voltage(voltage = 1.)
+        mc.set_current(current = 1.)
+
+        #Re-start data acq
+        mc.acq.start()

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -58,6 +58,7 @@ API Reference        Full API documentation for core parts of the SOCS library.
     agents/pysmurf-monitor
     agents/scpi_psu
     agents/smurf_crate_monitor
+    agents/sorenson_dlm
     agents/suprsync
     agents/synacc
     agents/tektronix3021c

--- a/tests/default.yaml
+++ b/tests/default.yaml
@@ -46,5 +46,12 @@ hosts:
                      ['--mode', 'init'],
                     ]
       },
+      {'agent-class': 'DLMAgent',
+       'instance-id': 'dlm',
+       'arguments': [['--ip-address', '127.0.0.1'],
+                      # ['--mode', 'acq'],
+                      ['--port', '9221'],
+                    ]
+      },
     ]
   }

--- a/tests/integration/test_dlm_agent_integration.py
+++ b/tests/integration/test_dlm_agent_integration.py
@@ -1,0 +1,123 @@
+import time
+import pytest
+
+import ocs
+from ocs.base import OpCode
+
+from ocs.testing import (
+    create_agent_runner_fixture,
+    create_client_fixture,
+)
+
+from integration.util import create_crossbar_fixture
+
+from socs.testing.device_emulator import create_device_emulator
+
+pytest_plugins = "docker_compose"
+
+wait_for_crossbar = create_crossbar_fixture()
+run_agent = create_agent_runner_fixture(
+    "../agents/sorenson_dlm/dlm_agent.py",
+    "dlm_agent",
+    args=["--log-dir", "./logs/"],
+)
+client = create_client_fixture("dlm")
+emu = create_device_emulator({"hello": "world"}, relay_type="tcp", port=9221)
+
+
+@pytest.mark.integtest
+def test_dlm_init(wait_for_crossbar, emu, run_agent, client):
+    resp = client.init_dlm.status()
+    print(resp)
+    assert resp.status == ocs.OK
+    print(resp.session)
+    assert resp.session["op_code"] == OpCode.SUCCEEDED.value
+
+
+@pytest.mark.integtest
+def test_dlm_acq(wait_for_crossbar, emu, run_agent, client):
+    responses = {"SOUR:VOLT?;OPC?": "15", "MEAS:CURR?;OPC?": "1.85"}
+    emu.define_responses(responses)
+
+    resp = client.acq.start()
+    assert resp.status == ocs.OK
+    assert resp.session["op_code"] == OpCode.STARTING.value
+    time.sleep(1)
+    resp = client.acq.status()
+    assert resp.status == ocs.OK
+    assert resp.session["op_code"] == OpCode.RUNNING.value
+
+    client.acq.stop()
+    time.sleep(1)  # can implement a 'run_once' param for testing later
+    resp = client.acq.status()
+    print(resp)
+    assert resp.status == ocs.OK
+    print(resp.session)
+    assert resp.session["op_code"] in [OpCode.STOPPING.value, OpCode.SUCCEEDED.value]
+
+
+@pytest.mark.integtest
+def test_dlm_set_over_volt(wait_for_crossbar, emu, run_agent, client):
+    responses = {
+        "SOUR:VOLT:PROT?;OPC?": "25.5",
+        "STAT:PROT:ENABLE?;OPC?": "8",
+        "STAT:PROT:EVENT?;OPC?": "0",
+    }
+    emu.define_responses(responses)
+
+    resp = client.set_over_volt(over_volt=25.5)
+    print(resp)
+    assert resp.status == ocs.OK
+    print(resp.session)
+    assert resp.session["op_code"] == OpCode.SUCCEEDED.value
+
+
+@pytest.mark.integtest
+def test_dlm_set_voltage(wait_for_crossbar, emu, run_agent, client):
+    responses = {
+        "SOUR:VOLT:PROT?;OPC?": "120",
+        "STAT:PROT:ENABLE?;OPC?": "8",
+        "STAT:PROT:EVENT?;OPC?": "0",
+    }
+    emu.define_responses(responses)
+
+    resp = client.set_over_volt(over_volt=120)
+    resp = client.set_voltage(voltage=75.8)
+    print(resp)
+    assert resp.status == ocs.OK
+    print(resp.session)
+    assert resp.session["op_code"] == OpCode.SUCCEEDED.value
+
+
+@pytest.mark.integtest
+def test_dlm_trigger_over_volt(wait_for_crossbar, emu, run_agent, client):
+    responses = {
+        "SOUR:VOLT:PROT?;OPC?": "13.5",
+        "STAT:PROT:ENABLE?;OPC?": "8",
+        "STAT:PROT:EVENT?;OPC?": "0",
+    }
+    emu.define_responses(responses)
+
+    resp = client.set_over_volt(over_volt=13.5)
+    resp = client.set_voltage(voltage=23.2)
+    print(resp)
+    assert resp.status == ocs.OK
+    print(resp.session)
+    assert resp.session["op_code"] == OpCode.FAILED.value
+
+
+@pytest.mark.integtest
+def test_dlm_set_current(wait_for_crossbar, emu, run_agent, client):
+    responses = {
+        "SOUR:VOLT:PROT?;OPC?": "50",
+        "STAT:PROT:ENABLE?;OPC?": "8",
+        "STAT:PROT:EVENT?;OPC?": "0",
+    }
+    emu.define_responses(responses)
+
+    resp = client.set_over_volt(over_volt=50)
+    resp = client.set_current(current=1.35)
+    print(resp)
+    assert resp.status == ocs.OK
+    print(resp.session)
+    assert resp.session["op_code"] == OpCode.SUCCEEDED.value


### PR DESCRIPTION
First PR for the DLM agent. This agent is used to communicate with the Sorenson DLM power supply, used for powering the LATR's 4k heaters and magnetic field tests. 

## Description
Completed the data acquisition functions, added a function to set current values, and adding tasks for clients (tasks will control voltage and current outputs, and overvoltage protections values).

## Motivation and Context
This is the first PR for the DLM agent. It will be used for DAQ purposes at LATR labs and in deployment.

Closes #60.

## How Has This Been Tested?
This has been tested with the Sorenson DLM hardware at Penn. It can publish voltage and current readings to a feed, and I have written a client that can set voltages (not in this PR). 

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly. 
- [x] Unless I am preparing a release, I have opened this PR onto the `develop` branch.


Regarding tasks and process failing to get locks: If I use the set_voltage task (or any task), I need to stop the acq process otherwise the task does not get the lock. I think there was a discussion about this a while back, but I cannot find the thread, what is the correct way to do this?  