### PR TITLE
Install socs from temp branch w/o python_requires>=3.7

### DIFF
--- a/agents/pysmurf_controller/Dockerfile
+++ b/agents/pysmurf_controller/Dockerfile
@@ -3,7 +3,7 @@ FROM simonsobs/sodetlib:v0.4.0
 WORKDIR /app
 
 # SOCS installation
-RUN python3 -m pip install --src=/app/ -e git+https://github.com/simonsobs/socs.git#egg=socs
+RUN python3 -m pip install --src=/app/ -e git+https://github.com/simonsobs/socs.git@py36#egg=socs
 
 ENV OCS_CONFIG_DIR /config
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
This is a temporary fix for the pysmurf-controller builds, which are still based on Ubuntu 18.04 images and only have Python 3.6. Should only remain in place until the sodetlib images can be updated.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
#316 broke the docker image builds with the python_requires>=3.7 update (which is propagating from so3g+ocs.) We need the builds to keep working for now though.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
Built the image successfully locally.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] Unless I am preparing a release, I have opened this PR onto the `develop` branch.
