### PR TITLE
Move port numbers for binding in common tests

### DIFF
--- a/tests/common/test_moxa_serial.py
+++ b/tests/common/test_moxa_serial.py
@@ -6,7 +6,7 @@ from socs.common import moxa_serial
 from socs.testing.device_emulator import create_device_emulator
 
 tcp_emulator = create_device_emulator({'ping': 'pong\r'},
-                                      'tcp', 9001)
+                                      'tcp', 19001)
 
 
 # Tried this as a fixture, but connections weren't cleaning up properly.
@@ -14,7 +14,7 @@ def create_tcpserver():
     # Connection might not work on first attempt
     for i in range(5):
         try:
-            ser = moxa_serial.Serial_TCPServer(('127.0.0.1', 9001), 0.1)
+            ser = moxa_serial.Serial_TCPServer(('127.0.0.1', 19001), 0.1)
             break
         except ConnectionRefusedError:
             print("Could not connect, waiting and trying again.")

--- a/tests/common/test_pmx.py
+++ b/tests/common/test_pmx.py
@@ -7,7 +7,7 @@ from socs.testing.device_emulator import create_device_emulator
 
 tcp_emulator = create_device_emulator({'ping': 'pong\r',
                                        'SYST:REM': 'test'},
-                                      'tcp', 9001)
+                                      'tcp', 19002)
 
 
 # Tried this as a fixture, but connections weren't cleaning up properly.
@@ -15,7 +15,7 @@ def create_command():
     # Connection might not work on first attempt
     for i in range(5):
         try:
-            pmx = PMX(tcp_ip='127.0.0.1', tcp_port=9001, timeout=0.1)
+            pmx = PMX(tcp_ip='127.0.0.1', tcp_port=19002, timeout=0.1)
             cmd = Command(pmx)
             break
         except ConnectionRefusedError:


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
This PR changes the ports used for the device emulator in tests from `tests/common/`.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
In a recent test run in #343 these weren't cleaning up in time for the next test, causing an error. This could be solved at a lower level, but moving ports is a quick and easy solution. No need to always bind to the same one across all tests.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
Run here: https://github.com/simonsobs/socs/actions/runs/4185908565/jobs/7253644486

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
