### PR TITLE
Attempt failed connection again in pid_controller

### DIFF
--- a/agents/hwp_rotation/src/pid_controller.py
+++ b/agents/hwp_rotation/src/pid_controller.py
@@ -44,10 +44,16 @@ class PID:
 
         """
         conn = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
-        try:
-            conn.connect((ip, port))
-        except ConnectionRefusedError:
-            print(f"Failed to connect to device at {ip}:{port}")
+        # unit tests might fail on first connection attempt
+        attempts = 3
+        for attempt in range(attempts):
+            try:
+                conn.connect((ip, port))
+                break
+            except ConnectionRefusedError:
+                print(f"Failed to connect to device at {ip}:{port}")
+                print(f"Connection attempts remaining: {attempts-attempt-1}")
+            time.sleep(1)
         conn.settimeout(timeout)
 
         return conn


### PR DESCRIPTION

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
This improves a flaky test for the HWP Rotation again PID controller by attempting the PID controller connection again after a second if it fails to connect the first (or second) time.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
The pid controller tests can be kind of flaky when all tests are run. This seems to be because the device emulator isn't quite ready yet. I've seen it vary a lot when run on Github Actions.

A recent failure: https://github.com/simonsobs/socs/runs/7415872076?check_suite_focus=true 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
I've reproduced the flakiness locally by running:
```
$ python3 -m pytest -s --cov --cov-report html agents/test_suprsync_agent.py agents/hwp_rotation/test_pid_controller.py
```

Running separately doesn't quite do it, but running another test beforehand generates the error more often than not.

After adding the patch I haven't seen a failure locally, we'll what happens on the CI.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] Unless I am preparing a release, I have opened this PR onto the `develop` branch.
