### PR TITLE
Suprsync update copy attempts

### DIFF
--- a/agents/suprsync/suprsync.py
+++ b/agents/suprsync/suprsync.py
@@ -120,7 +120,7 @@ def make_parser(parser=None):
                         help="Time (sec) after which this agent will delete "
                              "local copies of successfully transfered files. "
                              "If None, will not delete files.")
-    pgroup.add_argument('--max-copy-attempts', type=int,
+    pgroup.add_argument('--max-copy-attempts', type=int, default=5,
                         help="Number of failed copy attempts before the agent "
                              "will stop trying to copy a file")
     pgroup.add_argument('--copy-timeout', type=float,

--- a/bin/suprsync
+++ b/bin/suprsync
@@ -18,6 +18,7 @@ def check_func(args):
         print(file)
         print('-' * 80)
 
+
 def next_func(args):
     srfm = SupRsyncFilesManager(args.db, create_all=False)
 

--- a/bin/suprsync
+++ b/bin/suprsync
@@ -4,18 +4,19 @@ Utility script for interacting with the suprsync db.
 """
 from socs.db.suprsync import SupRsyncFilesManager, SupRsyncFile
 import argparse
+import os
 
 
 def check_func(args):
     srfm = SupRsyncFilesManager(args.db, create_all=False)
     session = srfm.Session()
-    file = session.query(SupRsyncFile).filter(
+    files = session.query(SupRsyncFile).filter(
         SupRsyncFile.local_path == args.file
-    ).one()
-    print('-' * 80)
-    print(file)
-    print('-' * 80)
-
+    ).all()
+    for file in files:
+        print('-' * 80)
+        print(file)
+        print('-' * 80)
 
 def next_func(args):
     srfm = SupRsyncFilesManager(args.db, create_all=False)
@@ -67,6 +68,9 @@ if __name__ == '__main__':
     list_parser.add_argument('--db', default=default_db)
 
     args = parser.parse_args()
+    if not os.path.exists(args.db):
+        raise Exception(f"Could not find file {args.db}")
+
     if hasattr(args, 'func'):
         args.func(args)
     else:

--- a/socs/db/suprsync.py
+++ b/socs/db/suprsync.py
@@ -345,6 +345,11 @@ class SupRsyncFileHandler:
                         file.failed_copy_attempts += 1
                         continue
 
+                    if os.path.exists(tmp_path):
+                        self.log.warn("Temp file {path} already exists!", path=tmp_path)
+                        file.failed_copy_attempts += 1
+                        continue
+
                     os.symlink(file.local_path, tmp_path)
 
                     remote_path = os.path.normpath(

--- a/socs/db/suprsync.py
+++ b/socs/db/suprsync.py
@@ -371,6 +371,18 @@ class SupRsyncFileHandler:
                 md5sum, path = line.split()
                 file_map[os.path.normpath(path)].remote_md5sum = md5sum
 
+            for file in files:
+                if file.remote_md5sum != file.local_md5sum:
+                    file.failed_copy_attempts += 1
+                    self.log.info(
+                        f"Copy failed for file {file.local_path}! "
+                        f"(copy attempts: {file.failed_copy_attempts})"
+                    )
+                    self.log.info(f"Local md5: {file.local_md5sum}, "
+                                  f"remote_md5: {file.remote_md5sum}")
+
+
+
     def delete_files(self, delete_after):
         """
         Gets deletable files, deletes them, and updates file info

--- a/socs/db/suprsync.py
+++ b/socs/db/suprsync.py
@@ -347,7 +347,6 @@ class SupRsyncFileHandler:
 
                     os.symlink(file.local_path, tmp_path)
 
-
                     remote_path = os.path.normpath(
                         os.path.join(self.remote_basedir, file.remote_path)
                     )

--- a/socs/db/suprsync.py
+++ b/socs/db/suprsync.py
@@ -382,8 +382,6 @@ class SupRsyncFileHandler:
                     self.log.info(f"Local md5: {file.local_md5sum}, "
                                   f"remote_md5: {file.remote_md5sum}")
 
-
-
     def delete_files(self, delete_after):
         """
         Gets deletable files, deletes them, and updates file info

--- a/socs/db/suprsync.py
+++ b/socs/db/suprsync.py
@@ -206,20 +206,21 @@ class SupRsyncFilesManager:
         if session is None:
             session = self.Session()
 
+        if max_copy_attempts is None:
+            max_copy_attempts = 2**10
+
         query = session.query(SupRsyncFile).filter(
             SupRsyncFile.removed == None,  # noqa: E711
             SupRsyncFile.archive_name == archive_name,
+            SupRsyncFile.failed_copy_attempts < max_copy_attempts
         )
-
-        if max_copy_attempts is not None:
-            query.filter(SupRsyncFile.failed_copy_attempts < max_copy_attempts)
 
         files = []
         for f in query.all():
             if f.local_md5sum != f.remote_md5sum:
                 files.append(f)
             if num_files is not None:
-                if len(files) == num_files:
+                if len(files) >= num_files:
                     break
 
         return files


### PR DESCRIPTION
Fixes a bug in the suprsync agent where failed_copy_attempts wasn't being updated.
<!--- Provide a general summary of your changes in the Title above -->

## Description
Changes 'copy_files' function so that if md5sums don't match at the end of the function, failed_copy_attempts will be incremented. Before, `failed_copy_attempts` was built into the database, but I think after the latest refactoring it just never gets updated. 

This also fixes an issue with getting files from the db where files weren't being filtered by failed_copy_attempts

Also changes `max-copy-attempts` default from None to 5 so it doesn't attempt to copy files forever by default.

Also adds better handling of files where it can't find the local path on the host (different issue, but found during the same debugging session)

## Motivation and Context
 to fix the system at Penn, where local file overwrites made it was impossible to copy over files correctly since the local md5sums have been changed.

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
Currently running successfully on the penn system
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] Unless I am preparing a release, I have opened this PR onto the `develop` branch.
