### PR TITLE
Run flake8 on all files

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -5,6 +5,8 @@ ignore =
     E501,
     # module level import not at top of file
     E402,
+    # line break before binary operator
+    W503,
 in-place = true
 recursive = true
 aggressive = 2

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -10,8 +10,7 @@ repos:
     rev: v1.6.0
     hooks:
     -   id: autopep8
-# comment out while we process all files
-#-   repo: https://github.com/pycqa/flake8
-#    rev: 4.0.1
-#    hooks:
-#    -   id: flake8
+-   repo: https://github.com/pycqa/flake8
+    rev: 4.0.1
+    hooks:
+    -   id: flake8

--- a/README.rst
+++ b/README.rst
@@ -20,6 +20,10 @@ SOCS - Simons Observatory Control System
    :target: https://pypi.org/project/socs/
    :alt: PyPI Package
 
+.. image:: https://results.pre-commit.ci/badge/github/simonsobs/socs/develop.svg
+   :target: https://results.pre-commit.ci/latest/github/simonsobs/socs/develop
+   :alt: pre-commit.ci status
+
 Overview
 --------
 

--- a/agents/bluefors/bluefors_log_tracker.py
+++ b/agents/bluefors/bluefors_log_tracker.py
@@ -391,12 +391,12 @@ class LogParser:
             elif log_type in ['channels', 'status', 'heater']:
                 data = self._parse_multi_value_log(new, log_type, log_name)
             elif log_type == 'errors':
-                LOG.info("The Bluefors Agent cannot process error logs. " +
-                         "Not publishing.")
+                LOG.info("The Bluefors Agent cannot process error logs. "
+                         + "Not publishing.")
                 data = None
             else:
-                LOG.warn("Warning: Unknown log type. Skipping publish step. " +
-                         "This probably shouldn't happen.")
+                LOG.warn("Warning: Unknown log type. Skipping publish step. "
+                         + "This probably shouldn't happen.")
                 LOG.warn("Filename: {}".format(k))
                 data = None
 
@@ -407,9 +407,9 @@ class LogParser:
                 if (time.time() - data['timestamp']) < int(self.stale_time) * 60:
                     app_session.app.publish_to_feed('bluefors', data)
                 else:
-                    LOG.warn("Not publishing stale data. Make sure your log " +
-                             "file sync is done at a rate faster than once ever " +
-                             "{x} minutes.", x=self.stale_time)
+                    LOG.warn("Not publishing stale data. Make sure your log "
+                             + "file sync is done at a rate faster than once ever "
+                             + "{x} minutes.", x=self.stale_time)
 
 
 class BlueforsAgent:

--- a/agents/chwp/hwpbbb_agent.py
+++ b/agents/chwp/hwpbbb_agent.py
@@ -87,8 +87,6 @@ SEC_ENCODER_TO_PUBLISH = 10
 # Subsampling facot for the encoder counter data to influxdb
 NUM_SUBSAMPLE = 500
 
