### PR TITLE
Put the approx_hwp_freq in session.data object for SupervisorAgent

### DIFF
--- a/agents/chwp/Dockerfile
+++ b/agents/chwp/Dockerfile
@@ -1,7 +1,7 @@
 # CHWP Agent
 
 # Use socs base image
-FROM simonsobs/socs:latest
+FROM socs:latest
 
 # Set the working directory to registry directory
 WORKDIR /app/socs/agents/chwp/

--- a/agents/chwp/Dockerfile
+++ b/agents/chwp/Dockerfile
@@ -1,7 +1,7 @@
 # CHWP Agent
 
 # Use socs base image
-FROM socs:latest
+FROM simonsobs/socs:latest
 
 # Set the working directory to registry directory
 WORKDIR /app/socs/agents/chwp/
@@ -15,5 +15,3 @@ ENTRYPOINT ["dumb-init", "python3", "-u", "hwpbbb_agent.py"]
 # Sensible default arguments
 CMD ["--site-hub=ws://crossbar:8001/ws", \
      "--site-http=http://crossbar:8001/call"]
-
-EXPOSE 8080/udp

--- a/agents/chwp/Dockerfile
+++ b/agents/chwp/Dockerfile
@@ -15,3 +15,5 @@ ENTRYPOINT ["dumb-init", "python3", "-u", "hwpbbb_agent.py"]
 # Sensible default arguments
 CMD ["--site-hub=ws://crossbar:8001/ws", \
      "--site-http=http://crossbar:8001/call"]
+
+EXPOSE 8080/udp

--- a/agents/chwp/hwpbbb_agent.py
+++ b/agents/chwp/hwpbbb_agent.py
@@ -530,10 +530,14 @@ class HWPBBBAgent:
             self.take_data = True
 
             # Prepare data_cache for session.data
-            self.hwp_freq = None
+            self.hwp_freq = -1
             self.ct = time.time()
-            data_cache = {'fields': {'approx_hwp_freq': self.hwp_freq},
-                          'last_updated': self.ct}
+            data_cache = {
+                'approx_hwp_freq': self.hwp_freq,
+                'encoder_last_updated': self.ct,
+                'irig_time': self.irig_time,
+                'irig_last_updated': self.ct,
+            }
 
             while self.take_data:
                 # This is blocking until data are available
@@ -579,6 +583,10 @@ class HWPBBBAgent:
                     data['data']['irig_synch_pulse_clock_counts'] = synch_pulse_clock_counts
                     data['data']['irig_info'] = list(irig_info)
                     self.agent.publish_to_feed('HWPEncoder', data)
+
+                    data_cache['irig_time'] = self.irig_time
+                    data_cache['irig_last_updated'] = sys_time
+                    session.data.update(data_cache)
 
                 # Reducing the packet size, less frequent publishing
                 # Encoder data; packet coming rate = 570*2*2/150/4 ~ 4Hz packet at 2 Hz rotation
@@ -654,8 +662,8 @@ class HWPBBBAgent:
                         self.hwp_freq = hwp_freq
                         self.ct = ct
 
-                data_cache['fields']['approx_hwp_freq'] = self.hwp_freq
-                data_cache['last_updated'] = self.ct
+                data_cache['approx_hwp_freq'] = self.hwp_freq
+                data_cache['encoder_last_updated'] = self.ct
                 session.data.update(data_cache)
 
         self.agent.feeds['HWPEncoder'].flush_buffer()

--- a/agents/chwp/hwpbbb_agent.py
+++ b/agents/chwp/hwpbbb_agent.py
@@ -533,6 +533,9 @@ class HWPBBBAgent:
                 # This is blocking until data are available
                 self.parser.grab_and_parse_data()
 
+                # Session data
+                data_cache = {'fields': {'approx_hwp_freq': None}, 'last_updated': time.time()}
+
                 # IRIG data; normally every sec
                 while len(self.parser.irig_queue):
                     irig_data = self.parser.irig_queue.popleft()
@@ -574,6 +577,10 @@ class HWPBBBAgent:
                     data['data']['irig_info'] = list(irig_info)
                     self.agent.publish_to_feed('HWPEncoder', data)
 
+                    # Update session.data
+                    data_cache['fields']['irig_time'] = irig_time
+                    data_cache['last_updated'] = time.time()
+
                 # Reducing the packet size, less frequent publishing
                 # Encoder data; packet coming rate = 570*2*2/150/4 ~ 4Hz packet at 2 Hz rotation
                 while len(self.parser.counter_queue):
@@ -589,6 +596,7 @@ class HWPBBBAgent:
                     quad_list.append(quad_data)
                     quad_counter_list.append(counter_data[0][0])
                     ct = time.time()
+
                     if len(counter_list) >= NUM_ENCODER_TO_PUBLISH \
                        or (len(counter_list)
                            and (ct - time_encoder_published) > SEC_ENCODER_TO_PUBLISH):
@@ -642,6 +650,12 @@ class HWPBBBAgent:
                         received_time_list = []
 
                         time_encoder_published = ct
+
+                        # Update session.data
+                        data_cache['fields']['approx_hwp_freq'] = hwp_freq
+                        data_cache['last_updated'] = ct
+
+                session.data.update(data_cache)
 
         self.agent.feeds['HWPEncoder'].flush_buffer()
         return True, 'Acquisition exited cleanly.'

--- a/docs/agents/chwp_encoder.rst
+++ b/docs/agents/chwp_encoder.rst
@@ -79,8 +79,10 @@ Description
 
 session.data
 ````````````
-The most recent data collected is stored in session.data in the structure::
-
+The most recent data collected is stored in session.data in the following structure.
+The approx_hwp_freq is initialized by -1 and will be updated by non-negative rotation frequency
+if encoder agent is receiving encoder signal.
+If chwp is completely stopped, approx_hwp_freq will not be updated.::
     >>> response.session['data']
     {'approx_hwp_freq':      2.0,
      'encoder_last_updated': 1659486962.3731978,

--- a/docs/agents/chwp_encoder.rst
+++ b/docs/agents/chwp_encoder.rst
@@ -73,3 +73,16 @@ This again is an example to run multiple agents::
       - "--instance-id=HBA1"
       - "--site-hub=ws://crossbar:8001/ws"
       - "--site-http=http://crossbar:8001/call"
+
+Description
+-----------
+
+session.data
+````````````
+The most recent data collected is stored in session.data in the structure::
+
+    >>> response.session['data']
+    {'approx_hwp_freq':      2.0,
+     'encoder_last_updated': 1659486962.3731978,
+     'irig_time':            1659486983,
+     'irig_last_updated':    1659486983.8985631}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Put the `approx_hwp_freq` in the `acq` process' `session.data` object for SupervisorAgent to inspect `approx_hwp_freq` in shutdown operation.

The `acq` process of hwpbbb agent doesn't always publish encoder data or update `session.data` in all loops, `session.data` will keep last updated non null `approx_hwp_freq`.

Removed unnecessary EXPOSE from Dockerfile.

## Motivation and Context
For Supervisor Agent to inspect 'approx_hwp_freq' in shutdown operation.

## How Has This Been Tested?
Tested at CHWP setup at UTokyo

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] Unless I am preparing a release, I have opened this PR onto the `develop` branch.
