### PR TITLE
Stop and clear overrides scan in ACU Agent

### DIFF
--- a/agents/acu/acu_agent.py
+++ b/agents/acu/acu_agent.py
@@ -910,7 +910,7 @@ class ACUAgent:
             self.log.info('Uploaded a group')
         self.log.info('No more lines to upload')
         free_positions = self.data['status']['summary']['Free_upload_positions']
-        while free_positions < FULL_STACK:
+        while free_positions < FULL_STACK - 1:
             yield dsleep(0.1)
             modes = (self.data['status']['summary']['Azimuth_mode'],
                      self.data['status']['summary']['Elevation_mode'])
@@ -924,21 +924,18 @@ class ACUAgent:
         self.log.info('No more points in the queue')
         current_az = self.data['broadcast']['Corrected_Azimuth']
         current_el = self.data['broadcast']['Corrected_Elevation']
-        az_attempt_number = 0
-        while az_attempt_number < 10:
-            while round(current_az - end_az, 1) != 0.:
-                self.log.info('Waiting to settle at azimuth position')
-                yield dsleep(0.1)
-                az_attempt_number += 1
-                current_az = self.data['broadcast']['Corrected_Azimuth']
+        while round(current_az - end_az, 1) != 0.:
+            print('still rounding az')
+            self.log.info('Waiting to settle at azimuth position')
+            yield dsleep(0.1)
+            current_az = self.data['broadcast']['Corrected_Azimuth']
         if not azonly:
-            el_attempt_number = 0
-            while el_attempt_number < 10:
-                while round(current_el - end_el, 1) != 0.:
-                    self.log.info('Waiting to settle at elevation position')
-                    yield dsleep(0.1)
-                    el_attempt_number += 1
-                    current_el = self.data['broadcast']['Corrected_Elevation']
+            while round(current_el - end_el, 1) != 0.:
+                print('still rounding el')
+                self.log.info('Waiting to settle at elevation position')
+                yield dsleep(0.1)
+                current_el = self.data['broadcast']['Corrected_Elevation']
+        print('rounding completed')
         yield dsleep(self.sleeptime)
         yield self.acu_control.stop()
         self.data['uploads']['Start_Azimuth'] = 0.0

--- a/agents/acu/acu_agent.py
+++ b/agents/acu/acu_agent.py
@@ -893,11 +893,9 @@ class ACUAgent:
                 self.agent.publish_to_feed('acu_upload', acu_upload, from_reactor=True)
             text = ''.join(upload_lines)
             yield dsleep(0.05)
-            free_positions = self.data['status']['summary']\
-                ['Free_upload_positions']
+            free_positions = self.data['status']['summary']['Free_upload_positions']
             while free_positions < 9899:
-                free_positions = self.data['status']['summary']\
-                    ['Free_upload_positions']
+                free_positions = self.data['status']['summary']['Free_upload_positions']
                 yield dsleep(0.05)
                 if free_positions > 9997:
                     self.log.warn('Scan aborted!')

--- a/agents/acu/acu_agent.py
+++ b/agents/acu/acu_agent.py
@@ -780,13 +780,13 @@ class ACUAgent:
         yield self._run_specified_scan(session, times, azs, els, vas, ves, azflags, elflags, azonly=False)
         yield True, 'Track completed'
 
-#    @ocs_agent.param('azpts', type=tuple)
-#    @ocs_agent.param('el', type=float)
-#    @ocs_agent.param('azvel', type=float)
-#    @ocs_agent.param('acc', type=float)
-#    @ocs_agent.param('ntimes', type=int)
-#    @ocs_agent.param('azonly', type=bool)
-#    @ocs_agent.param('simulator', default=False, type=bool)
+    @ocs_agent.param('azpts', cast=tuple, type=tuple)
+    @ocs_agent.param('el', type=float)
+    @ocs_agent.param('azvel', type=float)
+    @ocs_agent.param('acc', type=float)
+    @ocs_agent.param('ntimes', type=int)
+    @ocs_agent.param('azonly', type=bool)
+    @ocs_agent.param('simulator', default=False, type=bool)
     @inlineCallbacks
     def constant_velocity_scan(self, session, params=None):
         """constant_velocity_scan(azpts=None, el=None, azvel=None, acc=None, \

--- a/agents/acu/acu_agent.py
+++ b/agents/acu/acu_agent.py
@@ -780,13 +780,13 @@ class ACUAgent:
         yield self._run_specified_scan(session, times, azs, els, vas, ves, azflags, elflags, azonly=False)
         yield True, 'Track completed'
 
-    @ocs_agent.param('azpts', type=tuple)
-    @ocs_agent.param('el', type=float)
-    @ocs_agent.param('azvel', type=float)
-    @ocs_agent.param('acc', type=float)
-    @ocs_agent.param('ntimes', type=int)
-    @ocs_agent.param('azonly', type=bool)
-    @ocs_agent.param('simulator', default=False, type=bool)
+#    @ocs_agent.param('azpts', type=tuple)
+#    @ocs_agent.param('el', type=float)
+#    @ocs_agent.param('azvel', type=float)
+#    @ocs_agent.param('acc', type=float)
+#    @ocs_agent.param('ntimes', type=int)
+#    @ocs_agent.param('azonly', type=bool)
+#    @ocs_agent.param('simulator', default=False, type=bool)
     @inlineCallbacks
     def constant_velocity_scan(self, session, params=None):
         """constant_velocity_scan(azpts=None, el=None, azvel=None, acc=None, \
@@ -889,12 +889,16 @@ class ACUAgent:
                               }
                 self.agent.publish_to_feed('acu_upload', acu_upload, from_reactor=True)
             text = ''.join(upload_lines)
+            yield dsleep(0.05)
             free_positions = self.data['status']['summary']\
                 ['Free_upload_positions']
             while free_positions < 9899:
                 free_positions = self.data['status']['summary']\
                     ['Free_upload_positions']
-                yield dsleep(0.1)
+                yield dsleep(0.05)
+                if free_positions > 9997:
+                    self.log.warn('Scan aborted!')
+                    return False
             yield self.acu_control.http.UploadPtStack(text)
             self.log.info('Uploaded a group')
         self.log.info('No more lines to upload')


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
stop_and_clear successfully stopped motion with the ACU but could not stop _run_specified_scan from uploading points. We add a check on the number of points to determine whether stop_and_clear has cleared all uploaded points and, if so, end the Task.

## Motivation and Context
Implemented to allow the end of _run_specified_scan if a scan needs to be aborted

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] Unless I am preparing a release, I have opened this PR onto the `develop` branch.