-### Definitions of utility functions ###
-
 
 def de_irig(val, base_shift=0):
     """Converts the IRIG signal into sec/min/hours/day/year depending on the parameters
@@ -258,7 +256,7 @@ class EncoderParser:
                   'Clock Count', edge)
 
         # Set the current time in seconds (changed to seconds from unix epoch)
-        #self.current_time = secs + mins*60 + hours*3600
+        # self.current_time = secs + mins*60 + hours*3600
         try:
             st_time = time.strptime("%d %d %d:%d:%d" % (year, day, hours, mins, secs),
                                     "%y %j %H:%M:%S")
@@ -331,7 +329,7 @@ class EncoderParser:
                     header = self.data[0:4]
                     # Convert a structure value from the beaglebone (header) to an int
                     header = struct.unpack('<I', header)[0]
-                    #print('header ', '0x%x'%header)
+                    # print('header ', '0x%x'%header)
 
                     # 0x1EAF = Encoder Packet
                     # 0xCAFE = IRIG Packet
@@ -570,8 +568,8 @@ class HWPBBBAgent:
                     # 0.09: time difference in seconds b/w reference marker and
                     #       the first index marker
                     data['timestamps'] = sys_time + 0.09 + np.arange(10) * 0.1
-                    data['data']['irig_synch_pulse_clock_time'] = list(irig_time + 0.09 +
-                                                                       np.arange(10) * 0.1)
+                    data['data']['irig_synch_pulse_clock_time'] = list(irig_time + 0.09
+                                                                       + np.arange(10) * 0.1)
                     data['data']['irig_synch_pulse_clock_counts'] = synch_pulse_clock_counts
                     data['data']['irig_info'] = list(irig_info)
                     self.agent.publish_to_feed('HWPEncoder', data)

--- a/agents/cryomech_cpa/cryomech_cpa_agent.py
+++ b/agents/cryomech_cpa/cryomech_cpa_agent.py
@@ -206,7 +206,7 @@ class PTCAgent:
         self.fake_errors = fake_errors
 
         self.port = port
-        self.module: Optional[Module] = None
+        self.module = None
         self.f_sample = f_sample
 
         self.initialized = False

--- a/agents/hwp_rotation/src/pid_controller.py
+++ b/agents/hwp_rotation/src/pid_controller.py
@@ -244,8 +244,8 @@ class PID:
                 data = self.conn.recv(4096).decode().strip()
                 break
             except socket.timeout:
-                print("Caught timeout waiting for response from PID controller. " +
-                      "Trying again...")
+                print("Caught timeout waiting for response from PID controller. "
+                      + "Trying again...")
                 time.sleep(1)
                 if attempt == 1:
                     raise RuntimeError(

--- a/agents/lakeshore336/LS336_agent.py
+++ b/agents/lakeshore336/LS336_agent.py
@@ -218,8 +218,8 @@ class LS336_Agent:
                 for i, channel in enumerate(self.module.channels.values()):
                     channel_str = channel.input_name.replace(' ', '_')
                     temperatures_message['data'][channel_str + '_T'] = temps[i]
-                    temperatures_message['data'][channel_str +
-                                                 '_V'] = voltages[i]
+                    temperatures_message['data'][channel_str
+                                                 + '_V'] = voltages[i]
 
                 # append to recent temps array for temp stability check
                 self._recent_temps = np.roll(self._recent_temps, 1, axis=0)

--- a/agents/lakeshore370/LS370_agent.py
+++ b/agents/lakeshore370/LS370_agent.py
@@ -245,12 +245,12 @@ class LS370_Agent:
 
                             # Check user set dwell time isn't too long
                             if self.dwell_time_delay > dwell_time:
-                                self.log.warn("WARNING: User set dwell_time_delay of " +
-                                              "{delay} s is larger than channel " +
-                                              "dwell time of {chan_time} s. If " +
-                                              "you are autoscanning this will " +
-                                              "cause no data to be collected. " +
-                                              "Reducing dwell time delay to {s} s.",
+                                self.log.warn("WARNING: User set dwell_time_delay of "
+                                              + "{delay} s is larger than channel "
+                                              + "dwell time of {chan_time} s. If "
+                                              + "you are autoscanning this will "
+                                              + "cause no data to be collected. "
+                                              + "Reducing dwell time delay to {s} s.",
                                               delay=self.dwell_time_delay,
                                               chan_time=dwell_time,
                                               s=dwell_time - 1)

--- a/agents/lakeshore372/LS372_agent.py
+++ b/agents/lakeshore372/LS372_agent.py
@@ -313,12 +313,12 @@ class LS372_Agent:
 
                             # Check user set dwell time isn't too long
                             if self.dwell_time_delay > dwell_time:
-                                self.log.warn("WARNING: User set dwell_time_delay of " +
-                                              "{delay} s is larger than channel " +
-                                              "dwell time of {chan_time} s. If " +
-                                              "you are autoscanning this will " +
-                                              "cause no data to be collected. " +
-                                              "Reducing dwell time delay to {s} s.",
+                                self.log.warn("WARNING: User set dwell_time_delay of "
+                                              + "{delay} s is larger than channel "
+                                              + "dwell time of {chan_time} s. If "
+                                              + "you are autoscanning this will "
+                                              + "cause no data to be collected. "
+                                              + "Reducing dwell time delay to {s} s.",
                                               delay=self.dwell_time_delay,
                                               chan_time=dwell_time,
                                               s=dwell_time - 1)
@@ -629,7 +629,7 @@ class LS372_Agent:
 
             session.set_status('running')
 
-            current_dwell = self.module.channels[params["channel"]].set_dwell(params["dwell"])
+            self.module.channels[params["channel"]].set_dwell(params["dwell"])
             session.add_message(f'Set dwell to {params["dwell"]}')
 
         return True, f'Set channel {params["channel"]} dwell time to {params["dwell"]}'
@@ -761,22 +761,22 @@ class LS372_Agent:
 
             # Check we're in correct control mode for servo.
             if self.module.sample_heater.mode != 'Closed Loop':
-                session.add_message(f'Changing control to Closed Loop mode for servo.')
+                session.add_message('Changing control to Closed Loop mode for servo.')
                 self.module.sample_heater.set_mode("Closed Loop")
 
             # Check we aren't autoscanning.
             if self.module.get_autoscan() is True:
-                session.add_message(f'Autoscan is enabled, disabling for PID control on dedicated channel.')
+                session.add_message('Autoscan is enabled, disabling for PID control on dedicated channel.')
                 self.module.disable_autoscan()
 
             # Check we're scanning same channel expected by heater for control.
             if self.module.get_active_channel().channel_num != int(self.module.sample_heater.input):
-                session.add_message(f'Changing active channel to expected heater control input')
+                session.add_message('Changing active channel to expected heater control input')
                 self.module.set_active_channel(int(self.module.sample_heater.input))
 
             # Check we're setup to take correct units.
             if self.module.get_active_channel().units != 'kelvin':
-                session.add_message(f'Setting preferred units to Kelvin on heater control input.')
+                session.add_message('Setting preferred units to Kelvin on heater control input.')
                 self.module.get_active_channel().set_units('kelvin')
 
             # Make sure we aren't servoing too high in temperature.
@@ -826,7 +826,7 @@ class LS372_Agent:
 
             if np.abs(mean - setpoint) < params['threshold']:
                 print("passed threshold")
-                session.add_message(f'Setpoint Difference: ' + str(mean - setpoint))
+                session.add_message('Setpoint Difference: ' + str(mean - setpoint))
                 session.add_message(f'Average is within {params["threshold"]} K threshold. Proceeding with calibration.')
 
                 return True, f"Servo temperature is stable within {params['threshold']} K"

--- a/agents/magpie/magpie_agent.py
+++ b/agents/magpie/magpie_agent.py
@@ -1,5 +1,5 @@
 import argparse
-import so3g
+import so3g  # noqa: F401
 from spt3g import core
 import txaio
 import os
@@ -804,7 +804,7 @@ class MagpieAgent:
                 stream_start_time = now
 
             this_frame_time = stream_start_time + (t - first_frame_time) + self.delay
-            res = sleep_while_running(this_frame_time - now, session)
+            sleep_while_running(this_frame_time - now, session)
             sender.Process(f)
 
         return True, "Stopped send process"

--- a/agents/meinberg_m1000/meinberg_m1000_agent.py
+++ b/agents/meinberg_m1000/meinberg_m1000_agent.py
@@ -170,8 +170,8 @@ class MeinbergSNMP:
 
         # I don't expect any other types at the moment, but just in case.
         if not isinstance(oid_value, (int, bytes, str)):
-            self.log.error("{oid} is of unknown and unhandled type " +
-                           "{oid_type}. Returning None.",
+            self.log.error("{oid} is of unknown and unhandled type "
+                           + "{oid_type}. Returning None.",
                            oid=oid, oid_type=type(oid_value))
             oid_value = None
 
@@ -410,9 +410,9 @@ class MeinbergM1000Agent:
         yield self.meinberg.run_snmp_get(session)
         if not self.meinberg.oid_cache['m1000_connection'].get('connected', False):
             self.log.error('No initial SNMP response.')
-            self.log.error('Either there is a network connection issue, ' +
-                           'or maybe you are using the wrong SNMP ' +
-                           'version. Either way, we are exiting.')
+            self.log.error('Either there is a network connection issue, '
+                           + 'or maybe you are using the wrong SNMP '
+                           + 'version. Either way, we are exiting.')
 
             reactor.callFromThread(reactor.stop)
             return False, 'acq process failed - No connection to M1000'
@@ -447,14 +447,14 @@ def make_parser(parser=None):
     # Add options specific to this agent.
     pgroup = parser.add_argument_group("Agent Options")
     pgroup.add_argument("--auto-start", default=True, type=bool,
-                        help="Automatically start polling for data at " +
-                        "Agent startup.")
+                        help="Automatically start polling for data at "
+                        + "Agent startup.")
     pgroup.add_argument("--address", help="Address to listen to.")
     pgroup.add_argument("--port", default=161,
                         help="Port to listen on.")
     pgroup.add_argument("--snmp-version", default='3', choices=['1', '2', '3'],
-                        help="SNMP version for communication. Must match " +
-                             "configuration on the M1000.")
+                        help="SNMP version for communication. Must match "
+                             + "configuration on the M1000.")
 
     return parser
 

--- a/agents/pfeiffer_tc400/pfeiffer_tc400_agent.py
+++ b/agents/pfeiffer_tc400/pfeiffer_tc400_agent.py
@@ -72,8 +72,8 @@ class PfeifferTC400Agent:
                                            self.port_number,
                                            self.turbo_address)
             except socket.timeout as e:
-                self.log.error("Turbo Controller timed out" +
-                               f"during connect with error {e}")
+                self.log.error("Turbo Controller timed out"
+                               + f"during connect with error {e}")
                 return False, "Timeout"
             self.log.info("Connected to turbo controller")
 
@@ -222,14 +222,14 @@ def make_parser(parser=None):
 
     # Add options specific to this agent.
     pgroup = parser.add_argument_group('Agent Options')
-    pgroup.add_argument('--ip-address', type=str, help="Serial-to-ethernet " +
-                        "converter ip address")
-    pgroup.add_argument('--port-number', type=int, help="Serial-to-ethernet " +
-                        "converter port")
-    pgroup.add_argument('--turbo-address', type=int, help="Internal address " +
-                        "used by power supplies")
-    pgroup.add_argument('--mode', type=str, help="Set to acq to run acq on " +
-                        "startup")
+    pgroup.add_argument('--ip-address', type=str, help="Serial-to-ethernet "
+                        + "converter ip address")
+    pgroup.add_argument('--port-number', type=int, help="Serial-to-ethernet "
+                        + "converter port")
+    pgroup.add_argument('--turbo-address', type=int, help="Internal address "
+                        + "used by power supplies")
+    pgroup.add_argument('--mode', type=str, help="Set to acq to run acq on "
+                        + "startup")
 
     return parser
 

--- a/agents/pfeiffer_tpg366/pfeiffer_tpg366_agent.py
+++ b/agents/pfeiffer_tpg366/pfeiffer_tpg366_agent.py
@@ -4,7 +4,6 @@
 
 import argparse
 import socket
-import numpy as np
 from ocs import ocs_agent, site_config
 from ocs.ocs_twisted import TimeoutLock
 import time
@@ -51,7 +50,7 @@ class Pfeiffer:
         msg = 'PR%d\r\n' % ch_no
         self.comm.send(msg.encode())
         # Can use this to catch exemptions, for troubleshooting
-        status = self.comm.recv(BUFF_SIZE).decode()
+        self.comm.recv(BUFF_SIZE).decode()
         self.comm.send(ENQ.encode())
         read_str = self.comm.recv(BUFF_SIZE).decode()
         pressure_str = read_str.split(',')[-1].split('\r')[0]
@@ -72,12 +71,11 @@ class Pfeiffer:
         msg = 'PRX\r\n'
         self.comm.send(msg.encode())
         # Could use this to catch exemptions, for troubleshooting
-        status = self.comm.recv(BUFF_SIZE).decode()
+        self.comm.recv(BUFF_SIZE).decode()
         self.comm.send(ENQ.encode())
         read_str = self.comm.recv(BUFF_SIZE).decode()
         pressure_str = read_str.split('\r')[0]
-        #gauge_states = pressure_str.split(',')[::2]
-        #gauge_states = np.array(gauge_states, dtype=int)
+        # gauge_states = pressure_str.split(',')[::2]
         pressures = pressure_str.split(',')[1::2]
         pressures = [float(p) for p in pressures]
         return pressures

--- a/agents/pysmurf_monitor/pysmurf_monitor.py
+++ b/agents/pysmurf_monitor/pysmurf_monitor.py
@@ -138,7 +138,7 @@ class PysmurfMonitor(DatagramProtocol):
 
             path = data['payload']['path']
             val = data['payload']['value']
-            val_type = data['payload']['type']
+            data['payload']['type']
 
             field_name = ocs_feed.Feed.enforce_field_name_rules(path)
             feed_name = f'{stream_id}_meta'

--- a/agents/scpi_psu/scpi_psu_agent.py
+++ b/agents/scpi_psu/scpi_psu_agent.py
@@ -43,7 +43,7 @@ class ScpiPsuAgent:
                 self.psu = PsuInterface(self.ip_address, self.gpib_slot)
                 self.idn = self.psu.identify()
             except socket.timeout as e:
-                self.log.error("PSU timed out during connect")
+                self.log.error(f"PSU timed out during connect: {e}")
                 return False, "Timeout"
             self.log.info("Connected to psu: {}".format(self.idn))
 

--- a/agents/smurf_stream_simulator/smurf_stream_simulator.py
+++ b/agents/smurf_stream_simulator/smurf_stream_simulator.py
@@ -15,7 +15,7 @@ txaio.use_twisted()
 ON_RTD = os.environ.get('READTHEDOCS') == 'True'
 if not ON_RTD:
     from ocs import ocs_agent, site_config
-    import so3g
+    import so3g  # noqa: F401
     from spt3g import core
 
 
@@ -341,8 +341,8 @@ def make_parser(parser=None):
     # Add options specific to this agent.
     pgroup = parser.add_argument_group("Agent Options")
     pgroup.add_argument("--auto-start", default=False, type=bool,
-                        help="Automatically start streaming at " +
-                        "Agent startup.")
+                        help="Automatically start streaming at "
+                        + "Agent startup.")
     pgroup.add_argument("--target-host", default="*",
                         help="Target remote host.")
     pgroup.add_argument("--port", default=50000,

--- a/bin/rename_fields
+++ b/bin/rename_fields
@@ -247,10 +247,10 @@ class HKRenamer:
                 try:
                     Feed.verify_data_field_string(new_field)
                 except ValueError:
-                    raise ValueError("An unexpected invalid field name, " +
-                                     f"'{new_field}', was encountered. Please " +
-                                     "report this field name as an issue to " +
-                                     "the socs repository.")
+                    raise ValueError("An unexpected invalid field name, "
+                                     + f"'{new_field}', was encountered. Please "
+                                     + "report this field name as an issue to "
+                                     + "the socs repository.")
 
                 # print(k, new_field)
                 new_block[new_field] = core.G3VectorDouble(v)

--- a/simulators/lakeshore372/ls372_simulator.py
+++ b/simulators/lakeshore372/ls372_simulator.py
@@ -234,8 +234,8 @@ class Lakeshore372_Simulator:
                     cmds = data.decode().split(';')
 
                     if int(self.scanner) == 1:  # useful only if all channels have the same dwell and pause settings
-                        channel_change = int(elapsed_time // (self.channels[int(self.active_channel)].dwell +
-                                                              self.channels[int(self.active_channel)].pause))
+                        channel_change = int(elapsed_time // (self.channels[int(self.active_channel)].dwell
+                                                              + self.channels[int(self.active_channel)].pause))
                         # print(channel_change)
                         if 0 < channel_change < 16:
                             self.active_channel = 1 + channel_change
@@ -501,19 +501,19 @@ class Lakeshore372_Simulator:
             return
 
         if 0.0 <= float(p) <= 1000:
-            self.heaters[int(heater_output)].P = float(p)
+            self.heaters[int(heater_output)].p = float(p)
         else:
             self.log.warning("P value must be between 0.0 and 1000")
             return
 
         if 0 <= float(i) <= 10000:
-            self.heaters[int(heater_output)].I = float(i)
+            self.heaters[int(heater_output)].i = float(i)
         else:
             self.log.warning("I value must be between 0 and 10000")
             return
 
         if 0 <= float(d) <= 2500:
-            self.heaters[int(heater_output)].D = float(d)
+            self.heaters[int(heater_output)].d = float(d)
         else:
             self.log.warning("D value must be between 0 and 2500")
             return
@@ -521,7 +521,7 @@ class Lakeshore372_Simulator:
     def get_curve_header(self, curve):
         curve_index = int(curve)
         if not 1 <= curve_index <= 59:
-            self.log.warning(f"curve num must be between 1 and 59")
+            self.log.warning("curve num must be between 1 and 59")
             return
 
         return self.curves[curve_index].get_header()
@@ -529,7 +529,7 @@ class Lakeshore372_Simulator:
     def set_curve_header(self, curve, *args):
         curve_index = int(curve)
         if not 21 <= curve_index <= 59:
-            self.log.warning(f"curve num must be between 21 and 59")
+            self.log.warning("curve num must be between 21 and 59")
             return
 
         args = map(str, args)
@@ -538,7 +538,7 @@ class Lakeshore372_Simulator:
     def get_curve_data(self, curve, index):
         curve_index = int(curve)
         if not 1 <= curve_index <= 59:
-            self.log.warning(f"curve num must be between 1 and 59")
+            self.log.warning("curve num must be between 1 and 59")
             return
 
         return '{},{},{}'.format(str(self.curves[curve_index].data[int(index)][0]),
@@ -548,7 +548,7 @@ class Lakeshore372_Simulator:
     def set_curve_data(self, curve, index, units, kelvin, curvature=0):
         curve_index = int(curve)
         if not 21 <= curve_index <= 59:
-            self.log.warning(f"curve num must be between 21 and 59")
+            self.log.warning("curve num must be between 21 and 59")
             return
 
         self.curves[curve_index].data[int(index)][0] = float(units)
@@ -558,7 +558,7 @@ class Lakeshore372_Simulator:
     def delete_curve(self, curve):
         curve_index = int(curve)
         if not 21 <= curve_index <= 59:
-            self.log.warning(f"curve num must be between 21 and 59")
+            self.log.warning("curve num must be between 21 and 59")
             return
 
         for i in range(1, 201):
@@ -697,9 +697,9 @@ class Heater:
 
         self.setpoint = 0
 
-        self.P = 0
-        self.I = 0
-        self.D = 0
+        self.p = 0
+        self.i = 0
+        self.d = 0
 
     def get_output_mode(self):
         return ','.join([

--- a/socs/Lakeshore/Lakeshore240.py
+++ b/socs/Lakeshore/Lakeshore240.py
@@ -7,21 +7,14 @@ Created on Fri Feb 23 14:15:51 2018
 """
 
 from serial import Serial
