### PR TITLE
Adds MultiSlotController

### DIFF
--- a/socs/smurf/MultiSlotController.py
+++ b/socs/smurf/MultiSlotController.py
@@ -1,0 +1,116 @@
+from ocs.ocs_client import OCSClient
+
+class MultiSlotController:
+    """
+    Simple client controller useful for managing all pysmurf-controller
+    agents that exist on a network. This can dispatch operations and check
+    operation status for any or all pysmurf-controllers on a network.
+
+    Args
+    -----
+    client_args: list
+        List of command line arguments to pass onto the OCSClient objects.
+
+    Attributes
+    ---------------
+    smurfs : dict
+        Dictionary containing OCSClient objects for each pysmurf-controller
+        on the network. This assumes pysmurf controller agents have
+        instance-id's of the form ``pysmurf-controller-<id>`` where id
+        can be the uxm-id or something like ``crate1slot2``. The keys of this
+        dict will be ``<id>``. This is populated from the registry agent on
+        init or using the funciton ``get_active_smurfs``.
+    """
+    def __init__(self, client_args=[]):
+        self.client_args=client_args
+        self.reg = OCSClient('registry', args=client_args)
+        self.smurfs = {}
+        self.get_active_smurfs()
+
+    def get_active_smurfs(self):
+        """
+        Obtains a list of active pysmurf-controller agents on a network from
+        the registry agent. Uses this to populate the ``smurfs`` dictionary,
+        which contains an OCSClient object for each.
+        """
+        reg_agents = self.reg.main.status().session['data']
+        self.smurfs = {}
+        for k, v in reg_agents.items():
+            if 'pysmurf-controller' not in k:
+                continue
+            if v['expired']:
+                continue
+
+            instance_id = k.split('.')[-1]
+            smurf_key = instance_id.split('-')[-1]
+            self.smurfs[smurf_key] = OCSClient(instance_id,
+                                               args=self.client_args)
+
+    def start(self, op_name, ids=None, **kwargs):
+        """
+        Starts an operation on any or all pysmurf controllers.
+
+        Args
+        ----
+        op_name : str
+            Name of the operation to start
+        ids : list, optional
+            List of pysmurf-controller id's. This defaults to running on all
+            controllers.
+        **kwargs
+            Any additional keyword arguments are passed onto the start
+            operation as params
+        """
+        if ids is None:
+            ids = list(self.smurfs.keys())
+        elif isinstance(ids, str):
+            ids = [ids]
+        rv = {}
+        for smurf_id in ids:
+            rv[smurf_id] = getattr(self.smurfs[smurf_id], op_name).start(**kwargs)
+        return rv
+
+    def stop(self, op_name, ids=None, **kwargs):
+        """
+        Stops an operation on any or all pysmurf controllers.
+
+        Args
+        ----
+        op_name : str
+            Name of the operation to stop
+        ids : list, optional
+            List of pysmurf-controller id's. This defaults to running on all
+            controllers.
+        **kwargs
+            Any additional keyword arguments are passed onto the stop operation
+            as params
+        """
+        if ids is None:
+            ids = list(self.smurfs.keys())
+        elif isinstance(ids, str):
+            ids = [ids]
+        rv = {}
+        for smurf_id in ids:
+            rv[smurf_id] = getattr(self.smurfs[smurf_id], op_name).stop(**kwargs)
+        return rv
+
+    def status(self, op_name, ids=None):
+        """
+        Checks the status of an operation on any or all pysmurf controllers
+
+        Args
+        ----
+        op_name : str
+            Name of the operation to stop
+        ids : list, optional
+            List of pysmurf-controller id's. This defaults to running on all
+            controllers.
+        """
+        if ids is None:
+            ids = list(self.smurfs.keys())
+        elif isinstance(ids, str):
+            ids = [ids]
+        rv = {}
+        for smurf_id in ids:
+            rv[smurf_id] = getattr(self.smurfs[smurf_id], op_name).status()
+        return rv


### PR DESCRIPTION
Client object useful for commanding multiple pysmurf controllers

## Description
Class to contain OCS client objects for all pysmurf-controller agnets on a network, with methods to easily dispatch start/stop/status commands.

## Motivation and Context
This is required for operating multiple pysmurf controllers at once without sorunlib (for instance during this LATR cooldown).

## How Has This Been Tested?
Tested at USCD with the full smurf-crate in loopback mode.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] Unless I am preparing a release, I have opened this PR onto the `develop` branch.
