### PR TITLE
New parameter for scan start position in generator scans

### DIFF
--- a/agents/acu/acu_agent.py
+++ b/agents/acu/acu_agent.py
@@ -948,7 +948,9 @@ class ACUAgent:
     def generate_scan(self, session, params):
         """generate_scan(az_endpoint1=None, az_endpoint2=None, az_speed=None, \
                          acc=None, el_endpoint1=None, el_endpoint2=None, \
-                         el_speed=None)
+                         el_speed=None, num_batches=None, start_time=None, \
+                         wait_to_start=None, step_time=None, batch_size=None, \
+                         az_start=None, ptstack_fmt=None)
 
         **Process** - Scan generator, currently only works for
         constant-velocity az scans with fixed elevation.
@@ -963,7 +965,26 @@ class ACUAgent:
                 currently both el endpoints should be equal
             el_speed (float): speed of motion for a scan with changing
                 elevation. For dev, currently set to 0.0
-
+            num_batches (int or None): number of times to traverse a direction
+                of the scan. Default value is None, interpreted as infinite
+            start_time (float or None): a ctime at which to start the scan.
+                Default is None, interpreted as now
+            wait_to_start (float): number of seconds to wait before starting a
+                scan. Default is 3 seconds
+            step_time (float): time between points on the constant-velocity
+                parts of the motion. Default is 0.1 s. Minimum 0,05 s
+            batch_size (int): number of values to produce in each iteration.
+            Default is 500. Batch size is reset to the length of one leg of the
+            motion if num_batches is not None.
+        az_start (str): part of the scan to start at. Options are:
+            'az_endpoint1', 'az_endpoint2', 'mid_inc' (start in the middle of
+            the scan and start with increasing azimuth), 'mid_dec' (start in
+            the middle of the scan and start with decreasing azimuth).
+        ptstack_fmt (bool): determine whether values are produced with the
+            necessary format to upload to the ACU. If False, this function will
+            produce lists of time, azimuth, elevation, azimuth velocity,
+            elevation velocity, azimuth flags, and elevation flags. Default is
+            True.
         """
         ok, msg = self._try_set_job('control')
         if not ok:
@@ -976,10 +997,20 @@ class ACUAgent:
         el_endpoint1 = params.get('el_endpoint1')
         el_endpoint2 = params.get('el_endpoint2')
         el_speed = params.get('el_speed')
+        num_batches = params.get('num_batches')
+        start_time = params.get('start_time')
+        wait_to_start = params.get('wait_to_start')
+        step_time = params.get('step_time')
+        batch_size = params.get('batch_size')
+        az_start = params.get('az_start')
 
         yield self.acu_control.stop()
         g = sh.generate_constant_velocity_scan(az_endpoint1, az_endpoint2,
-                                               az_speed, acc, el_endpoint1, el_endpoint2, el_speed)
+                                               az_speed, acc, el_endpoint1,
+                                               el_endpoint2, el_speed,
+                                               num_batches, start_time,
+                                               wait_to_start, step_time,
+                                               batch_size, az_start)
         self.acu_control.mode('ProgramTrack')
         while True:
             lines = next(g)

--- a/agents/acu/acu_agent.py
+++ b/agents/acu/acu_agent.py
@@ -965,8 +965,9 @@ class ACUAgent:
                 currently both el endpoints should be equal
             el_speed (float): speed of motion for a scan with changing
                 elevation. For dev, currently set to 0.0
-            num_batches (int or None): number of times to traverse a direction
-                of the scan. Default value is None, interpreted as infinite
+            num_batches (int or None): sets the number of batches for the
+                generator to create. Default value is None (interpreted as infinite
+                batches).
             start_time (float or None): a ctime at which to start the scan.
                 Default is None, interpreted as now
             wait_to_start (float): number of seconds to wait before starting a
@@ -980,11 +981,6 @@ class ACUAgent:
             'az_endpoint1', 'az_endpoint2', 'mid_inc' (start in the middle of
             the scan and start with increasing azimuth), 'mid_dec' (start in
             the middle of the scan and start with decreasing azimuth).