-from serial.serialutil import SerialException
 import time
 import sys
-import numpy as np
 from collections import OrderedDict
 import socket
 from typing import List
 
 
 BUFF_SIZE = 1024
-
-try:
-    from tqdm import *
-except ModuleNotFoundError:
-    def tqdm(x): return x
 
 
 class Module:

--- a/socs/Lakeshore/Lakeshore336.py
+++ b/socs/Lakeshore/Lakeshore336.py
@@ -745,8 +745,8 @@ class Curve:
             with open(_file, 'w') as f:
                 f.write('Curve Name:\t' + self.name + '\r\n')
                 f.write('Serial Number:\t' + self.serial_number + '\r\n')
-                f.write('Data Format:\t' +
-                        format_lock[self.format] + f'\t({self.format})\r\n')
+                f.write('Data Format:\t'
+                        + format_lock[self.format] + f'\t({self.format})\r\n')
                 f.write('SetPoint Limit:\t%s\t(Kelvin)\r\n' % '%0.4f' %
                         np.max(self.breakpoints['temperature']))
                 f.write('Temperature coefficient:\t'
@@ -1273,25 +1273,25 @@ class Heater:
         Returns
         -------
         tuple
-            (P, I, D)
+            (p, i, d)
 
         """
         resp = self.ls.msg(f"PID? {self.output}").split(',')
-        self.P = float(resp[0])
-        self.I = float(resp[1])
-        self.D = float(resp[2])
-        return self.P, self.I, self.D
+        self.p = float(resp[0])
+        self.i = float(resp[1])
+        self.d = float(resp[2])
+        return self.p, self.i, self.d
 
-    def set_pid(self, P, I, D):
+    def set_pid(self, p, i, d):
         """Set PID parameters for closed loop control.
 
         Parameters
         ----------
-        P : float
+        p : float
             proportional term in PID loop
-        I : float
+        i : float
             integral term in PID loop
-        D : float
+        d : float
             derivative term in PID loop
 
         Returns
@@ -1300,15 +1300,15 @@ class Heater:
             response from PID command
 
         """
-        assert float(P) <= 1000 and float(P) >= 0.1
-        assert float(I) <= 1000 and float(I) >= 0.1
-        assert float(D) <= 200 and float(D) >= 0
+        assert float(p) <= 1000 and float(p) >= 0.1
+        assert float(i) <= 1000 and float(i) >= 0.1
+        assert float(d) <= 200 and float(d) >= 0
 
-        self.P = P
-        self.I = I
-        self.D = D
+        self.p = p
+        self.i = i
+        self.d = d
 
-        resp = self.ls.msg(f"PID {self.output},{P},{I},{D}")
+        resp = self.ls.msg(f"PID {self.output},{p},{i},{d}")
         return resp
 
     def get_ramp(self):

--- a/socs/Lakeshore/Lakeshore370.py
+++ b/socs/Lakeshore/Lakeshore370.py
@@ -6,8 +6,6 @@ import serial
 import time
 import numpy as np
 
-import traceback
-
 # Lookup keys for command parameters.
 autorange_key = {'0': 'off',
                  '1': 'on'}
@@ -208,7 +206,7 @@ class LS370:
             self.channels.append(c)
 
         self.sample_heater = Heater(self)
-        #self.still_heater = Heater(self, 2)
+        # self.still_heater = Heater(self, 2)
 
     def msg(self, message):
         """Send message to the Lakeshore 370 over RS-232.
@@ -391,7 +389,7 @@ class Channel:
         self._get_input_channel_parameter()
         self._get_input_setup()
         self.name = f'Channel {channel_num}'
-        #self.tlimit = self.get_temperature_limit()
+        # self.tlimit = self.get_temperature_limit()
 
     def _get_input_channel_parameter(self):
         """Run Input Channel Parameter Query
@@ -488,7 +486,7 @@ class Channel:
         _range = resp[2]
         _autorange = resp[3]
         _csshunt = resp[4]
-        #_units = resp[5]
+        # _units = resp[5]
 
         self.mode = mode_key[_mode]
 
@@ -507,7 +505,7 @@ class Channel:
 
         self.csshunt = csshunt_key[_csshunt]
 
-        #self.units = units_key[_units]
+        # self.units = units_key[_units]
 
         return resp
 
@@ -1392,7 +1390,7 @@ class Heater:
 
         self.resistance = None  # only for output = 0
         # self.max_current = None   in 370, there is only htrrng limit and curve limit
-        #self.max_user_current = None  not in 370
+        # self.max_user_current = None  not in 370
         self.rng_limit = None
         self.display = None
 
@@ -1451,8 +1449,8 @@ class Heater:
         self.display = heater_display_key[resp[4]]
         self.rng_limit = heater_range_key[resp[5]]
         self.resistance = float(resp[6])
-        #self.max_current = int(resp[1])
-        #self.max_user_current = float(resp[2].strip('E+'))
+        # self.max_current = int(resp[1])
+        # self.max_user_current = float(resp[2].strip('E+'))
 
         return [self.display, self.rng_limit, self.resistance]
 
@@ -1700,7 +1698,7 @@ class Heater:
         if str(_range).lower() == 'on':
             _range = "On"
 
-        resp = self.ls.msg(f"HTRRNG {heater_range_lock[_range]}").strip()
+        self.ls.msg(f"HTRRNG {heater_range_lock[_range]}").strip()
 
         # refresh self.heater value with RANGE? query
         self.get_heater_range()
@@ -1711,7 +1709,7 @@ class Heater:
         :returns: heater range in amps
         :rtype: float
         """
-        resp = self.ls.msg(f"HTRRNG?").strip()
+        resp = self.ls.msg("HTRRNG?").strip()
 
         self.range = heater_range_key[resp]
 
@@ -1723,7 +1721,7 @@ class Heater:
 
     # SETP? - heater class, uses self.units to interpret value
     def get_setpoint(self):
-        resp = self.ls.msg(f"SETP?")
+        resp = self.ls.msg("SETP?")
         return resp
 
     # STILL - heater class?
@@ -1732,7 +1730,7 @@ class Heater:
 
     # STILL? - heater_class?
     def get_still_output(self):
-        resp = self.ls.msg(f"STILL?")
+        resp = self.ls.msg("STILL?")
         return resp
 
     # ANALOG, ANALOG?, AOUT?
@@ -1744,31 +1742,31 @@ class Heater:
         pass
 
     # PID
-    def set_pid(self, P, I, D):
+    def set_pid(self, p, i, d):
         """Set PID parameters for closed loop control.
 
-        :params P: proportional term in PID loop
-        :type P: float
-        :params I: integral term in PID loop
-        :type I: float
-        :params D: derivative term in PID loop
-        :type D: float
+        :params p: proportional term in PID loop
+        :type p: float
+        :params i: integral term in PID loop
+        :type i: float
+        :params d: derivative term in PID loop
+        :type d: float
 
         :returns: response from PID command
         :rtype: str
         """
-        assert float(P) <= 1000 and float(P) >= 0
-        assert float(I) <= 10000 and float(I) >= 0
-        assert float(D) <= 2500 and float(D) >= 0
+        assert float(p) <= 1000 and float(p) >= 0
+        assert float(i) <= 10000 and float(i) >= 0
+        assert float(d) <= 2500 and float(d) >= 0
 
-        resp = self.ls.msg(f"PID {P},{I},{D}")
+        resp = self.ls.msg(f"PID {p},{i},{d}")
         return resp
 
     # PID?
     def get_pid(self):
         """Get PID parameters with PID? command.
 
-        :returns: P, I, D
+        :returns: p, i, d
         :rtype: float, float, float
         """
         resp = self.ls.msg("PID?").split(',')

--- a/socs/Lakeshore/Lakeshore372.py
+++ b/socs/Lakeshore/Lakeshore372.py
@@ -2,7 +2,6 @@
 
 import sys
 import socket
-import time
 import numpy as np
 
 # Lookup keys for command parameters.
@@ -1728,11 +1727,11 @@ class Heater:
             _range = "On"
 
         if self.output == 0:
-            resp = self.ls.msg(f"RANGE {self.output} {heater_range_lock[_range]}").strip()
+            self.ls.msg(f"RANGE {self.output} {heater_range_lock[_range]}").strip()
         else:
             on_off_key = {"0": "Off", "1": "On"}
             on_off_lock = {v: k for k, v in on_off_key.items()}
-            resp = self.ls.msg(f"RANGE {self.output} {on_off_lock[_range]}").strip()
+            self.ls.msg(f"RANGE {self.output} {on_off_lock[_range]}").strip()
 
         # refresh self.heater value with RANGE? query
         self.get_heater_range()
@@ -1768,7 +1767,7 @@ class Heater:
 
     # STILL? - heater_class?
     def get_still_output(self):
-        resp = self.ls.msg(f"STILL?")
+        resp = self.ls.msg("STILL?")
         return resp
 
     # ANALOG, ANALOG?, AOUT?
@@ -1780,31 +1779,31 @@ class Heater:
         pass
 
     # PID
-    def set_pid(self, P, I, D):
+    def set_pid(self, p, i, d):
         """Set PID parameters for closed loop control.
 
-        :params P: proportional term in PID loop
-        :type P: float
-        :params I: integral term in PID loop
-        :type I: float
-        :params D: derivative term in PID loop
-        :type D: float
+        :params p: proportional term in PID loop
+        :type p: float
+        :params i: integral term in PID loop
+        :type i: float
+        :params d: derivative term in PID loop
+        :type d: float
 
         :returns: response from PID command
         :rtype: str
         """
-        assert float(P) <= 1000 and float(P) >= 0
-        assert float(I) <= 10000 and float(I) >= 0
-        assert float(D) <= 2500 and float(D) >= 0
+        assert float(p) <= 1000 and float(p) >= 0
+        assert float(i) <= 10000 and float(i) >= 0
+        assert float(d) <= 2500 and float(d) >= 0
 
-        resp = self.ls.msg(f"PID {self.output},{P},{I},{D}")
+        resp = self.ls.msg(f"PID {self.output},{p},{i},{d}")
         return resp
 
     # PID?
     def get_pid(self):
         """Get PID parameters with PID? command.
 
-        :returns: P, I, D
+        :returns: p, i, d
         :rtype: float, float, float
         """
         resp = self.ls.msg("PID?").split(',')

--- a/socs/agent/moxaSerial.py
+++ b/socs/agent/moxaSerial.py
@@ -230,5 +230,5 @@ class Serial_TCPServer(object):
         return self.__timeout
 
     timeout = property(gettimeout, settimeout,
-                       doc='Communication timeout. Only use timeout mode ' +
-                           'with ``timeout > 0.0``.')
+                       doc='Communication timeout. Only use timeout mode '
+                           + 'with ``timeout > 0.0``.')

