### PR TITLE
Fix Cryomech CPA Agent acq process auto start

### DIFF
--- a/agents/cryomech_cpa/cryomech_cpa_agent.py
+++ b/agents/cryomech_cpa/cryomech_cpa_agent.py
@@ -82,6 +82,7 @@ class PTC:
             raise ValueError(f"Invalid state: {state}")
 
         self.comm.sendall(bytes(command))
+        self.comm.recv(1024)  # Discard the echoed command
 
     def breakdownReplyData(self, rawdata):
         """Take in raw ptc data, and return a dictionary.

--- a/agents/cryomech_cpa/cryomech_cpa_agent.py
+++ b/agents/cryomech_cpa/cryomech_cpa_agent.py
@@ -247,7 +247,8 @@ class PTCAgent:
                               "{} is already running".format(self.lock.job))
                 return False, "Could not acquire lock."
 
-            session.set_status('starting')
+            session.set_status('running')
+
             # Establish connection to ptc
             self.ptc = PTC(self.ip_address, port=self.port,
                            fake_errors=self.fake_errors)
@@ -262,7 +263,8 @@ class PTCAgent:
 
         # Start data acquisition if requested
         if params['auto_acquire']:
-            self.agent.start('acq')
+            resp = self.agent.start('acq', params={})
+            self.log.info(f'Response from acq.start(): {resp[1]}')
 
         return True, "PTC agent initialized"
 

--- a/tests/integration/test_cryomech_cpa_agent_integration.py
+++ b/tests/integration/test_cryomech_cpa_agent_integration.py
@@ -27,6 +27,8 @@ init_res = b'\t\x99\x00\x00\x00m\x01\x04j\x00\x00\x00\x00\x00\x00\x80\x00\x00\x0
 wait_for_crossbar = create_crossbar_fixture()
 run_agent = create_agent_runner_fixture(
     '../agents/cryomech_cpa/cryomech_cpa_agent.py', 'cryomech_cpa_agent')
+run_agent_acq = create_agent_runner_fixture(
+    '../agents/cryomech_cpa/cryomech_cpa_agent.py', 'cryomech_cpa_agent', args=['--mode', 'acq'])
 client = create_client_fixture('cryomech')
 emulator = create_device_emulator({init_msg: init_res}, relay_type='tcp', port=5502, encoding=None)
 
@@ -58,6 +60,17 @@ def test_cryomech_cpa_power_ptc(wait_for_crossbar, emulator, run_agent,
     assert resp.status == ocs.OK
     print(resp.session)
     assert resp.session['op_code'] == OpCode.SUCCEEDED.value
+
+
+@pytest.mark.integtest
+def test_cryomech_cpa_auto_start_acq(wait_for_crossbar, emulator, run_agent_acq, client):
+    client.init()
+
+    resp = client.acq.status()
+
+    # just check that the start call worked
+    print(resp)
+    assert resp.status == ocs.OK
 
 
 @pytest.mark.integtest


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Fix bug in the calling of `acq.start()` within the `init` Task where no `params` argument was being passed and the `acq` Process was failing at the param decorator check.

This has been seen before and reported here: https://github.com/simonsobs/ocs/issues/251

This was discovered while trying to test the new on/off functionality. While testing we also found that the echoed response from powering on/off would end up coming back once `acq()` was restarted. Changes in 7519ac12b700611912aa719876c9f8573b698ca8 simply discard the echoed response.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Discovered while testing updated version of the Agent at Penn.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
New test written for the auto startup of acq, which would fail before these changes. And all changes tested on an actual compressor at Penn.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] Unless I am preparing a release, I have opened this PR onto the `develop` branch.
