### PR TITLE
More docs standarization

### DIFF
--- a/docs/agents/fts_agent.rst
+++ b/docs/agents/fts_agent.rst
@@ -2,9 +2,9 @@
 
 .. _fts_aerotech_stage:
 
-=====================
+==================
 FTS Aerotech Agent
-=====================
+==================
 
 This agent is used to communicate with the FTS mirror stage for two FTSs with
 Aerotech motion controllers.
@@ -20,8 +20,9 @@ Configuration File Examples
 Below are configuration examples for the ocs config file and for running the
 Agent in a docker container.
 
-ocs-config
-``````````
+OCS Site Config
+```````````````
+
 To configure the FTS Agent we need to add a block to our ocs
 configuration file. Here is an example configuration block using all of
 the available arguments::
@@ -37,8 +38,9 @@ the available arguments::
           ]},
 
 
-fts-config
+FTS Config
 ``````````
+
 The FTS takes a separate YAML config file to specify some inner paramters. Here
 is an example using all the available arguments.::
 
@@ -47,30 +49,30 @@ is an example using all the available arguments.::
     speed: 10
     timeout: 10
 
-Example Client
---------------
-Below is an example client demonstrating full agent functionality.
-Note that all tasks can be run even while the data acquisition process
-is running.::
-
-    from ocs.matched_client import MatchedClient
-
-    #Initialize the Stages
-    fts_agent = MatchedClient('Falcon', args=[])
-    fts_agent.init.start()
-    fts_agent.init.wait()
-
-    #Home Axis
-    fts_agent.home.start()
-    fts_agent.home.wait()
-
-    #Move to a specific position
-    fts_agent.move_to.start( position=0)
-    fts_agent.move_to.wait()
-
-
 Agent API
 ---------
 
 .. autoclass:: socs.agents.fts_aerotech.agent.FTSAerotechAgent
-    :members: init_stage_task, home_task, move_to, start_acq, stop_acq
+    :members:
+
+Example Clients
+---------------
+
+Below is an example client demonstrating full agent functionality.
+Note that all tasks can be run even while the data acquisition process
+is running.::
+
+    from ocs.ocs_client import OCSClient
+
+    # Initialize the Stages
+    fts_agent = OCSClient('Falcon', args=[])
+    fts_agent.init.start()
+    fts_agent.init.wait()
+
+    # Home Axis
+    fts_agent.home.start()
+    fts_agent.home.wait()
+
+    # Move to a specific position
+    fts_agent.move_to.start( position=0)
+    fts_agent.move_to.wait()

--- a/docs/agents/hwp_encoder.rst
+++ b/docs/agents/hwp_encoder.rst
@@ -21,8 +21,9 @@ Configuration File Examples
 Below are useful configurations examples for the relevant OCS files and for
 running the agent in a docker container.
 
-ocs-config
-``````````
+OCS Site Config
+```````````````
+
 To configure the CHWP encoder BBB agent we need to add a HWPBBBAgent
 block to our ocs configuration file. Here is an example configuration block
 using all of the available arguments::
@@ -44,8 +45,9 @@ Multiple BBBs on the same network are distinguished by port numbers.
 You should assign a port for each BBB, which should be consistent with
 the setting on the BBB side.
 
-Docker
-``````
+Docker Compose
+``````````````
+
 The CHWP BBB agent can be run via a Docker container. The following is an
 example of what to insert into your institution's docker-compose file.
 This again is an example to run multiple agents::
@@ -85,3 +87,9 @@ If chwp is completely stopped, approx_hwp_freq will not be updated.::
      'encoder_last_updated': 1659486962.3731978,
      'irig_time':            1659486983,
      'irig_last_updated':    1659486983.8985631}
+
+Agent API
+---------
+
+.. autoclass:: socs.agents.hwp_encoder.agent.HWPBBBAgent
+    :members:

--- a/docs/agents/lakeshore370.rst
+++ b/docs/agents/lakeshore370.rst
@@ -16,8 +16,11 @@ control an LS370 is provided by the
     :func: make_parser
     :prog: python3 agent.py
 
-OCS Configuration
------------------
+Configuration File Examples
+---------------------------
+
+OCS Site Config
+```````````````
 
 To configure your Lakeshore 370 for use with OCS you need to add a
 Lakeshore370Agent block to your ocs configuration file. Here is an example
@@ -32,8 +35,8 @@ configuration block::
 Each device requires configuration under 'agent-instances'. See the OCS site
 configs documentation for more details.
 
-Docker Configuration
---------------------
+Docker Compose
+``````````````
 
 The Lakeshore 370 Agent should be configured to run in a Docker container. An
 example configuration is::
@@ -55,8 +58,11 @@ example configuration is::
     The device path may differ on your machine, and if only using the ttyUSB
     value as shown here, is not guaranteed to be static.
 
+Description
+-----------
+
 Direct Communication
---------------------
+````````````````````
 Direct communication with the Lakeshore can be achieved without OCS, using the
 ``Lakeshore370.py`` module in ``socs/socs/Lakeshore/``. From that directory,
 you can run a script like::
@@ -79,7 +85,7 @@ Agent API
 ---------
 
 .. autoclass:: socs.agents.lakeshore370.agent.LS370_Agent
-    :members: init_lakeshore_task, start_acq
+    :members:
 
 Supporting APIs
 ---------------

--- a/docs/agents/latrt_xy_stage.rst
+++ b/docs/agents/latrt_xy_stage.rst
@@ -24,8 +24,9 @@ Configuration File Examples
 ---------------------------
 Below are configuration examples for the ocs config file.
 
-ocs-config
-``````````
+OCS Site Config
+```````````````
+
 To configure the LATRt XY Stage Agent we need to add a block to our ocs
 configuration file. Here is an example configuration block using all of
 the available arguments::