--- a/socs/agent/pmx.py
+++ b/socs/agent/pmx.py
@@ -1,7 +1,6 @@
 import time
 import serial
 import sys
-import os
 
 from socs.agent import moxaSerial as mx
 
@@ -44,7 +43,7 @@ class PMX:
     def check_voltage(self):
         """Check the voltage."""
         self.clean_serial()
-        bts = self.ser.write("MEAS:VOLT?\n\r")
+        self.ser.write("MEAS:VOLT?\n\r")
         self.wait()
         val = float(self.ser.readline())
         msg = "Measured voltage = %.3f V" % (val)
@@ -66,10 +65,10 @@ class PMX:
         self.clean_serial()
         voltage = self.check_voltage()[1]
         current = self.check_current()[1]
-        msg = (
-            "Measured voltage = %.3f V\n"
-            "Measured current = %.3f A\n"
-            % (voltage, current))
+        # msg = (
+        #     "Measured voltage = %.3f V\n"
+        #     "Measured current = %.3f A\n"
+        #     % (voltage, current))
         # print(msg)
         return voltage, current
 
@@ -97,7 +96,7 @@ class PMX:
         self.wait()
         val = self.ser.readline()
         msg = "Voltage set = %.3f V" % (float(val))
-        if (silent != True):
+        if silent is not True:
             print(msg)
 
         return msg
