### PR TITLE
Adds rotation arg to magpie

### DIFF
--- a/docs/agents/magpie.rst
+++ b/docs/agents/magpie.rst
@@ -46,6 +46,7 @@ a detmap csv file, with a target sample rate of 20 Hz::
          # Detmap CSV file
          '--det-map', '/home/jlashner/lyrebird_demo/detmap.csv',
          '--offset', 0, 0,
+         '--rotation', 0,
          '--demod-freq', 8,
          '--demod-bandwidth', 0.5
        ]},


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Adds an argument to magpie that lets you set a wafer's rotation about its center.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Necessary for bringing up a focal-plane in lyrebird

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
Tested locally with fake data.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project.
- [X] My change requires a change to the documentation.
- [X] I have updated the documentation accordingly.
- [ ] Unless I am preparing a release, I have opened this PR onto the `develop` branch.
