### PR TITLE
Replace master and develop branches with "main" branch

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -24,4 +24,3 @@
 - [ ] My code follows the code style of this project.
 - [ ] My change requires a change to the documentation.
 - [ ] I have updated the documentation accordingly.
-- [ ] Unless I am preparing a release, I have opened this PR onto the `develop` branch.

--- a/.github/workflows/develop.yml
+++ b/.github/workflows/develop.yml
@@ -1,8 +1,8 @@
-name: Build Develop Images
+name: Build Test Images
 
 on:
   push:
-    branches: [ develop ]
+    branches: [ main ]
     paths-ignore:
       - 'docs/**'
       - '**.rst'
@@ -15,7 +15,7 @@ jobs:
     uses: ./.github/workflows/pytest.yml
 
   build:
-    name: build and deploy dev images
+    name: build and deploy test images
     needs: test
     runs-on: ubuntu-latest
 
@@ -37,7 +37,7 @@ jobs:
         username: ${{ secrets.REGISTRY_USER }}
         password: ${{ secrets.REGISTRY_PASSWORD }}
 
-    - name: Build and push development docker image
+    - name: Tag and push test docker images
       env:
         DOCKERHUB_ORG: "simonsobs"
       run: |

--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -5,6 +5,22 @@ Contributing to SOCS
 Branches
 --------
 