@@ -39,33 +40,34 @@ the available arguments::
           ['--sampling_freqency', '2'],
           ]},
 
-Example Client
---------------
-Below is an example client demonstrating full agent functionality.
-Note that all tasks can be run even while the data acquisition process
-is running.::
-
-    from ocs.matched_client import MatchedClient
-
-    #Initialize the Stages
-    xy_agent = MatchedClient('XYWing', args=[])
-    xy_agent.init.start()
-    xy_agent.init.wait()
-
-    #Move in X
-    xy_agent.move_x_cm.start( distance=6, velocity=1)
-    xy_agent.move_x_cm.wait()
-
-    #Move in Y
-    xy_agent.move_y_cm.start( distance=6, velocity=1)
-    xy_agent.move_y_cm.wait()
-
-    #Get instantaneous position
-    status, message, session = xy_stage.acq.status()
-    print(session['data']['data'])
-
 Agent API
 ---------
 
 .. autoclass:: socs.agents.xy_stage.agent.LATRtXYStageAgent
-    :members: init_xy_stage_task, move_x_cm, move_y_cm, set_position, start_acq, stop_acq
+    :members:
+
+Example Clients
+---------------
+
+Below is an example client demonstrating full agent functionality.
+Note that all tasks can be run even while the data acquisition process
+is running.::
+
+    from ocs.ocs_client import OCSClient
+
+    # Initialize the Stages
+    xy_agent = OCSClient('XYWing', args=[])
+    xy_agent.init.start()
+    xy_agent.init.wait()
+
+    # Move in X
+    xy_agent.move_x_cm.start( distance=6, velocity=1)
+    xy_agent.move_x_cm.wait()
+
+    # Move in Y
+    xy_agent.move_y_cm.start( distance=6, velocity=1)
+    xy_agent.move_y_cm.wait()
+
+    # Get instantaneous position
+    status, message, session = xy_stage.acq.status()
+    print(session['data']['data'])

--- a/docs/agents/pfeiffer.rst
+++ b/docs/agents/pfeiffer.rst
@@ -21,9 +21,10 @@ Configuration File Examples
 Below are useful configurations examples for the relevent OCS files and for
 running the agent in a docker container.
 
-ocs-config
-``````````
-To configure the Cryomech CPA Agent we need to add a CryomechCPAAgent
+OCS Site Config
+```````````````
+
+To configure the Pfeiffer TPG 366 Agent we need to add a PfeifferAgent
 block to our ocs configuration file. Here is an example configuration block
 using all of the available arguments::
 
@@ -39,9 +40,9 @@ You should assign a static IP address to Pfeiffer device, and record it here.
 In general, the Pfeiffer device will assign port 8000 by default. This should
 not need to be changed unless you you specificy the port otherwise.
 
+Docker Compose
+``````````````
 
-Docker
-``````
 The Pfeiffer Agent can be run via a Docker container. The following is an
 example of what to insest into your institution's docker-compose file. ::
 
@@ -55,16 +56,19 @@ example of what to insest into your institution's docker-compose file. ::
     volumes:
       - ${OCS_CONFIG_DIR}:/config:ro
 
+Agent API
+---------
 
-Example Client
---------------
-Below is an example client to start data acquisition
+.. autoclass:: socs.agents.pfeiffer_tpg366.agent.PfeifferAgent
+    :members:
 
-::
+Example Clients
+---------------
+Below is an example client to start data acquisition::
 
-    from ocs.matched_client import MatchedClienti
+    from ocs.ocs_client import OCSClienti
     import time
-    pfeiffer = MatchedClient("pfeiffer", args=[])
+    pfeiffer = OCSClient("pfeiffer", args=[])
     params = {'auto_acquire': True}
     pfeiffer.acq.start(**params)
     pfeiffer.acq.wait()

--- a/docs/agents/scpi_psu.rst
+++ b/docs/agents/scpi_psu.rst
@@ -2,9 +2,9 @@
 
 .. _scpi_psu:
 
-==================
+==============
 SCPI PSU Agent
-==================
+==============
 
 This agent uses Standard Commands for Programmable Instruments (SCPI)
 It works for many power supplies, including the Keithley 2230G
@@ -23,8 +23,9 @@ Configuration File Examples
 Below are configuration examples for the ocs config file and for running the
 Agent in a docker container.
 
-ocs-config
-``````````
+OCS Site Config
+```````````````
+
 To configure the SCPI PSU Agent we need to add a block to our ocs
 configuration file. Here is an example configuration block using all of
 the available arguments::
@@ -41,8 +42,9 @@ have GPIB ports rather than ethernet ports. Therefore a GPIB-to-ethernet
 converter is required, and the gpib slot must be specified in the ocs
 configuration file. The IP address is then associated with the converter.
 
-Docker
-``````
+Docker Compose
+``````````````
+
 The SCPI PSU Agent should be configured to run in a Docker container.
 An example docker-compose service configuration is shown here::
 
@@ -55,42 +57,42 @@ An example docker-compose service configuration is shown here::
     volumes:
       - ${OCS_CONFIG_DIR}:/config:ro
 
-Example Client
---------------
-Below is an example client demonstrating full agent functionality.
-Note that all tasks can be run even while the data acquisition process
-is running.::
-
-    from ocs.matched_client import MatchedClient
-
-    #Initialize the power supply
-    psuK = MatchedClient('psuK', args=[])
-    psuK.init.start()
-    psuK.init.wait()
-
-    #Turn on channel 1
-    psuK.set_output.start(channel = 1, state=True)
-    psuK.set_output.wait()
-
-    #Set channel 1 voltage
-    psuK.set_voltage.start(channel=1, volts=30)
-    psuK.set_voltage.wait()
-
-    #Set channel 1 current
-    psuK.set_current.start(channel=1, current=0.1)
-    psuK.set_current.wait()
-
-    #Get instantaneous reading of current and voltage output
-    statusK, messageK, sessionK = psuK.monitor_output.status()
-    print(sessionK['data']['data'])
-
-    #Start live monitoring of current and voltage output
-    statusK, messageK, sessionK = psuK.monitor_output.start()
-    print(sessionK)
-
-
 Agent API
 ---------
 
 .. autoclass:: socs.agents.scpi_psu.agent.ScpiPsuAgent