@@ -111,7 +110,7 @@ class PMX:
         self.wait()
         val = self.ser.readline()
         msg = "Current set = %.3f A\n" % (float(val))
-        if (silent != True):
+        if silent is not True:
             print(msg)
 
         return msg
@@ -151,7 +150,7 @@ class PMX:
         self.wait()
         val = self.ser.readline()
         msg = "Voltage limit set = %.3f V" % (float(val))
-        if (silent != True):
+        if silent is not True:
             print(msg)
 
         return msg
@@ -165,7 +164,7 @@ class PMX:
         self.wait()
         val = self.ser.readline()
         msg = "Current limit set = %.3f A\n" % (float(val))
-        if (silent != True):
+        if silent is not True:
             print(msg)
 
         return msg
@@ -210,8 +209,8 @@ class PMX:
             raise Exception(
                 "Aborted PMX._conn() due to no RTU or "
                 "TCP port specified")
-        elif (rtu_port is not None and
-              (tcp_ip is not None or tcp_port is not None)):
+        elif (rtu_port is not None
+              and (tcp_ip is not None or tcp_port is not None)):
             raise Exception(
                 "Aborted PMX._conn() due to RTU and TCP port both being "
                 "specified. Can only have one or the other.")
@@ -330,7 +329,7 @@ class Command:
         """Take user input and execute PMX command."""
         argv = arg.split()
         # if len(args) > 0:
-        #value = float(args[0])
+        # value = float(args[0])
 
         while len(argv):
             cmd = str(argv.pop(0)).upper()
@@ -359,10 +358,10 @@ class Command:
 
             # elif cmd == self._cmds["set_v"]:
                 # print(value)
-                #ret = self._PMX.set_voltage(value)
+                # ret = self._PMX.set_voltage(value)
 
             # elif cmd == self._cmds["set_c"]:
-                #ret = self._PMX.set_current(value)
+                # ret = self._PMX.set_current(value)
 
             elif cmd == self._cmds["use_ext"]:
                 return self._PMX.use_external_voltage()

--- a/socs/snmp.py
+++ b/socs/snmp.py
@@ -62,8 +62,8 @@ class SNMPTwister:
         if error_status:
             self.log.error('%s: %s at %s' % (self.address,
                                              error_status.prettyPrint(),
-                                             error_index and
-                                             var_binds[int(error_index) - 1][0] or '?'))
+                                             error_index
+                                             and var_binds[int(error_index) - 1][0] or '?'))
         else:
             for var in var_binds:
                 self.log.debug(' = '.join([x.prettyPrint() for x in var]))

