### PR TITLE
Make docker-compose examples consistent

### DIFF
--- a/docs/agents/bluefors_agent.rst
+++ b/docs/agents/bluefors_agent.rst
@@ -45,11 +45,11 @@ Example docker-compose configuration::
     hostname: ocs-docker
     network_mode: "host"
     environment:
-      INSTANCE_ID: bluefors
-      LOGLEVEL: info
-      FRAME_LENGTH: 600
-      STALE_TIME: 2
-      MODE: follow
+      - INSTANCE_ID=bluefors
+      - LOGLEVEL=info
+      - FRAME_LENGTH=600
+      - STALE_TIME=2
+      - MODE=follow
     volumes:
       - ${OCS_CONFIG_DIR}:/config:ro
       - /home/simonsobs/bluefors/logs/:/logs:ro

--- a/docs/agents/pysmurf-controller.rst
+++ b/docs/agents/pysmurf-controller.rst
@@ -50,17 +50,17 @@ named ``ocs-pysmurf-monitor`` might look something like::
         security_opt:
             - "aparmor=docker-smurf"
         environment:
-            INSTANCE_ID=pysmurf-controller-s2
-            SITE_HUB=ws://${CB_HOST}:8001/ws
-            SITE_HTTP=ws://${CB_HOST}:8001/call
-            SMURFPUB_BACKEND: udp
-            SMURFPUB_ID: crate1slot2
-            SMURFPUB_UDP_HOST: ocs-pysmurf-monitor
-            DISPLAY: $DISPLAY
-            OCS_CONFIG_DIR: /config
-            EPICS_CA_ADDR_LIST: 127.255.255.255
-            EPICS_CA_MAX_ARRAY_BYTES: 80000000
-            SLOT: 2
+            - INSTANCE_ID=pysmurf-controller-s2
+            - SITE_HUB=ws://${CB_HOST}:8001/ws
+            - SITE_HTTP=ws://${CB_HOST}:8001/call
+            - SMURFPUB_BACKEND=udp
+            - SMURFPUB_ID=crate1slot2
+            - SMURFPUB_UDP_HOST=ocs-pysmurf-monitor
+            - DISPLAY
+            - OCS_CONFIG_DIR=/config
+            - EPICS_CA_ADDR_LIST=127.255.255.255
+            - EPICS_CA_MAX_ARRAY_BYTES=80000000
+            - SLOT=2
         volumes:
             - ${OCS_CONFIG_DIR}:/config
             - /data:/data


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

Fixes the example agent docker configuration blocks to have consistent usage of `=` instead of `:`.

Note this doesn't require users to change their existing configs.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

A mix of `=` and `:` will cause issues. Cornell saw this when updating recently (thanks @zhuber21 for the report!)

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
Cornell switched to consistent usage and it resolved their problem.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] - Documentation update

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] Unless I am preparing a release, I have opened this PR onto the `develop` branch.