-    :members: monitor_output, set_voltage, set_current, set_output
+    :members:
+
+Example Clients
+---------------
+
+Below is an example client demonstrating full agent functionality.
+Note that all tasks can be run even while the data acquisition process
+is running.::
+
+    from ocs.ocs_client import OCSClient
+
+    # Initialize the power supply
+    psuK = OCSClient('psuK', args=[])
+    psuK.init.start()
+    psuK.init.wait()
+
+    # Turn on channel 1
+    psuK.set_output.start(channel = 1, state=True)
+    psuK.set_output.wait()
+
+    # Set channel 1 voltage
+    psuK.set_voltage.start(channel=1, volts=30)
+    psuK.set_voltage.wait()
+
+    # Set channel 1 current
+    psuK.set_current.start(channel=1, current=0.1)
+    psuK.set_current.wait()
+
+    # Get instantaneous reading of current and voltage output
+    statusK, messageK, sessionK = psuK.monitor_output.status()
+    print(sessionK['data']['data'])
+
+    # Start live monitoring of current and voltage output
+    statusK, messageK, sessionK = psuK.monitor_output.start()
+    print(sessionK)

--- a/docs/agents/smurf_crate_monitor.rst
+++ b/docs/agents/smurf_crate_monitor.rst
@@ -8,18 +8,7 @@ Smurf Crate Monitor Agent
 
 The SMuRF readout system uses Advanced Telecommunications Computing Architecture
 (ATCA) crates for powering and communicating between boards and the site networking
-and timing infrastructure. These crates have a small computer on board called a
-shelf manager which monitors all of the sensors in the crate including ammeters, and
-voltmeters for the power into the crates and into each front and rear module of each
-active slot used in the crate. There are also tachometers on each of the crate fans
-and various thermometers withing the crate and each of the boards plugged into the
-crate which the shelf manager monitors. There are multiple crate manufacturers
-but the shelf managers all share the same set of programming/communication called
-Pigeon Poing Communication so this agent should work across multiple crate
-manufacturers. This agent connects to a shell terminal of a crate shelf
-manager over ssh through the python subprocess package and then runs the
-command 'clia sensordata' and parses its output to identify all of the available
-sensors then stream and publish them.
+and timing infrastructure. This Agent monitors the sensors in these ATCA crates.
 
 .. argparse::
     :filename: ../socs/agents/smurf_crate_monitor/agent.py
@@ -28,11 +17,13 @@ sensors then stream and publish them.
 
 Configuration File Examples
 ---------------------------
+
 Below are configuration examples for the ocs config file and for running the
 Agent in a docker container.
 
-ocs-config
-``````````
+OCS Site Config
+```````````````
+
 To configure the SMuRF Crate Monitor Agent we need to add a CrateAgent entry
 to our site configuration file. Here is an example configuration block using
 all of the available arguments::
@@ -69,8 +60,9 @@ the ocs-user in your 'docker-compose' file, see below for an example.
 The second argument, 'crate-id', is just an identifier for your feed names
 to distinguish between identical sensors on different crates.
 
-Docker
-``````
+Docker Compose
+``````````````
+
 The SMuRF Crate Agent should be configured to run in a Docker container. An
 example docker-compose service configuration is shown here::
 
@@ -94,8 +86,25 @@ An example of the 'ocs-base' anchor is shown here::
   volumes:
     - ${OCS_CONFIG_DIR}:/config
 
+Description
+-----------
+
+The ATCA crates have a small computer on board called a shelf manager which
+monitors all of the sensors in the crate including ammeters, and voltmeters for
+the power into the crates and into each front and rear module of each active
+slot used in the crate. There are also tachometers on each of the crate fans
+and various thermometers withing the crate and each of the boards plugged into
+the crate which the shelf manager monitors.
+
+There are multiple crate manufacturers but the shelf managers all share the
+same set of programming/communication called Pigeon Poing Communication so this
+agent should work across multiple crate manufacturers. This agent connects to a
+shell terminal of a crate shelf manager over ssh through the python subprocess
+package and then runs the command ``clia sensordata`` and parses its output to
+identify all of the available sensors then stream and publish them.
+
 Agent API
 ---------
 
 .. autoclass:: socs.agents.smurf_crate_monitor.agent.SmurfCrateMonitor
-    :members: init_crate, start_acq
+    :members:

--- a/docs/agents/synacc.rst
+++ b/docs/agents/synacc.rst
@@ -19,8 +19,9 @@ Configuration File Examples
 Below are configuration examples for the ocs config file and for running the
 Agent in a docker container.
 
-ocs-config
-``````````
+OCS Site Config
+```````````````
+
 To configure the Synaccess Agent we need to add a Synaccess Agent block to our ocs
 configuration file. Here is an example configuration block using all of the
 available arguments::
@@ -33,8 +34,9 @@ available arguments::
           ['--password', 'admin'],
           ]}
 
-Docker
-``````
+Docker Compose
+``````````````
+
 The Synaccess Agent should be configured to run in a Docker container.
 An example docker-compose service configuration is shown here::
 
@@ -50,12 +52,18 @@ An example docker-compose service configuration is shown here::
 Since the agent within the container needs to communicate with hardware on the
 host network you must use ``network_mode: "host"`` in your compose file.
 
-Example Client
---------------
+Agent API
+---------
+
+.. autoclass:: socs.agents.synacc.agent.SynaccessAgent
+    :members:
+
+Example Clients
+---------------
 Below is an example client to control outlets::
 