--- a/socs/testing/device_emulator.py
+++ b/socs/testing/device_emulator.py
@@ -27,8 +27,8 @@ def create_device_emulator(responses, relay_type, port=9001):
 
     """
     if relay_type not in ['serial', 'tcp']:
-        raise NotImplementedError(f"relay_type '{relay_type}' is not" +
-                                  "implemented or is an invalid type")
+        raise NotImplementedError(f"relay_type '{relay_type}' is not"
+                                  + "implemented or is an invalid type")
 
     @pytest.fixture()
     def create_device():

--- a/socs/util.py
+++ b/socs/util.py
@@ -1,7 +1,4 @@
 import hashlib
-from typing import ContextManager
-from contextlib import contextmanager
-import os
 
 
 def get_md5sum(filename):

--- a/tests/agents/test_cryomech_cpa_agent.py
+++ b/tests/agents/test_cryomech_cpa_agent.py
@@ -1,3 +1,3 @@
 import sys
 sys.path.insert(0, '../agents/cryomech_cpa/')
-from cryomech_cpa_agent import PTCAgent
+from cryomech_cpa_agent import PTCAgent  # noqa: F401

--- a/tests/agents/test_fts_aerotech_agent.py
+++ b/tests/agents/test_fts_aerotech_agent.py
@@ -1,3 +1,3 @@
 import sys
 sys.path.insert(0, '../agents/fts_aerotech_stage/')
-from fts_aerotech_agent import FTSAerotechAgent
+from fts_aerotech_agent import FTSAerotechAgent  # noqa: F401

--- a/tests/agents/test_hwpbbb_agent.py
+++ b/tests/agents/test_hwpbbb_agent.py
@@ -1,3 +1,3 @@
 import sys
 sys.path.insert(0, '../agents/chwp/')
-from hwpbbb_agent import HWPBBBAgent
+from hwpbbb_agent import HWPBBBAgent  # noqa: F401

--- a/tests/agents/test_ls240_agent.py
+++ b/tests/agents/test_ls240_agent.py
@@ -1,3 +1,3 @@
 import sys
 sys.path.insert(0, '../agents/lakeshore240/')
-from LS240_agent import LS240_Agent
+from LS240_agent import LS240_Agent  # noqa: F401

--- a/tests/agents/test_ls372_agent.py
+++ b/tests/agents/test_ls372_agent.py
@@ -325,7 +325,7 @@ def test_ls372_set_heater_range_identical_range(agent):
     agent.init_lakeshore(session, None)
 
     # Mock the heater interface
-    #agent.module.sample_heater.get_heater_range = mock.Mock(return_value="Off")
+    # agent.module.sample_heater.get_heater_range = mock.Mock(return_value="Off")
     agent.module.sample_heater.set_heater_range = mock.Mock()
 
     params = {'range': 'Off', 'heater': 'sample', 'wait': 0}

--- a/tests/agents/test_ls425_agent.py
+++ b/tests/agents/test_ls425_agent.py
@@ -1,3 +1,3 @@
 import sys
 sys.path.insert(0, '../agents/lakeshore425/')
-from LS425_agent import LS425Agent
+from LS425_agent import LS425Agent  # noqa: F401

--- a/tests/agents/test_meinberg_m1000_agent.py
+++ b/tests/agents/test_meinberg_m1000_agent.py
@@ -1,3 +1,3 @@
 import sys
 sys.path.insert(0, '../agents/meinberg_m1000/')
-from meinberg_m1000_agent import MeinbergM1000Agent
+from meinberg_m1000_agent import MeinbergM1000Agent  # noqa: F401

--- a/tests/agents/test_pfeiffer_tpg366_agent.py
+++ b/tests/agents/test_pfeiffer_tpg366_agent.py
@@ -1,3 +1,3 @@
 import sys
 sys.path.insert(0, '../agents/pfeiffer_tpg366/')
-from pfeiffer_tpg366_agent import PfeifferAgent
+from pfeiffer_tpg366_agent import PfeifferAgent  # noqa: F401

--- a/tests/agents/test_pysmurf_monitor.py
+++ b/tests/agents/test_pysmurf_monitor.py
@@ -1,3 +1,3 @@
 import sys
 sys.path.insert(0, '../agents/pysmurf_monitor/')
-from pysmurf_monitor import PysmurfMonitor
+from pysmurf_monitor import PysmurfMonitor  # noqa: F401

--- a/tests/agents/test_scpi_psu_agent.py
+++ b/tests/agents/test_scpi_psu_agent.py
@@ -1,3 +1,3 @@
 import sys
 sys.path.insert(0, '../agents/scpi_psu/')
-from scpi_psu_agent import ScpiPsuAgent
+from scpi_psu_agent import ScpiPsuAgent  # noqa: F401

--- a/tests/agents/test_smurf_crate_monitor.py
+++ b/tests/agents/test_smurf_crate_monitor.py
@@ -1,3 +1,3 @@
 import sys
 sys.path.insert(0, '../agents/smurf_crate_monitor/')
-from smurf_crate_monitor import SmurfCrateMonitor
+from smurf_crate_monitor import SmurfCrateMonitor  # noqa: F401

--- a/tests/agents/test_smurf_file_emulator.py
+++ b/tests/agents/test_smurf_file_emulator.py
@@ -1,12 +1,7 @@
 import sys
 sys.path.insert(0, '../agents/smurf_file_emulator/')
-import os
 from smurf_file_emulator import SmurfFileEmulator, make_parser
 
-
-from ocs.ocs_agent import OpSession
-
-import pytest
 from unittest import mock
 
 import txaio

--- a/tests/agents/test_smurf_stream_simulator.py
+++ b/tests/agents/test_smurf_stream_simulator.py
@@ -1,3 +1,3 @@
 import sys
 sys.path.insert(0, '../agents/smurf_stream_simulator/')
-from smurf_stream_simulator import SmurfStreamSimulator
+from smurf_stream_simulator import SmurfStreamSimulator  # noqa: F401

--- a/tests/agents/test_suprsync_agent.py
+++ b/tests/agents/test_suprsync_agent.py
@@ -4,8 +4,7 @@ import numpy as np
 import txaio
 
 sys.path.insert(0, '../agents/suprsync/')
-from suprsync import SupRsync
-from socs.db.suprsync import SupRsyncFilesManager, SupRsyncFile, SupRsyncFileHandler
+from socs.db.suprsync import SupRsyncFilesManager, SupRsyncFileHandler
 
 txaio.use_twisted()
 
@@ -27,7 +26,7 @@ def test_suprsync_handle_files(tmp_path):
     Tests file handling
     """
     txaio.start_logging(level='info')
-    log = txaio.make_logger()
+    txaio.make_logger()
     db_path = str(tmp_path / 'test.db')
     dest = tmp_path / 'dest'
     dest.mkdir()
@@ -51,7 +50,7 @@ def test_suprsync_handle_files(tmp_path):
         srfm.add_file(path, f'test_remote/{fname}', archive_name,
                       deletable=True)
 
