### PR TITLE
Rework pysmurf controller tests for sodetlib v0.5.0

### DIFF
--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -65,7 +65,7 @@ jobs:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       run: |
         mv ./tests/.coverage.* ./
-        pip install coveralls
+        pip install -U coveralls
         coverage combine
         coverage report
         coveralls --service=github

--- a/tests/agents/test_pysmurf_controller_agent.py
+++ b/tests/agents/test_pysmurf_controller_agent.py
@@ -245,11 +245,17 @@ def test_uxm_relock(agent):
     assert res[0] is True
 
 
+def mock_take_bgmap(S, cfg, **kwargs):
+    """Mock a typical valid response from bias_steps.take_bgmap."""
+    bsa = mock.MagicMock()
+    bsa.sid = 0
+    bsa.filepath = 'bias_step_analysis.npy'
+    bsa.bgmap = np.zeros((12, 2))
+    return bsa
+
+
 @mock.patch('socs.agents.pysmurf_controller.agent.PysmurfController._get_smurf_control', mock_pysmurf)
-@mock.patch('sodetlib.set_current_mode', mock_set_current_mode)
-@mock.patch('sodetlib.operations.bias_steps.BiasStepAnalysis', mock_biasstepanalysis)
-@mock.patch('matplotlib.figure.Figure.savefig', mock_plt_savefig())
-@mock.patch('time.sleep', mock.MagicMock())
+@mock.patch('sodetlib.operations.bias_steps.take_bgmap', mock_take_bgmap)
 def test_take_bgmap(agent):
     """test_take_bgmap()
 
@@ -258,6 +264,8 @@ def test_take_bgmap(agent):
     session = create_session('take_bgmap')
     res = agent.take_bgmap(session, {'kwargs': {'high_current_mode': False}})
     assert res[0] is True
+    assert session.data['nchans_per_bg'] == [24, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0]
+    assert session.data['filepath'] == 'bias_step_analysis.npy'
 
 
 @mock.patch('socs.agents.pysmurf_controller.agent.PysmurfController._get_smurf_control', mock_pysmurf)

--- a/tests/agents/test_pysmurf_controller_agent.py
+++ b/tests/agents/test_pysmurf_controller_agent.py
@@ -335,9 +335,13 @@ def test_take_noise(agent):
     assert res[0] is True
 
 
+def mock_bias_to_rfrac_range(*args, **kwargs):
+    biases = np.full((12,), 10.)
+    return biases
+
+
 @mock.patch('socs.agents.pysmurf_controller.agent.PysmurfController._get_smurf_control', mock_pysmurf)
-@mock.patch('sodetlib.set_current_mode', mock_set_current_mode)
-@mock.patch('time.sleep', mock.MagicMock())
+@mock.patch('sodetlib.operations.bias_dets.bias_to_rfrac_range', mock_bias_to_rfrac_range)
 def test_bias_dets(agent):
     """test_bias_dets()
 
@@ -349,6 +353,7 @@ def test_bias_dets(agent):
                                     'kwargs': {'iva': mock_ivanalysis(S=mm, cfg=mm, run_kwargs=mm,
                                                                       sid=mm, start_times=mm, stop_times=mm)}})
     assert res[0] is True
+    assert session.data['biases'] == np.full((12,), 10.).tolist()
 
 
 @mock.patch('socs.agents.pysmurf_controller.agent.PysmurfController._get_smurf_control', mock_pysmurf)

--- a/tests/agents/test_pysmurf_controller_agent.py
+++ b/tests/agents/test_pysmurf_controller_agent.py
@@ -209,11 +209,32 @@ def test_uxm_setup(agent):
     assert res[0] is True
 
 
+def mock_uxm_relock(S, cfg, bands, **kwargs):
+    """Mock a typical valid response from uxm_relock."""
+    summary = {'timestamps': [('setup_amps', 1671048272.6197276),
+                              ('load_tune', 1671048272.6274314),
+                              ('tracking_setup', 1671048272.6286802),
+                              ('noise', 1671048272.7402556),
+                              ('end', 1671048272.7404766)],
+               'amps': {'success': True},
+               'reload_tune': None,
+               'tracking_setup_results': mock.MagicMock(),
+               'noise': {'noise_pars': 0,
+                         'bands': 0,
+                         'channels': 0,
+                         'band_medians': 0,
+                         'f': 0,
+                         'axx': 0,
+                         'bincenters': 0,
+                         'lowfn': 0,
+                         'low_f_10mHz': 0,
+                         'am': mock.MagicMock()}}
+
+    return True, summary
+
+
 @mock.patch('socs.agents.pysmurf_controller.agent.PysmurfController._get_smurf_control', mock_pysmurf)