-    from ocs import matched_client
-    synaccess = matched_client.MatchedClient('synacc', args=[])
+    from ocs import ocs_client
+    synaccess = ocs_client.OCSClient('synacc', args=[])
 
     #Get status of the strip
     synaccess.get_status.start()
@@ -73,10 +81,3 @@ Below is an example client to control outlets::
     #Turn on/off all outlets
     synaccess.set_all.start(on=True)
     synaccess.set_all.wait()
-
-
-Agent API
----------
-
-.. autoclass:: socs.agents.synacc.agent.SynaccessAgent
-    :members:

--- a/docs/agents/tektronix3021c.rst
+++ b/docs/agents/tektronix3021c.rst
@@ -22,8 +22,9 @@ Configuration File Examples
 Below are configuration examples for the ocs config file and for running the
 Agent in a docker container.
 
-ocs-config
-``````````
+OCS Site Config
+```````````````
+
 To configure the Tektronix AWG Agent we need to add a block to our ocs
 configuration file. Here is an example configuration block using all of
 the available arguments::
@@ -40,8 +41,9 @@ have GPIB ports rather than ethernet ports. Therefore a GPIB-to-ethernet
 converter is required, and the gpib slot must be specified in the ocs
 configuration file. The IP address is then associated with the converter.
 
-Docker
-``````
+Docker Compose
+``````````````
+
 The Tektronix AWG Agent should be configured to run in a Docker container.
 An example docker-compose service configuration is shown here::
 
@@ -53,33 +55,33 @@ An example docker-compose service configuration is shown here::
     volumes:
       - ${OCS_CONFIG_DIR}:/config:ro
 
-Example Client
---------------
-Below is an example client demonstrating full agent functionality.
-Note that all tasks can be run even while the data acquisition process
-is running.::
-
-    from ocs.matched_client import MatchedClient
-
-    #Initialize the power supply
-    tek = MatchedClient('tektronix', args=[])
-    tek.init.start()
-    tek.init.wait()
-
-    #Set AWG frequency
-    psuK.set_frequency.start(frequency=200)
-    psuK.set_frequency.wait()
-
-    #Set AWG peak to peak voltage
-    psuK.set_amplitude.start(amplitude=5)
-    psuK.set_amplitude.wait()
-
-    #Set AWG on/off
-    psuK.set_output.start(state=True)
-    psuK.set_output.wait()
-
 Agent API
 ---------
 
 .. autoclass:: socs.agents.tektronix3021c.agent.TektronixAWGAgent
-    :members: set_frequency, set_amplitude, set_output
+    :members:
+
+Example Clients
+---------------
+Below is an example client demonstrating full agent functionality.
+Note that all tasks can be run even while the data acquisition process
+is running.::
+
+    from ocs.ocs_client import OCSClient
+
+    # Initialize the power supply
+    tek = OCSClient('tektronix', args=[])
+    tek.init.start()
+    tek.init.wait()
+
+    # Set AWG frequency
+    psuK.set_frequency.start(frequency=200)
+    psuK.set_frequency.wait()
+
+    # Set AWG peak to peak voltage
+    psuK.set_amplitude.start(amplitude=5)
+    psuK.set_amplitude.wait()
+
+    # Set AWG on/off
+    psuK.set_output.start(state=True)
+    psuK.set_output.wait()

--- a/docs/agents/vantage_pro2.rst
+++ b/docs/agents/vantage_pro2.rst
@@ -18,6 +18,57 @@ Here is the `VantagePro2 Operations manual`_.
 
 .. _`VantagePro2 Operations manual`: https://www.davisinstruments.com/support/weather/download/VantageSerialProtocolDocs_v261.pdf
 
+Configuration File Examples
+---------------------------
+Below are configuration examples for the ocs config file and for running the
+Agent in a docker container.
+
+OCS Site Config
+```````````````
+
+To configure the Vantage Pro2 Agent we need to add a VantagePro2Agent block to
+our ocs configuration file. Here is an example configuration block,
+where we do not specify the port.
+Note: One should first add the serial number of the VantagePro 2 device
+to the udev file and create SYMLINK.
+The Vendor ID is "10c4" and the Prodcut ID is "ea60" for the Vantage Pro2.
+Here, we associate the vendor and product ID's with the SYMLINK 'VP2'.
+So, we're setting the serial number argument as 'VP2'::
+
+     {'agent-class': 'VantagePro2Agent',
+       'instance-id': 'vantagepro2agent',
+       'arguments': [['--mode', 'acq'],
+                     ['--serial-number', 'VP2'],
+                     ['--sample-freq', '0.5']]},
+
+An example block of the udev rules file for the VantagePro 2 follows::
+
+        SUBSYSTEM=="tty", ATTRS{idVendor}=="10c4", ATTRS{idProduct}=="ea60",
+                SYMLINK="VP2"
+
+
+The agent will attempt to find the port that the Vantage Pro2 is connected to
+based on the serial number.
+
+Note the '--freq' argument specifies the sample frequency that the Vantage Pro2
+Monitor collects weather data. The Vantage Pro2 and weather station can
+sample weathervdata at a maximum sample frequency of 0.5 Hz.
+The user can define slower sample frequencies if they so desire.
+
+Docker Compose
+``````````````
+
+The Vantage Pro2 Agent should be configured to run in a Docker container. An
+example docker-compose service configuration is shown here::
+
+  ocs-vantage-pro2:
+    image: simonsobs/socs:latest
+    hostname: ocs-docker
+    command:
+      - INSTANCE_ID=vantagepro2agent
+    volumes:
+      - ${OCS_CONFIG_DIR}:/config:ro
+
 Description
 -----------
 Out of the box, one just needs to connect the weather station to the
