### PR TITLE
New control options for suprsync

### DIFF
--- a/agents/ocs_plugin_so.py
+++ b/agents/ocs_plugin_so.py
@@ -21,6 +21,7 @@ for n, f in [
         ('FTSAerotechAgent', 'fts_aerotech_stage/fts_aerotech_agent.py'),
         ('VantagePro2Agent', 'vantagePro2_agent/vantage_pro2_agent.py'),
         ('FPGAAgent', 'holo_fpga/roach_agent.py'),
-        ('SynthAgent', 'holo_synth/synth_agent.py')
+        ('SynthAgent', 'holo_synth/synth_agent.py'),
+        ('SupRsync', 'suprsync/suprsync.py'),
 ]:
     ocs.site_config.register_agent_class(n, os.path.join(root, f))

--- a/agents/suprsync/suprsync.py
+++ b/agents/suprsync/suprsync.py
@@ -92,6 +92,9 @@ class SupRsync:
             except subprocess.TimeoutExpired as e:
                 self.log.error("Timeout when copying files! {e}", e=e)
                 op['error'] = 'timed out'
+            except subprocess.CalledProcessError as e:
+                self.log.error("rsync returned non-zero exit code! {e}", e=e)
+                op['error'] = 'nonzero exit'
             op['stop_time'] = time.time()
             session.data['last_copy'] = op
 

--- a/agents/suprsync/suprsync.py
+++ b/agents/suprsync/suprsync.py
@@ -61,6 +61,8 @@ class SupRsync:
         self.copy_timeout = args.copy_timeout
         self.files_per_batch = args.files_per_batch
         self.sleep_time = args.sleep_time
+        self.compression = args.compression
+        self.bwlimit = args.bwlimit
 
     def run(self, session, params=None):
         """run()
@@ -74,7 +76,8 @@ class SupRsync:
         handler = SupRsyncFileHandler(
             srfm, self.archive_name, self.remote_basedir, ssh_host=self.ssh_host,
             ssh_key=self.ssh_key, cmd_timeout=self.cmd_timeout,
-            copy_timeout=self.copy_timeout
+            copy_timeout=self.copy_timeout, compression=self.compression,
+            bwlimit=self.bwlimit
         )
 
         self.running = True

--- a/agents/suprsync/suprsync.py
+++ b/agents/suprsync/suprsync.py
@@ -71,7 +71,6 @@ class SupRsync:
                                      'exclude_aggregator': True,
                                  })
 
-
     def run(self, session, params=None):
         """run()
 

--- a/agents/suprsync/suprsync.py
+++ b/agents/suprsync/suprsync.py
@@ -132,6 +132,10 @@ def make_parser(parser=None):
                         "is None, which will copy over all available files.")
     pgroup.add_argument('--sleep-time', type=float, default=60,
                         help="Time to sleep (sec) in between copy iterations")
+    pgroup.add_argument('--compression', action='store_true', default=False,
+                        help="Activate gzip on data transfer (rsync -z)")
+    pgroup.add_argument('--bwlimit', type=str, default=None,
+                        help="Bandwidth limit arg (passed through to rsync)")
     return parser
 
 


### PR DESCRIPTION
Modifications to suprsync for use in LAT testing, where we had a low bandwidth connection (at least some of the time).

This is a feature request in the form of a PR ... @jlashner let me know if you'd rather this be done differently.

## Description

New options:
- `--compression`: enables the -z switch to rsync
- `--bwlimit`: pass through to --bwlimit (bandwidth limit) switch of rsync

New method in SupRsyncFilesManager to just return a list of registered files... this helps auto-sync scripts to not re-add files that are already entered... maybe there's already some other way to do this?  I didn't notice the bin/suprsync script when I worked out a solution for our tests.

## How Has This Been Tested?

This version is running at LAT testing now.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] Unless I am preparing a release, I have opened this PR onto the `develop` branch.