+Following release v0.4.1, socs now has a single ``main`` branch, which replaces
+the old ``master`` and ``develop`` branch model, described below. ``main``
+functions like ``develop`` used to, and is the new default branch. Feature
+branches should be based off of the latest ``main``, and pull requests should
+be made into ``main``.
+
+Users that want a "stable" installation of socs should install from PyPI and/or
+use tagged Docker images corresponding to the targeted release, i.e. v0.4.1.
+Installing from source (i.e. from the ``main`` branch) comes with the usual
+caveats of potential instability.
+
+Old Branching Model
+```````````````````
+    **Note:** This branching model is no longer used, but the description is
+    left here while we transition to the new one.
+
 There are two long-lived branches in SOCS, ``master`` and ``develop``.
 ``master`` should be considered stable, and will only move forward on official
 releases. ``develop`` may be unstable, and is where all development should take
@@ -19,38 +35,35 @@ branches off of the latest ``develop`` branch, and pull request them into
 Pull Requests
 -------------
 
-When opening a pull request, you should push your feature branch, and select
-the ``develop`` branch as the base branch, the branch you want to merge your
-feature branch into. This is the default branch, so it should be automatically
-selected for you.
+If you are an SO collaborator you may have push access, in which case you can
+push your feature branch, then open a pull request, selecting the ``main``
+branch as the base branch. (This is the default branch, so it should be
+automatically selected for you.)
+
+If you are not an SO collaborator, or otherwise do not have push access, we
+still welcome your pull request! You will have to fork the repository and
+submit a PR from there. See the `GitHub documentation
+<https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/creating-a-pull-request-from-a-fork>`_
+for details on how to do so.
 
 Releases
 --------
 
     **Note:** Releases will be issued by core maintainers of SOCS.
 
-Before making an official release, test the release properly builds and
-publishes with a pre-release. You can do so by pushing a tag matching
-``v0.*.*a*``, ``v0.*.*b*``, or ``v0.*.*rc*``.
+If you are trying to issue a release of SOCS you should follow these steps:
 
-Once the release looks good, publish the official release by following these
-steps:
-
-1. Open a Pull Request, comparing ``develop`` to the ``master`` base branch.
-   Describe the features added for this release.
-2. Make a merge commit when you merge this PR.
-
-   * This merge commit will be what is tagged for the release.
-   * ``develop`` is now one commit behind ``master`` (the merge commit)
-
-3. Pull the latest ``master`` and ``develop`` branches to your work station.
-4. Checkout ``develop``, then run ``git merge --ff-only master``, catching ``develop`` up to ``master``.
-5. ``push origin develop`` to update the remote ``develop`` branch.
-
-The ``develop`` and ``master`` branches are now aligned, and ``master`` is
-ready to be released. You can use the GitHub release interface to create a new
-release, copying the change log you wrote in the PR and otherwise describing the
-release.
+1. Test the release properly builds and publishes with a pre-release. You can
+   do so by pushing a tag matching ``v0.*.*a*``, ``v0.*.*b*``, or
+   ``v0.*.*rc*``.
+2. If no new commits are made following a pre-release, remove the pre-release
+   tag. Multiple tags may prevent the official release from publishing properly.
+3. Use the GitHub releases interface to draft a new release, creating a new tag
+   targeting the ``main`` branch.
+4. Write the release notes. Make use of the "Generate release notes" feature.
+   It is helpful to organize these into sections as done in past releases. Be
+   sure to highlight any breaking changes and include instructions for any
+   actions users must take when updating.
 
 Development Guide
 -----------------
@@ -66,7 +79,7 @@ As a way to enforce development guide recommendations we have configured
 tool when contributing to socs. It will save both you and the reviewers time
 when submitting pull requests.
 
-You should set this up before making and commiting your changes. To do so make
+You should set this up before making and committing your changes. To do so make
 sure the ``pre-commit`` package is installed (it is in ``requirements.txt``)::
 
     $ pip install -r requirements.txt
@@ -118,9 +131,5 @@ and then re-run the commit. Here is the expected git output for this example:
         modified:   demo.py
     $ git add -u
     $ git commit
-
-**Note:** This is a new tool to this repo, and the flake8 output might still be
-somewhat strict. If there are warnings that you think should be ignored, please
-bring this up for discussion in a new issue.
 
 .. _pre-commit: https://pre-commit.com/

--- a/README.rst
+++ b/README.rst
@@ -2,16 +2,16 @@
 SOCS - Simons Observatory Control System
 ========================================
 
-.. image:: https://img.shields.io/github/actions/workflow/status/simonsobs/socs/develop.yml?branch=develop
-    :target: https://github.com/simonsobs/socs/actions?query=workflow%3A%22Build+Develop+Images%22
+.. image:: https://img.shields.io/github/actions/workflow/status/simonsobs/socs/develop.yml?branch=main
+    :target: https://github.com/simonsobs/socs/actions?query=workflow%3A%22Build+Test+Images%22
     :alt: GitHub Workflow Status
 
-.. image:: https://readthedocs.org/projects/socs/badge/?version=develop
-    :target: https://socs.readthedocs.io/en/develop/?badge=develop
+.. image:: https://readthedocs.org/projects/socs/badge/?version=main
+    :target: https://socs.readthedocs.io/en/main/?badge=main
     :alt: Documentation Status
 
-.. image:: https://coveralls.io/repos/github/simonsobs/socs/badge.svg?branch=develop
-    :target: https://coveralls.io/github/simonsobs/socs?branch=develop
+.. image:: https://coveralls.io/repos/github/simonsobs/socs/badge.svg
+    :target: https://coveralls.io/github/simonsobs/socs
 
 .. image:: https://img.shields.io/badge/dockerhub-latest-blue
     :target: https://hub.docker.com/r/simonsobs/ocs/tags
@@ -20,8 +20,8 @@ SOCS - Simons Observatory Control System
    :target: https://pypi.org/project/socs/
    :alt: PyPI Package
 
-.. image:: https://results.pre-commit.ci/badge/github/simonsobs/socs/develop.svg
-   :target: https://results.pre-commit.ci/latest/github/simonsobs/socs/develop
+.. image:: https://results.pre-commit.ci/badge/github/simonsobs/socs/main.svg
+   :target: https://results.pre-commit.ci/latest/github/simonsobs/socs/main
    :alt: pre-commit.ci status
 
 Overview
@@ -56,14 +56,14 @@ If you would like to install all optional dependencies use the special varient
 **Note:** Not all optional dependencies can be installed this way. See the
 `Installation Documentation`_ for more info on specific agent dependencies.
 
-.. _`Installation Documentation`: https://socs.readthedocs.io/en/develop/user/installation.html
+.. _`Installation Documentation`: https://socs.readthedocs.io/en/main/user/installation.html
 
 Installing from Source
 ``````````````````````
 
-If you are considering contributing to SOCS, or would like to use the
-development branch, you will want to install from source. To do so,
-clone the repository and install using pip:
+If you are considering contributing to SOCS, or would like to use an unreleased
+feature, you will want to install from source. To do so, clone this repository
+and install using pip:
 
 .. code-block:: bash
 
@@ -86,7 +86,7 @@ configured host if it does not already exist:
 
 See the `ocs docs`_ for more details.
 
-.. _`ocs docs`: https://ocs.readthedocs.io/en/develop/developer/site_config.html
+.. _`ocs docs`: https://ocs.readthedocs.io/en/main/developer/site_config.html
 
 Docker Images
 -------------
@@ -95,11 +95,11 @@ releases will be tagged with their release version, i.e. ``v0.1.0``. These are
 only built on release, and the ``latest`` tag will point to the latest of these
 released tags. These should be considered stable.
 
-Development images will be tagged with the latest released version tag, the
-number of commits ahead of that release, the latest commit hash, and the tag
-``-dev``, i.e.  ``v0.0.2-81-g9c10ba6-dev``. These get built on each commit to
-the ``develop`` branch, and are useful for testing and development, but should
-be considered unstable.
+Test images will be tagged with the latest released version tag, the number of
+commits ahead of that release, the latest commit hash, i.e.
+``v0.0.2-81-g9c10ba6-dev``. These get built on each commit to the ``main``
+branch, and are useful for testing and development, but should be considered
+unstable.
 
 .. _Docker Hub: https://hub.docker.com/u/simonsobs
 

--- a/docker/pysmurf_controller/Dockerfile
+++ b/docker/pysmurf_controller/Dockerfile
@@ -5,7 +5,7 @@ ENV OCS_CONFIG_DIR /config
 ENV PYTHONUNBUFFERED=1
 
 # SOCS installation
-RUN python3 -m pip install git+https://github.com/simonsobs/socs.git@develop
+RUN python3 -m pip install git+https://github.com/simonsobs/socs.git@main
 
 RUN pip3 install dumb-init
 

--- a/docs/user/sequencer.rst
+++ b/docs/user/sequencer.rst
@@ -83,7 +83,7 @@ the backend database:
     to allow the backend to connect to the crossbar server. Your needs may differ
     depending on your network configuration. For details on an "ocs-net" like
     configuration see the `OCS Docs