@@ -87,57 +138,8 @@ types of weather data:
 - Time of Sunrise: Time is stored as hour x 100 + min
 - Time of Sunset: Time is stored as hour x 100 + min
 
-Configuration File Examples
----------------------------
-Below are configuration examples for the ocs config file and for running the
-Agent in a docker container.
-
-ocs-config
-``````````
-To configure the Vantage Pro2 Agent we need to add a VantagePro2Agent block to
-our ocs configuration file. Here is an example configuration block,
-where we do not specify the port.
-Note: One should first add the serial number of the VantagePro 2 device
-to the udev file and create SYMLINK.
-The Vendor ID is "10c4" and the Prodcut ID is "ea60" for the Vantage Pro2.
-Here, we associate the vendor and product ID's with the SYMLINK 'VP2'.
-So, we're setting the serial number argument as 'VP2'::
-
-     {'agent-class': 'VantagePro2Agent',
-       'instance-id': 'vantagepro2agent',
-       'arguments': [['--mode', 'acq'],
-                     ['--serial-number', 'VP2'],
-                     ['--sample-freq', '0.5']]},
-
-An example block of the udev rules file for the VantagePro 2 follows::
-
-        SUBSYSTEM=="tty", ATTRS{idVendor}=="10c4", ATTRS{idProduct}=="ea60",
-                SYMLINK="VP2"
-
-
-The agent will attempt to find the port that the Vantage Pro2 is connected to
-based on the serial number.
-
-Note the '--freq' argument specifies the sample frequency that the Vantage Pro2
-Monitor collects weather data. The Vantage Pro2 and weather station can
-sample weathervdata at a maximum sample frequency of 0.5 Hz.
-The user can define slower sample frequencies if they so desire.
-
-Docker
-``````
-The Vantage Pro2 Agent should be configured to run in a Docker container. An
-example docker-compose service configuration is shown here::
-
-  ocs-vantage-pro2:
-    image: simonsobs/socs:latest
-    hostname: ocs-docker
-    command:
-      - INSTANCE_ID=vantagepro2agent
-    volumes:
-      - ${OCS_CONFIG_DIR}:/config:ro
-
 Agent API
 ---------
 
 .. autoclass:: socs.agents.vantagepro2.agent.VantagePro2Agent
-    :members: init_VantagePro2_task, start_acq
+    :members:

