### PR TITLE
Add release and acquire function to cryomech cpa agent

### DIFF
--- a/agents/cryomech_cpa/cryomech_cpa_agent.py
+++ b/agents/cryomech_cpa/cryomech_cpa_agent.py
@@ -242,7 +242,6 @@ class PTCAgent:
         if self.initialized:
             return True, "Already Initialized"
 
-
         with self.lock.acquire_timeout(0, job='init') as acquired:
             if not acquired:
                 self.log.warn("Could not start init because "
@@ -282,7 +281,7 @@ class PTCAgent:
             Desired power state of the PTC, either 'on', or 'off'.
 
         """
-        with self.lock.acquire_timeout(0, job='power_ptc') as acquired:
+        with self.lock.acquire_timeout(10, job='power_ptc') as acquired:
             if not acquired:
                 self.log.warn("Could not start task because {} is already "
                               "running".format(self.lock.job))

--- a/agents/cryomech_cpa/cryomech_cpa_agent.py
+++ b/agents/cryomech_cpa/cryomech_cpa_agent.py
@@ -242,6 +242,7 @@ class PTCAgent:
         if self.initialized:
             return True, "Already Initialized"
 
+
         with self.lock.acquire_timeout(0, job='init') as acquired:
             if not acquired:
                 self.log.warn("Could not start init because "
@@ -312,10 +313,20 @@ class PTCAgent:
 
             session.set_status('running')
 
+            last_release = time.time()
+
             self.take_data = True
 
-            # Publish data, waiting 1/f_sample seconds in between calls.
             while self.take_data:
+                # Relinquish sampling lock occasionally
+                if time.time() - last_release > 1.:
+                    last_release = time.time()
+                    if not self.lock.release_and_acquire(timeout=10):
+                        self.log.warn(f"Failed to re-acquire sampling lock, "
+                                      f"currently held by {self.lock.job}.")
+                        continue
+
+                # Publish data, waiting 1/f_sample seconds in between calls.
                 pub_data = {'timestamp': time.time(),
                             'block_name': 'ptc_status'}
                 data_flag, data = self.ptc.get_data()

--- a/agents/cryomech_cpa/cryomech_cpa_agent.py
+++ b/agents/cryomech_cpa/cryomech_cpa_agent.py
@@ -281,7 +281,7 @@ class PTCAgent:
             Desired power state of the PTC, either 'on', or 'off'.
 
         """
-        with self.lock.acquire_timeout(10, job='power_ptc') as acquired:
+        with self.lock.acquire_timeout(3, job='power_ptc') as acquired:
             if not acquired:
                 self.log.warn("Could not start task because {} is already "
                               "running".format(self.lock.job))

--- a/tests/integration/test_cryomech_cpa_agent_integration.py
+++ b/tests/integration/test_cryomech_cpa_agent_integration.py
@@ -96,8 +96,7 @@ def test_cryomech_cpa_release_reacquire(wait_for_crossbar, emulator, run_agent_a
                                         client, state, command):
     client.init.wait()
     response = {command: command,
-                init_msg: init_msg,
-                init_res: init_res}
+                init_msg: init_res}
     emulator.define_responses(response)
 
     resp = client.power_ptc(state=state)

--- a/tests/integration/test_cryomech_cpa_agent_integration.py
+++ b/tests/integration/test_cryomech_cpa_agent_integration.py
@@ -95,7 +95,9 @@ def test_cryomech_cpa_acq(wait_for_crossbar, emulator, run_agent, client):
 def test_cryomech_cpa_release_reacquire(wait_for_crossbar, emulator, run_agent_acq,
                                         client, state, command):
     client.init.wait()
-    response = {command: command}
+    response = {command: command,
+                init_msg: init_msg,
+                init_res: init_res}
     emulator.define_responses(response)
 
     resp = client.power_ptc(state=state)

--- a/tests/integration/test_cryomech_cpa_agent_integration.py
+++ b/tests/integration/test_cryomech_cpa_agent_integration.py
@@ -88,3 +88,14 @@ def test_cryomech_cpa_acq(wait_for_crossbar, emulator, run_agent, client):
     # already stopped, but will set self.take_data = False
     resp = client.acq.stop()
     print(resp)
+
+
+@pytest.mark.integtest
+def test_cryomech_cpa_release_reacquire(wait_for_crossbar, emulator, run_agent_acq,
+                                        client):
+    resp = client.init.wait()
+    resp = client.init.status()
+    print(resp)
+    assert resp.status == ocs.OK
+    print(resp.session)
+    assert resp.session['op_code'] == OpCode.SUCCEEDED.value

--- a/tests/integration/test_cryomech_cpa_agent_integration.py
+++ b/tests/integration/test_cryomech_cpa_agent_integration.py
@@ -91,10 +91,14 @@ def test_cryomech_cpa_acq(wait_for_crossbar, emulator, run_agent, client):
 
 
 @pytest.mark.integtest
+@pytest.mark.parametrize("state,command", [('on', b'\t\x99\x00\x00\x00\x06\x01\x06\x00\x01\x00\x01')])
 def test_cryomech_cpa_release_reacquire(wait_for_crossbar, emulator, run_agent_acq,
-                                        client):
-    resp = client.init.wait()
-    resp = client.init.status()
+                                        client, state, command):
+    client.init.wait()
+    response = {command: command}
+    emulator.define_responses(response)
+
+    resp = client.power_ptc(state=state)
     print(resp)
     assert resp.status == ocs.OK
     print(resp.session)


### PR DESCRIPTION
## Description
Added release and acquire function to `acq` process in cryomech cpa agent to release the lock so that short operations like `power_ptc` can run without stopping and restarting `acq`

## Motivation and Context
Keeps the user from having to stop and restart `acq` process

## How Has This Been Tested?
Wrote release and reacquire integration test for cpa agent to make sure the lock releases to run a task during acq process

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] Unless I am preparing a release, I have opened this PR onto the `develop` branch.
