### PR TITLE
Smurf emulator tune support

### DIFF
--- a/agents/smurf_file_emulator/smurf_file_emulator.py
+++ b/agents/smurf_file_emulator/smurf_file_emulator.py
@@ -404,7 +404,7 @@ class SmurfFileEmulator:
 
     @ocs_agent.param('test_mode', type=bool, default=False)
     def uxm_setup(self, session, params):
-        """uxm_setup()
+        """uxm_setup(test_mode=False)
 
         **Task** - Emulates files that might come from a general tune dets
         function. These are some of the files found on simons1 registered when

--- a/agents/smurf_file_emulator/smurf_file_emulator.py
+++ b/agents/smurf_file_emulator/smurf_file_emulator.py
@@ -304,10 +304,10 @@ class DataStreamer:
         """
         frame_starts = np.arange(start, stop, self.frame_len)
         frame_stops = frame_starts + self.frame_len
-        
+
         # In case there's already an open file
         self.seq = 0
-        self.end_file() 
+        self.end_file()
 
         self._new_file()
         for t0, t1 in zip(frame_starts, frame_stops):

--- a/agents/smurf_file_emulator/smurf_file_emulator.py
+++ b/agents/smurf_file_emulator/smurf_file_emulator.py
@@ -26,10 +26,12 @@ SMURF_FREQ_RANGE = (4e3, 8e3)
 SUBBANDS_PER_BAND = 512
 CHANS_PER_BAND = 512
 
+
 class Tune:
     """
     Helper class for generating tunes
     """
+
     def __init__(self, nchans=1720):
         self.log = txaio.make_logger()
 
@@ -41,7 +43,7 @@ class Tune:
 
         rs = self.res_freqs - SMURF_FREQ_RANGE[0]
         self.bands = (rs / band_width).astype(int)
-        self.subbands = ((rs / subband_width) % SUBBANDS_PER_BAND).astype(int) 
+        self.subbands = ((rs / subband_width) % SUBBANDS_PER_BAND).astype(int)
 
         # just assigns channels in order for each band, making sure this
         # doesn't go above chans_per_band
@@ -127,7 +129,7 @@ class Tune:
             m = self.bands == b
             d = np.array([
                 self.res_freqs[m],
-                self.subbands[m], 
+                self.subbands[m],
                 self.channels[m],
                 np.full(np.sum(m), -1)
             ]).T
@@ -222,6 +224,7 @@ class DataStreamer:
     """
     Helper class for streaming G3 data
     """
+
     def __init__(self, stream_id, sample_rate, tune, timestreamdir,
                  file_duration, frame_len):
         self.frame_gen = G3FrameGenerator(stream_id, sample_rate, tune)
@@ -280,8 +283,6 @@ class DataStreamer:
                     time.sleep(t1 - now)
             self.writer(self.frame_gen.get_data_frame(start, stop))
         self.end_file()
-        
-
 
 
 class SmurfFileEmulator:
@@ -474,7 +475,6 @@ class SmurfFileEmulator:
                                    action_time=action_time)
 
         return True, "Finished taking bgmap"
-
 
     def bias_dets(self, session, params=None):
         """bias_dets()

--- a/docs/agents/smurf_file_emulator.rst
+++ b/docs/agents/smurf_file_emulator.rst
@@ -63,3 +63,15 @@ Agent API
 
 .. autoclass:: agents.smurf_file_emulator.smurf_file_emulator.SmurfFileEmulator
     :members:
+
+Supporting API
+---------------
+
+.. autoclass:: agents.smurf_file_emulator.smurf_file_emulator.Tune
+    :members:
+
+.. autoclass:: agents.smurf_file_emulator.smurf_file_emulator.DataStreamer
+    :members:
+
+.. autoclass:: agents.smurf_file_emulator.smurf_file_emulator.G3FrameGenerator
+    :members:

--- a/tests/agents/test_smurf_file_emulator.py
+++ b/tests/agents/test_smurf_file_emulator.py
@@ -48,7 +48,7 @@ def test_take_noise(tmp_path):
     emulator.take_noise(session)
 
 
-def take_bgmap(tmp_path):
+def test_take_bgmap(tmp_path):
     emulator = create_agent(str(tmp_path))
     session = mock.MagicMock()
     session.data = {}

--- a/tests/agents/test_smurf_file_emulator.py
+++ b/tests/agents/test_smurf_file_emulator.py
@@ -19,17 +19,40 @@ def create_agent(base_dir, file_duration=10, frame_len=2,
     parser = make_parser()
     args = parser.parse_args(args=[
         '--stream-id', 'test_em', '--base-dir', base_dir,
-        '--file-duration', str(file_duration), '--frame-len', str(frame_len)
+        '--file-duration', str(file_duration), '--frame-len', str(frame_len),
+        '--sample-rate', str(10),
     ])
     agent = SmurfFileEmulator(mock_agent, args)
     return agent
 
 
-def test_tune_up(tmp_path):
+def test_uxm_setup(tmp_path):
     emulator = create_agent(str(tmp_path))
     session = mock.MagicMock()
     session.data = {}
-    emulator.tune_dets(session, {'test_mode': True})
+    emulator.uxm_setup(session, {'test_mode': True})
+
+
+def test_uxm_relock(tmp_path):
+    emulator = create_agent(str(tmp_path))
+    session = mock.MagicMock()
+    session.data = {}
+    emulator.uxm_relock(session, {'test_mode': True})
+
+
+def test_take_noise(tmp_path):
+    emulator = create_agent(str(tmp_path))
+    session = mock.MagicMock()
+    session.data = {}
+    emulator.uxm_relock(session, {'test_mode': True})
+    emulator.take_noise(session)
+
+
+def take_bgmap(tmp_path):
+    emulator = create_agent(str(tmp_path))
+    session = mock.MagicMock()
+    session.data = {}
+    emulator.take_bgmap(session)
 
 
 def test_take_iv(tmp_path):
@@ -51,7 +74,8 @@ def test_bias_dets(tmp_path):
 
 
 def test_stream(tmp_path):
-    emulator = create_agent(str(tmp_path), file_duration=0.2, frame_len=0.05)
+    emulator = create_agent(str(tmp_path), file_duration=1, frame_len=.5)
     session = mock.MagicMock()
     session.data = {}
-    emulator.stream(session, params={'duration': 1})
+    emulator.uxm_relock(session, {'test_mode': True})
+    emulator.stream(session, params={'duration': 2})


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Modifications to the SmurfFileEmulator agent, adding realistic tune-files and additional tasks matching those in the pysmurf-controller

## Description
<!--- Describe your changes in detail -->
Adds realistic tune files and channel assignment files to tune uxm_setup / relock tasks, and adds relevant data to the status dump frame. This is required for emulated data to be indexable by G3tSmurf. 

Adds the DataStreamer class, which makes it easier to create fake g3 streams.

Renames `tune_dets` to `uxm_setup` (and `uxm_relock`) and adds a few tasks that correspond with pysmurf-controller tasks (`take_noise`, `take_bgmap`, `uxm_relock`).

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Tune support makes the data outputs indexable with G3tSmurf.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
Tested creating files locally, and tested indexing / loading them using G3tSmurf.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project.
- [X] My change requires a change to the documentation.
- [X] I have updated the documentation accordingly.
- [ ] Unless I am preparing a release, I have opened this PR onto the `develop` branch.