-@mock.patch('numpy.save', mock_np_save())
-@mock.patch('matplotlib.figure.Figure.savefig', mock_plt_savefig())
-@mock.patch('sodetlib.noise.take_noise', mock_take_noise)
-@mock.patch('time.sleep', mock.MagicMock())
+@mock.patch('sodetlib.operations.uxm_relock.uxm_relock', mock_uxm_relock)
 def test_uxm_relock(agent):
     """test_uxm_relock()
 

--- a/tests/agents/test_pysmurf_controller_agent.py
+++ b/tests/agents/test_pysmurf_controller_agent.py
@@ -155,10 +155,10 @@ def mock_set_current_mode(S, bgs, mode, const_current=True):
     return mock.MagicMock()
 
 
-def mock_biasstepanalysis(S, cfg, bgs, run_kwargs):
-    """mock_biasstepanalysis()
+def mock_biasstepanalysis():
+    """Mock Bias Step Analysis (bsa) object typically returned by sodetlib
+    operations.
 
-    **Mock** - Mock BiasStepAnalysis class in sodetlib.
     """
     bsa = mock.MagicMock()
     bsa.sid = 0
@@ -247,10 +247,7 @@ def test_uxm_relock(agent):
 
 def mock_take_bgmap(S, cfg, **kwargs):
     """Mock a typical valid response from bias_steps.take_bgmap."""
-    bsa = mock.MagicMock()
-    bsa.sid = 0
-    bsa.filepath = 'bias_step_analysis.npy'
-    bsa.bgmap = np.zeros((12, 2))
+    bsa = mock_biasstepanalysis()
     return bsa
 
 
@@ -282,10 +279,14 @@ def test_take_iv(agent):
     assert res[0] is True
 
 
+def mock_take_bias_steps(S, cfg, **kwargs):
+    """Mock a typical valid response from bias_steps.take_bias_steps."""
+    bsa = mock_biasstepanalysis()
+    return bsa
+
+
 @mock.patch('socs.agents.pysmurf_controller.agent.PysmurfController._get_smurf_control', mock_pysmurf)
-@mock.patch('sodetlib.set_current_mode', mock_set_current_mode)
-@mock.patch('sodetlib.operations.bias_steps.BiasStepAnalysis', mock_biasstepanalysis)
-@mock.patch('time.sleep', mock.MagicMock())
+@mock.patch('sodetlib.operations.bias_steps.take_bias_steps', mock_take_bias_steps)
 def test_take_bias_steps(agent):
     """test_take_bias_steps()
 
@@ -294,6 +295,7 @@ def test_take_bias_steps(agent):
     session = create_session('take_bias_steps')
     res = agent.take_bias_steps(session, {'kwargs': None})
     assert res[0] is True
+    assert session.data['filepath'] == 'bias_step_analysis.npy'
 
 
 @mock.patch('socs.agents.pysmurf_controller.agent.PysmurfController._get_smurf_control', mock_pysmurf)


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
This changes some of the tests to mock out the sodetlib functions a higher level. This is needed so that they don't depend on the sodetlib internals as much. Of course, if sodetlib function return values change significantly the mocked up values here will need updating.

### Questions
I had some questions that came up while working on this that'd be good to answer/incorporate here.

* What shape is `bsa.bgmap` typically? Here it's (12, 2), probably that's right, I just wanted to double check for myself.
* What's the `session.data` look like for `take_iv` on a live system?

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
[Tests were failing](https://github.com/simonsobs/socs/actions/runs/3698000088/jobs/6263663111) on the update to sodetlib v0.5.0 being done following P10R1, in prep for P10R2. See https://github.com/simonsobs/socs/pull/376.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
Tested locally with sodetlib v0.4.1 and v0.5.0. Tests were demonstrated to fail with v0.5.0 and pass in v0.4.1. Starting from v0.4.1 the tests were modified to change the mocks, creating the new mocked responses from the existing tests. Then tests were verified to pass with v0.5.0.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] Unless I am preparing a release, I have opened this PR onto the `develop` branch.