-    fname = f"dont_delete.npy"
+    fname = "dont_delete.npy"
     path = str(data_dir / fname)
     np.save(path, file_data)
     srfm.add_file(path, f'test_remote/{fname}', archive_name,

--- a/tests/agents/test_synacc.py
+++ b/tests/agents/test_synacc.py
@@ -1,3 +1,3 @@
 import sys
 sys.path.insert(0, '../agents/synacc/')
-from synacc import SynaccessAgent
+from synacc import SynaccessAgent  # noqa: F401

--- a/tests/agents/test_tektronix_agent.py
+++ b/tests/agents/test_tektronix_agent.py
@@ -1,3 +1,3 @@
 import sys
 sys.path.insert(0, '../agents/tektronix3021c/')
-from tektronix_agent import TektronixAWGAgent
+from tektronix_agent import TektronixAWGAgent  # noqa: F401

--- a/tests/agents/test_vantage_pro2_agent.py
+++ b/tests/agents/test_vantage_pro2_agent.py
@@ -1,3 +1,3 @@
 import sys
 sys.path.insert(0, '../agents/vantagePro2_agent/')
-from vantage_pro2_agent import VantagePro2Agent
+from vantage_pro2_agent import VantagePro2Agent  # noqa: F401

--- a/tests/hardware/ls240/conftest.py
+++ b/tests/hardware/ls240/conftest.py
@@ -14,5 +14,5 @@ def client(request):
     c = MatchedClient(inst, args=[])
     print("Initializing Lakeshore.....")
     c.init_lakeshore.start()
-    x = c.init_lakeshore.wait()
+    c.init_lakeshore.wait()
     return c

--- a/tests/integration/test_ls425_agent_integration.py
+++ b/tests/integration/test_ls425_agent_integration.py
@@ -1,14 +1,5 @@
-import os
 import time
 import pytest
-import signal
-import subprocess
-import coverage.data
-import urllib.request
-
-from urllib.error import URLError
-
-from ocs.matched_client import MatchedClient
 
 import ocs
 from ocs.base import OpCode

--- a/tests/integration/test_pfeiffer_tc400_agent_integration.py
+++ b/tests/integration/test_pfeiffer_tc400_agent_integration.py
@@ -1,5 +1,4 @@
 import os
-import time
 import pytest
 
 import ocs

--- a/tests/test_snmp.py
+++ b/tests/test_snmp.py
@@ -1,1 +1,1 @@
-from socs import snmp
+from socs import snmp  # noqa: F401

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -1,1 +1,1 @@
-from socs import util
+from socs import util  # noqa: F401


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
This addresses all flake8 warnings across the entire repo. This was run using the new pre-commit hook, and makes changes to conform to PEP08.

A full list of the warnings addressed:
```
tests/agents/test_smurf_stream_simulator.py:3:1: F401 'smurf_stream_simulator.SmurfStreamSimulator' imported but unused
tests/agents/test_pfeiffer_tpg366_agent.py:3:1: F401 'pfeiffer_tpg366_agent.PfeifferAgent' imported but unused
agents/magpie/magpie_agent.py:2:1: F401 'so3g' imported but unused
agents/magpie/magpie_agent.py:807:13: F841 local variable 'res' is assigned to but never used
tests/test_snmp.py:1:1: F401 'socs.snmp' imported but unused
tests/agents/test_smurf_crate_monitor.py:3:1: F401 'smurf_crate_monitor.SmurfCrateMonitor' imported but unused
tests/agents/test_meinberg_m1000_agent.py:3:1: F401 'meinberg_m1000_agent.MeinbergM1000Agent' imported but unused
tests/agents/test_suprsync_agent.py:7:1: F401 'suprsync.SupRsync' imported but unused
tests/agents/test_suprsync_agent.py:8:1: F401 'socs.db.suprsync.SupRsyncFile' imported but unused
tests/agents/test_suprsync_agent.py:30:5: F841 local variable 'log' is assigned to but never used
tests/agents/test_suprsync_agent.py:54:13: F541 f-string is missing placeholders
agents/smurf_stream_simulator/smurf_stream_simulator.py:18:5: F401 'so3g' imported but unused
agents/smurf_stream_simulator/smurf_stream_simulator.py:344:66: W504 line break after binary operator
agents/lakeshore372/LS372_agent.py:316:88: W504 line break after binary operator
agents/lakeshore372/LS372_agent.py:317:83: W504 line break after binary operator
agents/lakeshore372/LS372_agent.py:318:82: W504 line break after binary operator
agents/lakeshore372/LS372_agent.py:319:81: W504 line break after binary operator
agents/lakeshore372/LS372_agent.py:320:81: W504 line break after binary operator
agents/lakeshore372/LS372_agent.py:632:13: F841 local variable 'current_dwell' is assigned to but never used
agents/lakeshore372/LS372_agent.py:764:37: F541 f-string is missing placeholders
agents/lakeshore372/LS372_agent.py:769:37: F541 f-string is missing placeholders
agents/lakeshore372/LS372_agent.py:774:37: F541 f-string is missing placeholders
agents/lakeshore372/LS372_agent.py:779:37: F541 f-string is missing placeholders
agents/lakeshore372/LS372_agent.py:829:37: F541 f-string is missing placeholders
agents/lakeshore370/LS370_agent.py:248:88: W504 line break after binary operator
agents/lakeshore370/LS370_agent.py:249:83: W504 line break after binary operator
agents/lakeshore370/LS370_agent.py:250:82: W504 line break after binary operator
agents/lakeshore370/LS370_agent.py:251:81: W504 line break after binary operator
agents/lakeshore370/LS370_agent.py:252:81: W504 line break after binary operator
socs/snmp.py:65:58: W504 line break after binary operator
socs/Lakeshore/Lakeshore372.py:5:1: F401 'time' imported but unused
socs/Lakeshore/Lakeshore372.py:1735:13: F841 local variable 'resp' is assigned to but never used
socs/Lakeshore/Lakeshore372.py:1771:28: F541 f-string is missing placeholders
socs/Lakeshore/Lakeshore372.py:1783:26: E741 ambiguous variable name 'I'
agents/chwp/hwpbbb_agent.py:90:1: E266 too many leading '#' for block comment
agents/chwp/hwpbbb_agent.py:110:13: W503 line break before binary operator
agents/chwp/hwpbbb_agent.py:111:13: W503 line break before binary operator
agents/chwp/hwpbbb_agent.py:112:13: W503 line break before binary operator
agents/chwp/hwpbbb_agent.py:113:13: W503 line break before binary operator
agents/chwp/hwpbbb_agent.py:114:13: W503 line break before binary operator
agents/chwp/hwpbbb_agent.py:115:13: W503 line break before binary operator
agents/chwp/hwpbbb_agent.py:116:13: W503 line break before binary operator
agents/chwp/hwpbbb_agent.py:261:9: E265 block comment should start with '# '
agents/chwp/hwpbbb_agent.py:334:21: E265 block comment should start with '# '
agents/chwp/hwpbbb_agent.py:418:36: W503 line break before binary operator
agents/chwp/hwpbbb_agent.py:468:36: W503 line break before binary operator
agents/chwp/hwpbbb_agent.py:573:89: W504 line break after binary operator
agents/chwp/hwpbbb_agent.py:596:28: W503 line break before binary operator
tests/agents/test_ls240_agent.py:3:1: F401 'LS240_agent.LS240_Agent' imported but unused
tests/agents/test_vantage_pro2_agent.py:3:1: F401 'vantage_pro2_agent.VantagePro2Agent' imported but unused
tests/agents/test_tektronix_agent.py:3:1: F401 'tektronix_agent.TektronixAWGAgent' imported but unused
tests/test_util.py:1:1: F401 'socs.util' imported but unused
tests/agents/test_pysmurf_monitor.py:3:1: F401 'pysmurf_monitor.PysmurfMonitor' imported but unused
tests/integration/test_pfeiffer_tc400_agent_integration.py:2:1: F401 'time' imported but unused
agents/pfeiffer_tc400/pfeiffer_tc400_agent.py:75:61: W504 line break after binary operator
agents/pfeiffer_tc400/pfeiffer_tc400_agent.py:225:78: W504 line break after binary operator
agents/pfeiffer_tc400/pfeiffer_tc400_agent.py:227:79: W504 line break after binary operator
agents/pfeiffer_tc400/pfeiffer_tc400_agent.py:229:79: W504 line break after binary operator
agents/pfeiffer_tc400/pfeiffer_tc400_agent.py:231:78: W504 line break after binary operator
agents/meinberg_m1000/meinberg_m1000_agent.py:173:70: W504 line break after binary operator
agents/meinberg_m1000/meinberg_m1000_agent.py:413:75: W504 line break after binary operator
agents/meinberg_m1000/meinberg_m1000_agent.py:414:69: W504 line break after binary operator
agents/meinberg_m1000/meinberg_m1000_agent.py:450:73: W504 line break after binary operator
agents/meinberg_m1000/meinberg_m1000_agent.py:456:76: W504 line break after binary operator
tests/agents/test_cryomech_cpa_agent.py:3:1: F401 'cryomech_cpa_agent.PTCAgent' imported but unused
agents/pfeiffer_tpg366/pfeiffer_tpg366_agent.py:7:1: F401 'numpy as np' imported but unused
agents/pfeiffer_tpg366/pfeiffer_tpg366_agent.py:54:9: F841 local variable 'status' is assigned to but never used
agents/pfeiffer_tpg366/pfeiffer_tpg366_agent.py:75:9: F841 local variable 'status' is assigned to but never used
agents/pfeiffer_tpg366/pfeiffer_tpg366_agent.py:79:9: E265 block comment should start with '# '
agents/pfeiffer_tpg366/pfeiffer_tpg366_agent.py:80:9: E265 block comment should start with '# '
agents/cryomech_cpa/cryomech_cpa_agent.py:209:22: F821 undefined name 'Optional'
agents/cryomech_cpa/cryomech_cpa_agent.py:209:31: F821 undefined name 'Module'
tests/agents/test_hwpbbb_agent.py:3:1: F401 'hwpbbb_agent.HWPBBBAgent' imported but unused
tests/integration/test_ls425_agent_integration.py:1:1: F401 'os' imported but unused
tests/integration/test_ls425_agent_integration.py:4:1: F401 'signal' imported but unused
tests/integration/test_ls425_agent_integration.py:5:1: F401 'subprocess' imported but unused
tests/integration/test_ls425_agent_integration.py:6:1: F401 'coverage.data' imported but unused
tests/integration/test_ls425_agent_integration.py:7:1: F401 'urllib.request' imported but unused
tests/integration/test_ls425_agent_integration.py:9:1: F401 'urllib.error.URLError' imported but unused
tests/integration/test_ls425_agent_integration.py:11:1: F401 'ocs.matched_client.MatchedClient' imported but unused
agents/pysmurf_monitor/pysmurf_monitor.py:141:13: F841 local variable 'val_type' is assigned to but never used
agents/bluefors/bluefors_log_tracker.py:394:75: W504 line break after binary operator
agents/bluefors/bluefors_log_tracker.py:398:79: W504 line break after binary operator
agents/bluefors/bluefors_log_tracker.py:410:79: W504 line break after binary operator
agents/bluefors/bluefors_log_tracker.py:411:83: W504 line break after binary operator
bin/rename_fields:250:75: W504 line break after binary operator
bin/rename_fields:251:81: W504 line break after binary operator
bin/rename_fields:252:79: W504 line break after binary operator
tests/agents/test_ls372_agent.py:328:5: E265 block comment should start with '# '
socs/agent/moxaSerial.py:233:76: W504 line break after binary operator
socs/Lakeshore/Lakeshore240.py:10:1: F401 'serial.serialutil.SerialException' imported but unused
socs/Lakeshore/Lakeshore240.py:13:1: F401 'numpy as np' imported but unused
socs/Lakeshore/Lakeshore240.py:22:5: F403 'from tqdm import *' used; unable to detect undefined names
socs/Lakeshore/Lakeshore240.py:22:5: F401 'tqdm.*' imported but unused
socs/Lakeshore/Lakeshore240.py:24:5: E704 multiple statements on one line (def)
agents/hwp_rotation/src/pid_controller.py:247:83: W504 line break after binary operator
socs/Lakeshore/Lakeshore370.py:9:1: F401 'traceback' imported but unused
socs/Lakeshore/Lakeshore370.py:211:9: E265 block comment should start with '# '
socs/Lakeshore/Lakeshore370.py:394:9: E265 block comment should start with '# '
socs/Lakeshore/Lakeshore370.py:491:9: E265 block comment should start with '# '
socs/Lakeshore/Lakeshore370.py:510:9: E265 block comment should start with '# '
socs/Lakeshore/Lakeshore370.py:1395:9: E265 block comment should start with '# '
socs/Lakeshore/Lakeshore370.py:1454:9: E265 block comment should start with '# '
socs/Lakeshore/Lakeshore370.py:1455:9: E265 block comment should start with '# '
socs/Lakeshore/Lakeshore370.py:1703:9: F841 local variable 'resp' is assigned to but never used
socs/Lakeshore/Lakeshore370.py:1714:28: F541 f-string is missing placeholders
socs/Lakeshore/Lakeshore370.py:1726:28: F541 f-string is missing placeholders
socs/Lakeshore/Lakeshore370.py:1735:28: F541 f-string is missing placeholders
socs/Lakeshore/Lakeshore370.py:1747:26: E741 ambiguous variable name 'I'
socs/agent/pmx.py:4:1: F401 'os' imported but unused
socs/agent/pmx.py:47:9: F841 local variable 'bts' is assigned to but never used
socs/agent/pmx.py:69:9: F841 local variable 'msg' is assigned to but never used
socs/agent/pmx.py:100:20: E712 comparison to True should be 'if cond is not True:' or 'if not cond:'
socs/agent/pmx.py:114:20: E712 comparison to True should be 'if cond is not True:' or 'if not cond:'
socs/agent/pmx.py:154:20: E712 comparison to True should be 'if cond is not True:' or 'if not cond:'
socs/agent/pmx.py:168:20: E712 comparison to True should be 'if cond is not True:' or 'if not cond:'
socs/agent/pmx.py:213:36: W504 line break after binary operator
socs/agent/pmx.py:333:9: E265 block comment should start with '# '
socs/agent/pmx.py:362:17: E265 block comment should start with '# '
socs/agent/pmx.py:365:17: E265 block comment should start with '# '
tests/hardware/ls240/conftest.py:17:5: F841 local variable 'x' is assigned to but never used
agents/lakeshore336/LS336_agent.py:221:62: W504 line break after binary operator
agents/lakeshore336/LS336_agent.py:370:21: W503 line break before binary operator
agents/lakeshore336/LS336_agent.py:371:21: W503 line break before binary operator
tests/agents/test_smurf_file_emulator.py:3:1: F401 'os' imported but unused
tests/agents/test_smurf_file_emulator.py:7:1: F401 'ocs.ocs_agent.OpSession' imported but unused
tests/agents/test_smurf_file_emulator.py:9:1: F401 'pytest' imported but unused
tests/agents/test_fts_aerotech_agent.py:3:1: F401 'fts_aerotech_agent.FTSAerotechAgent' imported but unused
socs/util.py:2:1: F401 'typing.ContextManager' imported but unused
socs/util.py:3:1: F401 'contextlib.contextmanager' imported but unused
socs/util.py:4:1: F401 'os' imported but unused
tests/agents/test_synacc.py:3:1: F401 'synacc.SynaccessAgent' imported but unused
socs/Lakeshore/Lakeshore336.py:748:42: W504 line break after binary operator
socs/Lakeshore/Lakeshore336.py:753:25: W503 line break before binary operator
socs/Lakeshore/Lakeshore336.py:754:25: W503 line break before binary operator
socs/Lakeshore/Lakeshore336.py:1281:14: E741 ambiguous variable name 'I'
socs/Lakeshore/Lakeshore336.py:1285:26: E741 ambiguous variable name 'I'
socs/Lakeshore/Lakeshore336.py:1308:14: E741 ambiguous variable name 'I'
simulators/lakeshore372/ls372_simulator.py:237:109: W504 line break after binary operator
simulators/lakeshore372/ls372_simulator.py:510:46: E741 ambiguous variable name 'I'
simulators/lakeshore372/ls372_simulator.py:524:30: F541 f-string is missing placeholders
simulators/lakeshore372/ls372_simulator.py:532:30: F541 f-string is missing placeholders
simulators/lakeshore372/ls372_simulator.py:541:30: F541 f-string is missing placeholders
simulators/lakeshore372/ls372_simulator.py:551:30: F541 f-string is missing placeholders
simulators/lakeshore372/ls372_simulator.py:561:30: F541 f-string is missing placeholders
simulators/lakeshore372/ls372_simulator.py:701:14: E741 ambiguous variable name 'I'
agents/scpi_psu/scpi_psu_agent.py:45:13: F841 local variable 'e' is assigned to but never used
tests/agents/test_scpi_psu_agent.py:3:1: F401 'scpi_psu_agent.ScpiPsuAgent' imported but unused
socs/testing/device_emulator.py:30:71: W504 line break after binary operator
tests/agents/test_ls425_agent.py:3:1: F401 'LS425_agent.LS425Agent' imported but unused
```

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
The last step in adoption of pre-commit.ci.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
Unit and integration test pass. Not otherwise tested.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] Unless I am preparing a release, I have opened this PR onto the `develop` branch.
