### PR TITLE
Adds an interface to  `bias_to_volt_arr`

### DIFF
--- a/socs/agents/pysmurf_controller/agent.py
+++ b/socs/agents/pysmurf_controller/agent.py
@@ -863,7 +863,7 @@ class PysmurfController:
 
 
     @ocs_agent.param('biases')
-    @ocs_agent.params('kwargs', default=None)
+    @ocs_agent.param('kwargs', default=None)
     def bias_to_volt_arr(self, session, params):
         """bias_to_volt_arr(biases, kwargs=None)
 
@@ -891,7 +891,7 @@ class PysmurfController:
             session.set_status('running')
             S, cfg = self._get_smurf_control(session=session)
 
-            bias_dets.bias_to_volt_arr(S, cfg, biases, **params['kwargs'])
+            bias_dets.bias_to_volt_arr(S, cfg, params['biases'], **params['kwargs'])
 
             biases = S.get_tes_bias_bipolar_array()
             session.data['biases'] = biases.tolist()

--- a/tests/agents/test_pysmurf_controller_agent.py
+++ b/tests/agents/test_pysmurf_controller_agent.py
@@ -419,6 +419,7 @@ def test_all_off(agent):
     res = agent.all_off(session, {'disable_amps': True, 'disable_tones': True})
     assert res[0] is True
 
+
 @mock.patch('socs.agents.pysmurf_controller.agent.PysmurfController._get_smurf_control', mock_pysmurf)
 def test_bias_to_volt_arr(agent):
     """test_all_off()

--- a/tests/agents/test_pysmurf_controller_agent.py
+++ b/tests/agents/test_pysmurf_controller_agent.py
@@ -418,3 +418,20 @@ def test_all_off(agent):
     session = create_session('overbias_tes')
     res = agent.all_off(session, {'disable_amps': True, 'disable_tones': True})
     assert res[0] is True
+
+@mock.patch('socs.agents.pysmurf_controller.agent.PysmurfController._get_smurf_control', mock_pysmurf)
+def test_bias_to_volt_arr(agent):
+    """test_all_off()
+
+    **Test** - Tests the all_off task.
+    """
+    session = create_session('bias_to_volt_arr')
+    params = {
+        'biases': np.zeros(12).tolist(),
+        'kwargs': {
+            'overbias': False,
+            'bias_groups': np.arange(12).tolist()
+        }
+    }
+    res = agent.bias_to_volt_arr(session, params)
+    assert res[0] is True


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Adds an interface to the `bias_to_volt_arr` sodetlib function.

## Description
During p10r2 testing we realized there is currently no task to allow you to directly set bias voltages. This can be accomplished using the `bias_to_volt_arr` function, which lets you set the `tes_bias_bipolar_array` for active bgs.
This adds an interface to use that function through the pysmurf-controller.

## How Has This Been Tested?
Not yet, but will test on the SAT

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] Unless I am preparing a release, I have opened this PR onto the `develop` branch.
