### PR TITLE
Run pytest workflow PR only and fix wildcard pattern matching

### DIFF
--- a/.github/workflows/develop.yml
+++ b/.github/workflows/develop.yml
@@ -5,8 +5,8 @@ on:
     branches: [ develop ]
     paths-ignore:
       - 'docs/**'
-      - '*.rst'
-      - '*.md'
+      - '**.rst'
+      - '**.md'
       - '.flake8'
       - '.pre-commit-config.yaml'
 

--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -9,6 +9,7 @@ on:
       - '*.md'
       - '.flake8'
       - '.pre-commit-config.yaml'
+  pull_request:
   workflow_call:
 
 jobs:

--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -5,11 +5,17 @@ on:
     branches-ignore: [ develop ]
     paths-ignore:
       - 'docs/**'
-      - '*.rst'
-      - '*.md'
+      - '**.rst'
+      - '**.md'
       - '.flake8'
       - '.pre-commit-config.yaml'
   pull_request:
+    paths-ignore:
+      - 'docs/**'
+      - '**.rst'
+      - '**.md'
+      - '.flake8'
+      - '.pre-commit-config.yaml'
   workflow_call:
 
 jobs:

--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -1,14 +1,6 @@
 name: Run Tests
 
 on:
-  push:
-    branches-ignore: [ develop ]
-    paths-ignore:
-      - 'docs/**'
-      - '**.rst'
-      - '**.md'
-      - '.flake8'
-      - '.pre-commit-config.yaml'
   pull_request:
     paths-ignore:
       - 'docs/**'

--- a/.github/workflows/skipped-pytest.yml
+++ b/.github/workflows/skipped-pytest.yml
@@ -4,8 +4,8 @@ on:
   pull_request:
     paths:
       - 'docs/**'
-      - '*.rst'
-      - '*.md'
+      - '**.rst'
+      - '**.md'
       - '.flake8'
       - '.pre-commit-config.yaml'
 

--- a/.github/workflows/skipped-test-build.yml
+++ b/.github/workflows/skipped-test-build.yml
@@ -4,8 +4,8 @@ on:
   pull_request:
     paths:
       - 'docs/**'
-      - '*.rst'
-      - '*.md'
+      - '**.rst'
+      - '**.md'
       - '.flake8'
       - '.pre-commit-config.yaml'
 

--- a/.github/workflows/test-build.yml
+++ b/.github/workflows/test-build.yml
@@ -4,8 +4,8 @@ on:
   pull_request:
     paths-ignore:
       - 'docs/**'
-      - '*.rst'
-      - '*.md'
+      - '**.rst'
+      - '**.md'
       - '.flake8'
       - '.pre-commit-config.yaml'
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
I realized with the submission of #311 that my work in #286 (specifically ae00541) prevents the test workflow from running when an external collaborator submits a PR. We want this behavior, I think even at the cost of the workflow running twice. If anything probably we should stop running it on every push, though I do find that useful for when preparing to PR to avoid spamming everyone. (Edit: I've decided to actually do this and have removed the run trigger on push.)

Also I realized in another recent PR that the wildcards I setup for matching to .rst and .md files weren't match-y enough. Fixed that as well.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Trying to get #311 merged.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
Will be tested on new PRs.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] Unless I am preparing a release, I have opened this PR onto the `develop` branch.