-    <https://ocs.readthedocs.io/en/develop/user/docker_config.html#considerations-for-deployment>`_.
+    <https://ocs.readthedocs.io/en/main/user/docker_config.html#considerations-for-deployment>`_.
 
 .. note::
     Your site-config-file must point to the crossbar address as if from the

--- a/tests/README.rst
+++ b/tests/README.rst
@@ -67,7 +67,7 @@ To obtain code coverage::
 
 You can then view the coverage report in the ``htmlcov/`` directory. Coverage
 for SOCS is also automatically reported to
-`coveralls.io <https://coveralls.io/github/simonsobs/socs?branch=develop>`_.
+`coveralls.io <https://coveralls.io/github/simonsobs/socs>`_.
 
 Testing Against Hardware
 ------------------------


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
This is just following the lead of ocs (see https://github.com/simonsobs/ocs/pull/309.)

`main` will be made the default branch, effectively replacing `develop`. This probably won't happen until Monday (in case something breaks.) The old branches will stick around for a bit while we migrate.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Releases are cumbersome to make, and stable installations can now be done via PyPI (or on version tags here from the repo.)

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
I've checked some things on this branch, but external services sort of need us to take the plunge before they will work as expected. This whole transition went pretty smoothly in ocs though, so I don't expect any issues.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