-        ptstack_fmt (bool): determine whether values are produced with the
-            necessary format to upload to the ACU. If False, this function will
-            produce lists of time, azimuth, elevation, azimuth velocity,
-            elevation velocity, azimuth flags, and elevation flags. Default is
-            True.
         """
         ok, msg = self._try_set_job('control')
         if not ok:
@@ -995,14 +991,14 @@ class ACUAgent:
         az_speed = params.get('az_speed')
         acc = params.get('acc')
         el_endpoint1 = params.get('el_endpoint1')
-        el_endpoint2 = params.get('el_endpoint2')
-        el_speed = params.get('el_speed')
-        num_batches = params.get('num_batches')
-        start_time = params.get('start_time')
-        wait_to_start = params.get('wait_to_start')
-        step_time = params.get('step_time')
-        batch_size = params.get('batch_size')
-        az_start = params.get('az_start')
+        el_endpoint2 = params.get('el_endpoint2', el_endpoint1)
+        el_speed = params.get('el_speed', 0.0)
+        num_batches = params.get('num_batches', None)
+        start_time = params.get('start_time', None)
+        wait_to_start = params.get('wait_to_start', 3)
+        step_time = params.get('step_time', 0.1)
+        batch_size = params.get('batch_size', 500)
+        az_start = params.get('az_start', 'mid_inc')
 
         yield self.acu_control.stop()
         g = sh.generate_constant_velocity_scan(az_endpoint1, az_endpoint2,

--- a/agents/acu/acu_agent.py
+++ b/agents/acu/acu_agent.py
@@ -950,7 +950,7 @@ class ACUAgent:
                          acc=None, el_endpoint1=None, el_endpoint2=None, \
                          el_speed=None, num_batches=None, start_time=None, \
                          wait_to_start=None, step_time=None, batch_size=None, \
-                         az_start=None, ptstack_fmt=None)
+                         az_start=None)
 
         **Process** - Scan generator, currently only works for
         constant-velocity az scans with fixed elevation.
@@ -973,14 +973,14 @@ class ACUAgent:
             wait_to_start (float): number of seconds to wait before starting a
                 scan. Default is 3 seconds
             step_time (float): time between points on the constant-velocity
-                parts of the motion. Default is 0.1 s. Minimum 0,05 s
+                parts of the motion. Default is 0.1 s. Minimum 0.05 s
             batch_size (int): number of values to produce in each iteration.
-            Default is 500. Batch size is reset to the length of one leg of the
-            motion if num_batches is not None.
-        az_start (str): part of the scan to start at. Options are:
-            'az_endpoint1', 'az_endpoint2', 'mid_inc' (start in the middle of
-            the scan and start with increasing azimuth), 'mid_dec' (start in
-            the middle of the scan and start with decreasing azimuth).
+                Default is 500. Batch size is reset to the length of one leg of the
+                motion if num_batches is not None.
+            az_start (str): part of the scan to start at. Options are:
+                'az_endpoint1', 'az_endpoint2', 'mid_inc' (start in the middle of
+                the scan and start with increasing azimuth), 'mid_dec' (start in
+                the middle of the scan and start with decreasing azimuth).
         """
         ok, msg = self._try_set_job('control')
         if not ok:
@@ -991,22 +991,20 @@ class ACUAgent:
         az_speed = params.get('az_speed')
         acc = params.get('acc')
         el_endpoint1 = params.get('el_endpoint1')
+        scan_params = {k: params.get(k) for k in ['num_batches', 'start_time',
+                       'wait_to_start', 'step_time', 'batch_size', 'az_start']
+                       if params.get(k) is not None}
         el_endpoint2 = params.get('el_endpoint2', el_endpoint1)
         el_speed = params.get('el_speed', 0.0)
-        num_batches = params.get('num_batches', None)
-        start_time = params.get('start_time', None)
-        wait_to_start = params.get('wait_to_start', 3)
-        step_time = params.get('step_time', 0.1)
-        batch_size = params.get('batch_size', 500)
-        az_start = params.get('az_start', 'mid_inc')
 
         yield self.acu_control.stop()
-        g = sh.generate_constant_velocity_scan(az_endpoint1, az_endpoint2,
-                                               az_speed, acc, el_endpoint1,
-                                               el_endpoint2, el_speed,
-                                               num_batches, start_time,
-                                               wait_to_start, step_time,
-                                               batch_size, az_start)
+        g = sh.generate_constant_velocity_scan(az_endpoint1=az_endpoint1,
+                                               az_endpoint2=az_endpoint2,
+                                               az_speed=az_speed, acc=acc,
+                                               el_endpoint1=el_endpoint1,
+                                               el_endpoint2=el_endpoint2,
+                                               el_speed=el_speed,
+                                               **scan_params)
         self.acu_control.mode('ProgramTrack')
         while True:
             lines = next(g)

--- a/agents/acu/scan_helpers.py
+++ b/agents/acu/scan_helpers.py
@@ -208,7 +208,7 @@ def generate_constant_velocity_scan(az_endpoint1, az_endpoint2, az_speed,
             motion if num_batches is not None.
         az_start (str): part of the scan to start at. Options are:
             'az_endpoint1', 'az_endpoint2', 'mid_inc' (start in the middle of
-            the scan and start with increasing azimuth), 'mid_dec' (start in 
+            the scan and start with increasing azimuth), 'mid_dec' (start in
             the middle of the scan and start with decreasing azimuth).
         ptstack_fmt (bool): determine whether values are produced with the
             necessary format to upload to the ACU. If False, this function will


### PR DESCRIPTION
Include new string parameter az_start to indicate the beginning point
of a generator scan. Defaults to starting scans from the midpoint between
the two az endpoint inputs.

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] Unless I am preparing a release, I have opened this PR onto the `develop` branch.