--- a/docs/agents/wiregrid_encoder.rst
+++ b/docs/agents/wiregrid_encoder.rst
@@ -76,9 +76,11 @@ Description
 Hardware Configurations
 ```````````````````````
 
-The hardware-related variables are defined in ``wiregrid_encoder.py``.
+The hardware-related variables are defined in ``wiregrid_encoder.py``:
+
     - COUNTER_INFO_LENGTH = 100
     - COUNTS_ON_BELT = 52000
+
 These should be consistent with the script running in the BeagleBoneBlack,
 and these numbers will rarely be changed because they depend on the hardware.
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -69,7 +69,7 @@ master_doc = 'index'
 #
 # This is also used if you do content translation via gettext catalogs.
 # Usually you set "language" from the command line for these cases.
-language = None
+language = 'en'
 
 # List of patterns, relative to source directory, that match files and
 # directories to ignore when looking for source files.

--- a/socs/agents/lakeshore372/agent.py
+++ b/socs/agents/lakeshore372/agent.py
@@ -150,7 +150,7 @@ class LS372_Agent:
     @ocs_agent.param('force', default=False, type=bool)
     @ocs_agent.param('configfile', type=str, default=None)
     def init_lakeshore(self, session, params=None):
-        """init_lakeshore(auto_acquire=False, acq_params=None, force=False,
+        """init_lakeshore(auto_acquire=False, acq_params=None, force=False, \
                           configfile=None)
 
         **Task** - Perform first time setup of the Lakeshore 372 communication.
@@ -222,7 +222,7 @@ class LS372_Agent:
     @ocs_agent.param('sample_heater', default=False, type=bool)
     @ocs_agent.param('run_once', default=False, type=bool)
     def acq(self, session, params=None):
-        """acq(sample_heater=False)
+        """acq(sample_heater=False, run_once=False)
 
         **Process** - Acquire data from the Lakeshore 372.
 
@@ -415,9 +415,9 @@ class LS372_Agent:
 
     @ocs_agent.param('heater', type=str)
     @ocs_agent.param('range')
-    @ocs_agent.param('wait', type=float)
+    @ocs_agent.param('wait', type=float, default=0)
     def set_heater_range(self, session, params):
-        """set_heater_range(heater=None, range=None, wait=0)
+        """set_heater_range(heater, range, wait=0)
 
         **Task** - Adjust the heater range for servoing cryostat. Wait for a
         specified amount of time after the change.
@@ -459,7 +459,7 @@ class LS372_Agent:
     @ocs_agent.param('channel', type=int, check=lambda x: 1 <= x <= 16)
     @ocs_agent.param('mode', type=str, choices=['current', 'voltage'])
     def set_excitation_mode(self, session, params):
-        """set_excitation_mode(channel=None, mode=None)
+        """set_excitation_mode(channel, mode)
 
         **Task** - Set the excitation mode of a specified channel.
 
@@ -487,7 +487,7 @@ class LS372_Agent:
     @ocs_agent.param('channel', type=int, check=lambda x: 1 <= x <= 16)
     @ocs_agent.param('value', type=float)
     def set_excitation(self, session, params):
-        """set_excitation(channel=None, value=None)
+        """set_excitation(channel, value)
 
         **Task** - Set the excitation voltage/current value of a specified
         channel.
@@ -496,7 +496,7 @@ class LS372_Agent:
             channel (int): Channel to set the excitation for. Valid values
                 are 1-16.
             value (float): Excitation value in volts or amps depending on set
-            excitation mode. See
+                excitation mode. See
                 :func:`socs.Lakeshore.Lakeshore372.Channel.set_excitation`
 
         """
@@ -522,7 +522,7 @@ class LS372_Agent:
 
     @ocs_agent.param('channel', type=int, check=lambda x: 1 <= x <= 16)
     def get_excitation(self, session, params):
-        """get_excitation(channel=None)
+        """get_excitation(channel)
 
         **Task** - Get the excitation voltage/current value of a specified
         channel.
@@ -550,7 +550,7 @@ class LS372_Agent:
     @ocs_agent.param('channel', type=int, check=lambda x: 1 <= x <= 16)
     @ocs_agent.param('resistance_range', type=float)
     def set_resistance_range(self, session, params):
-        """set_resistance_range(channel=None,resistance_range=None)
+        """set_resistance_range(channel, resistance_range)
 
         **Task** - Set the resistance range for a specified channel.
 
@@ -586,7 +586,7 @@ class LS372_Agent:
 
     @ocs_agent.param('channel', type=int, check=lambda x: 1 <= x <= 16)
     def get_resistance_range(self, session, params):
-        """get_resistance_range(channel=None)
+        """get_resistance_range(channel)
 
         **Task** - Get the resistance range for a specified channel.
 
@@ -611,7 +611,7 @@ class LS372_Agent:
     @ocs_agent.param('channel', type=int, check=lambda x: 1 <= x <= 16)
     @ocs_agent.param('dwell', type=int, check=lambda x: 1 <= x <= 200)
     def set_dwell(self, session, params):
-        """set_dwell(channel=None, dwell=None)
+        """set_dwell(channel, dwell)
 
         **Task** - Set the autoscanning dwell time for a particular channel.
 
@@ -636,7 +636,7 @@ class LS372_Agent:
 
     @ocs_agent.param('channel', type=int, check=lambda x: 1 <= x <= 16)
     def get_dwell(self, session, params):
-        """get_dwell(channel=None, dwell=None)
+        """get_dwell(channel)
 
         **Task** - Get the autoscanning dwell time for a particular channel.
 
@@ -662,7 +662,7 @@ class LS372_Agent:
     @ocs_agent.param('I', type=int)
     @ocs_agent.param('D', type=int)
     def set_pid(self, session, params):
-        """set_pid(P=None, I=None, D=None)
+        """set_pid(P, I, D)
 
         **Task** - Set the PID parameters for servo control of fridge.
 
@@ -691,7 +691,7 @@ class LS372_Agent:
 
     @ocs_agent.param('channel', type=int)
     def set_active_channel(self, session, params):
-        """set_active_channel(channel=None)
+        """set_active_channel(channel)
 
         **Task** - Set the active channel on the LS372.
 
@@ -715,7 +715,7 @@ class LS372_Agent:
 
     @ocs_agent.param('autoscan', type=bool)
     def set_autoscan(self, session, params):
-        """set_autoscan(autoscan=None)
+        """set_autoscan(autoscan)
 
         **Task** - Sets autoscan on the LS372.
 
@@ -742,7 +742,7 @@ class LS372_Agent:
 
     @ocs_agent.param('temperature', type=float, check=lambda x: x < 1)
     def servo_to_temperature(self, session, params):
-        """servo_to_temperature(temperature=None)
+        """servo_to_temperature(temperature)
 
         **Task** - Servo to a given temperature using a closed loop PID on a
         fixed channel. This will automatically disable autoscan if enabled.
@@ -790,7 +790,7 @@ class LS372_Agent:
     @ocs_agent.param('measurements', type=int)
     @ocs_agent.param('threshold', type=float)
     def check_temperature_stability(self, session, params):
-        """check_temperature_stability(measurements=None, threshold=None)
+        """check_temperature_stability(measurements, threshold)
 
         Check servo temperature stability is within threshold.
 
@@ -840,7 +840,7 @@ class LS372_Agent:
     @ocs_agent.param('heater', type=str, choices=['sample', 'still'])
     @ocs_agent.param('mode', type=str, choices=['Off', 'Monitor Out', 'Open Loop', 'Zone', 'Still', 'Closed Loop', 'Warm up'])
     def set_output_mode(self, session, params=None):
-        """set_output_mode(heater=None, mode=None)
+        """set_output_mode(heater, mode)
 
         **Task** - Set output mode of the heater.
 
@@ -871,14 +871,13 @@ class LS372_Agent:
     @ocs_agent.param('output', type=float)
     @ocs_agent.param('display', type=str, choices=['current', 'power'], default=None)
     def set_heater_output(self, session, params=None):
-        """set_heater_output(heater=None, output=None, display=None)
+        """set_heater_output(heater, output, display=None)
 
         **Task** - Set display type and output of the heater.
 
         Parameters:
             heater (str): Name of heater to set range for, either 'sample' or
                 'still'.
-                "Open Loop", "Zone", "Still", "Closed Loop", or "Warm up"
             output (float): Specifies heater output value. For possible values see
                 :func:`socs.Lakeshore.Lakeshore372.Heater.set_heater_output`
             display (str, optional): Specifies heater display type. Can be
@@ -923,7 +922,7 @@ class LS372_Agent:
 
     @ocs_agent.param('output', type=float, check=lambda x: 0 <= x <= 100)
     def set_still_output(self, session, params=None):
-        """set_still_output(output=None)
+        """set_still_output(output)
 
         **Task** - Set the still output on the still heater. This is different
         than the manual output on the still heater. Use
@@ -987,7 +986,7 @@ class LS372_Agent:
 
     @ocs_agent.param('configfile', type=str)
     def input_configfile(self, session, params=None):
-        """input_configfile(configfile=None)
+        """input_configfile(configfile)
 
         **Task** - Upload 372 configuration file to initialize channel/device
         settings.

--- a/socs/agents/synacc/agent.py
+++ b/socs/agents/synacc/agent.py
@@ -8,15 +8,16 @@ from ocs.ocs_twisted import TimeoutLock
 
 
 class SynaccessAgent:
-    def __init__(self, agent, ip_address, username, password):
-        """
-        Initializes the class variables
+    """
+    Agent to control and monitor Synaccess Networks PDUs.
 
-        Args:
-            ip_address(str): IP Address for the agent.
-            username(str): username credential to login to strip
-            password(str): password credential to login to strip
-        """
+    Args:
+        ip_address(str): IP address for the device.
+        username(str): Username credential to login to device.
+        password(str): Password credential to login to device.
+    """
+
+    def __init__(self, agent, ip_address, username, password):
         self.agent = agent
         self.log = agent.log
         self.lock = TimeoutLock()
@@ -35,7 +36,13 @@ class SynaccessAgent:
         resp = r.content.decode()[:-6:-1]  # get last 5 elements, in reverse
         return resp
 
+    @ocs_agent.param('_')
     def get_status(self, session, params=None):
+        """get_status()
+
+        **Task** - Get the status of all outlets.
+
+        """
         with self.lock.acquire_timeout(3, job='get_status') as acquired:
             if acquired:
                 resp = self.__get_status()
@@ -49,7 +56,16 @@ class SynaccessAgent:
             else:
                 return False, "Could not acquire lock"
 
+    @ocs_agent.param('outlet', type=int)
     def reboot(self, session, params=None):
+        """reboot(outlet)
+
+        **Task** - Reboot a given outlet.
+
+        Parameters:
+            outlet (int): The outlet that we are changing the state of.
+
+        """
         with self.lock.acquire_timeout(3, job='reboot') as acquired:
             if acquired:
                 req = "http://" + self.user + ":" + \
@@ -60,13 +76,17 @@ class SynaccessAgent:
             else:
                 return False, "Could not acquire lock"
 
+    @ocs_agent.param('outlet', type=int)
+    @ocs_agent.param('on', type=bool)
     def set_outlet(self, session, params=None):
-        """
-        Sets a particular outlet to on/off
+        """set_outlet(outlet, on)
 
-        Args:
-            outlet (int): the outlet that we are changing the state of
-            on (bool): the new state
+        **Task** - Set a particular outlet on/off.
+
+        Parameters:
+            outlet (int): The outlet that we are changing the state of.
+            on (bool): The new state. True for on, False for off.
+
         """
         with self.lock.acquire_timeout(3, job='set_outlet') as acquired:
             if acquired:
@@ -83,13 +103,14 @@ class SynaccessAgent:
             else:
                 return False, "Could not acquire lock"
 
+    @ocs_agent.param('on', type=bool)
     def set_all(self, session, params=None):
-        """
+        """set_all(on)
 
-        Sets all outlets to on/off
+        **Task** - Set all outlets on/off.
 
-        Args:
-            on (bool): the new state
+        Parameters:
+            on (bool): The new state. True for on, False for off.
 
         """
         with self.lock.acquire_timeout(3, job='set_all') as acquired:
@@ -104,10 +125,11 @@ class SynaccessAgent:
             else:
                 return False, "Could not acquire lock"
 
+    @ocs_agent.param('_')
     def status_acq(self, session, params=None):
         """status_acq()
 
-        **Process** - Method to start data acquisition process.
+        **Process** - Start data acquisition.
 
         Notes:
             The most recent data collected is stored in session.data in the
@@ -192,9 +214,9 @@ def make_parser(parser=None):
 
     # Add options specific to this agent.
     pgroup = parser.add_argument_group('Agent Options')
-    pgroup.add_argument('--ip-address')
-    pgroup.add_argument('--username')
-    pgroup.add_argument('--password')
+    pgroup.add_argument('--ip-address', help='IP address for the device.')
+    pgroup.add_argument('--username', help='Username credential to login to device.')
+    pgroup.add_argument('--password', help='Password credential to login to device.')
     return parser
 
 

--- a/socs/agents/tektronix3021c/agent.py
+++ b/socs/agents/tektronix3021c/agent.py
@@ -2,26 +2,22 @@
 mrandall@ucsd.edu"""
 
 import argparse
-import os
 import socket
 import time
 
-from socs.agents.tektronix3021c.drivers import TektronixInterface
+from ocs import ocs_agent, site_config
+from ocs.ocs_twisted import TimeoutLock
 
-on_rtd = os.environ.get('READTHEDOCS') == 'True'
-if not on_rtd:
-    from ocs import ocs_agent, site_config
-    from ocs.ocs_twisted import TimeoutLock
+from socs.agents.tektronix3021c.drivers import TektronixInterface
 
 
 class TektronixAWGAgent:
-    """Tektronix3021c Agent.
+    """Tektronix3021c Function Generator Agent.
 
     Args:
-        ip_address (string): the IP address of the gpib to ethernet
+        ip_address (string): The IP address of the gpib to ethernet
             controller connected to the function generator.
-
-        gpib_slot (int): the gpib address currently set
+        gpib_slot (int): The gpib address currently set
             on the function generator.
 
     """
@@ -46,8 +42,13 @@ class TektronixAWGAgent:
                                  record=True,
                                  agg_params=agg_params)
 
-    def init_awg(self, session, params=None):
-        """ Task to connect to Tektronix AWG """
+    @ocs_agent.param('_')
+    def init(self, session, params=None):
+        """init()
+
+        **Task** - Initialize connection to Tektronix AWG.
+
+        """
 
         with self.lock.acquire_timeout(0) as acquired:
             if not acquired:
@@ -66,108 +67,73 @@ class TektronixAWGAgent:
 
         return True, 'Initialized AWG.'
 
+    @ocs_agent.param('frequency', type=float, check=lambda x: 0 <= x <= 25e6)
     def set_frequency(self, session, params=None):
-        """
-        Sets frequency of function generator:
+        """set_frequency(frequency)
 
-        Args:
-            frequency (float): Frequency to set in Hz.
-            Must be between 0 and 25,000,000.
+        **Task** - Set frequency of the function generator.
+
+        Parameters:
+            frequency (float): Frequency to set in Hz. Must be between 0 and
+                25,000,000.
         """
 
         with self.lock.acquire_timeout(1) as acquired:
             if acquired:
-                freq = params.get("frequency")
+                freq = params['frequency']
 
-                try:
-                    float(freq)
+                self.awg.set_freq(freq)
 
-                except ValueError as e:
-                    return False, """Frequency must
-                                    be a float or int -> {}""".format(e)
-
-                except TypeError as e:
-                    return False, """Frequency must
-                                    not be of NoneType -> {}""".format(e)
-
-                if 0 < freq < 25E6:
-                    self.awg.set_freq(freq)
-
-                    data = {'timestamp': time.time(),
-                            'block_name': "AWG_frequency_cmd",
-                            'data': {'AWG_frequency_cmd': freq}
-                            }
-                    self.agent.publish_to_feed('awg', data)
-
-                else:
-                    return False, """Invalid input:
-                        Frequency must be between 0 and 25,000,000 Hz"""
-
+                data = {'timestamp': time.time(),
+                        'block_name': "AWG_frequency_cmd",
+                        'data': {'AWG_frequency_cmd': freq}
+                        }
+                self.agent.publish_to_feed('awg', data)
             else:
                 return False, "Could not acquire lock"
 
-        return True, 'Set frequency {} Hz'.format(params)
+        return True, 'Set frequency {} Hz'.format(freq)
 
+    @ocs_agent.param('amplitude', type=float, check=lambda x: 0 <= x <= 10)
     def set_amplitude(self, session, params=None):
-        """
-        Sets current of power supply:
+        """set_amplitude(amplitude)
 
-        Args:
-            amplitude (float): Peak to Peak voltage to set.
-            Must be between 0 and 10.
+        **Task** - Set peak to peak voltage of the function generator.
+
+        Parameters:
+            amplitude (float): Peak to Peak voltage to set. Must be between 0
+                and 10.
+
         """
         with self.lock.acquire_timeout(1) as acquired:
             if acquired:
-                amp = params.get('amplitude')
-                try:
-                    float(amp)
+                amp = params['amplitude']
 
-                except ValueError as e:
-                    return False, """Amplitude must be
-                                    a float or int -> {}""".format(e)
+                self.awg.set_amp(amp)
 
-                except TypeError as e:
-                    return False, """Amplitude must not be
-                                    of NoneType -> {}""".format(e)
-
-                if 0 < amp < 10:
-                    self.awg.set_amp(amp)
-
-                    data = {'timestamp': time.time(),
-                            'block_name': "AWG_amplitude_cmd",
-                            'data': {'AWG_amplitude_cmd': amp}
-                            }
-                    self.agent.publish_to_feed('awg', data)
-
-                else:
-                    return False, """Amplitude must be
-                                    between 0 and 10 Volts peak to peak"""
-
+                data = {'timestamp': time.time(),
+                        'block_name': "AWG_amplitude_cmd",
+                        'data': {'AWG_amplitude_cmd': amp}
+                        }
+                self.agent.publish_to_feed('awg', data)
             else:
                 return False, "Could not acquire lock"
 
         return True, 'Set amplitude to {} Vpp'.format(params)
 
+    @ocs_agent.param('state', type=bool)
     def set_output(self, session, params=None):
-        """
-        Task to turn channel on or off.
+        """set_output(state)
 
-        Args:
+        **Task** - Turn function generator output on or off.
+
+        Parameters:
             state (bool): True for on, False for off.
+
         """
         with self.lock.acquire_timeout(1) as acquired:
             if acquired:
                 state = params.get("state")
-
-                try:
-                    bool(state)
-
-                except ValueError as e:
-                    return False, "State must be a boolean -> {}".format(e)
-
-                except TypeError as e:
-                    return False, """State must not
-                                    be of NoneType -> {}""".format(e)
 
                 self.awg.set_output(state)
 
@@ -189,9 +155,9 @@ def make_parser(parser=None):
 
     pgroup = parser.add_argument_group('Agent Options')
     pgroup.add_argument('--ip-address', type=str,
-                        help="IP address of tektronix device")
+                        help="IP address of Tektronix device.")
     pgroup.add_argument('--gpib-slot', type=int,
-                        help="GPIB slot of tektronix device")
+                        help="GPIB slot of Tektronix device.")
     return parser
 
 
@@ -205,7 +171,7 @@ def main(args=None):
 
     p = TektronixAWGAgent(agent, args.ip_address, args.gpib_slot)
 
-    agent.register_task('init', p.init_awg, startup=True)
+    agent.register_task('init', p.init, startup=True)
     agent.register_task('set_frequency', p.set_frequency)
     agent.register_task('set_amplitude', p.set_amplitude)
     agent.register_task('set_output', p.set_output)


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
This PR catches up on many of the Agent docs left after last year's documentation hack day (#208). It standardizes the documentation formatting in the following agents:
- SMuRF Crate Monitor
- HWP BBB Encoder
- Weather Monitor
- Synaccess
- SCPI PSU
- Pfeiffer TPG 366
- Tektronix AWG
- FTS Linear Stage
- LATRt XY Stage
- Lakeshore370

It also adds use of the `@ocs_agent.param` decorator, and where appropriate, modifies the tasks/processes to remove checks on valid params passing, as that check is now handled by the decorator.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
This has been on my to do list for a year, and I wanted to get it done before releasing v0.4.0.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
Not tested yet, except for where Agents have unit/integration tests.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] Unless I am preparing a release, I have opened this PR onto the `develop` branch.
