### PR TITLE
adds pysmurf-controller tag params

### DIFF
--- a/docker/pysmurf_controller/Dockerfile
+++ b/docker/pysmurf_controller/Dockerfile
@@ -1,4 +1,4 @@
-FROM simonsobs/sodetlib:v0.5.0-2-g0f91202
+FROM simonsobs/sodetlib:v0.5.0-35-ga937bff
 
 ENV OCS_CONFIG_DIR /config
 

--- a/socs/agents/pysmurf_controller/agent.py
+++ b/socs/agents/pysmurf_controller/agent.py
@@ -331,6 +331,7 @@ class PysmurfController:
     @ocs_agent.param("duration", default=None, type=float)
     @ocs_agent.param('kwargs', default=None)
     @ocs_agent.param('load_tune', default=True, type=bool)
+    @ocs_agent.param('tag', default=None)
     @ocs_agent.param('test_mode', default=False, type=bool)
     def stream(self, session, params):
         """stream(duration=None)
@@ -350,6 +351,9 @@ class PysmurfController:
         load_tune : bool
             If true, will load a tune-file to the pysmurf object on
             instantiation.
+        tag : Optional[string]
+            Tag (or comma-separated list of tags) to attach to the G3 stream.
+            This has precedence over the `tag` key in the kwargs dict.
 
         Notes
         ------
@@ -363,6 +367,9 @@ class PysmurfController:
         """
         if params['kwargs'] is None:
             params['kwargs'] = {}
+
+        if params['tag'] is not None:
+            params['kwarg']['tag'] = params['tag']
 
         with self.lock.acquire_timeout(0, job='stream') as acquired:
             if not acquired:
@@ -533,6 +540,7 @@ class PysmurfController:
 
     @ocs_agent.param('duration', default=30., type=float)
     @ocs_agent.param('kwargs', default=None)
+    @ocs_agent.param('tag', default=None)
     def take_noise(self, session, params):
         """take_noise(duration=30., kwargs=None)
 
@@ -549,6 +557,10 @@ class PysmurfController:
         kwargs : dict
             Dict containing additional keyword args to pass to the take_noise
             function.
+        tag : Optional[str]
+            String containing a tag or comma-separated list of tags to attach
+            to the g3 stream.
+            
 
         Notes
         -------
@@ -565,6 +577,9 @@ class PysmurfController:
         if params['kwargs'] is None:
             params['kwargs'] = {}
 
+        if params['tag'] is not None:
+            params['kwargs']['g3_tag'] = params['tag']
+
         with self.lock.acquire_timeout(0, job='take_noise') as acquired:
             if not acquired:
                 return False, f"Operation failed: {self.lock.job} is running."
@@ -575,6 +590,7 @@ class PysmurfController:
             return True, "Finished taking noise"
 
     @ocs_agent.param('kwargs', default=None)
+    @ocs_agent.param('tag', default=None)
     def take_bgmap(self, session, params):
         """take_bgmap(kwargs=None)
 
@@ -589,6 +605,9 @@ class PysmurfController:
         ----
         kwargs : dict
             Additional kwargs to pass to take_bgmap function.
+        tag : Optional[str]
+            String containing a tag or comma-separated list of tags to attach
+            to the g3 stream.
 
         Notes
         ------
@@ -605,6 +624,9 @@ class PysmurfController:
         """
         if params['kwargs'] is None:
             params['kwargs'] = {}
+
+        if params['tag'] is not None:
+            params['kwargs']['g3_tag'] = params['tag']
 
         with self.lock.acquire_timeout(0, job='take_bgmap') as acquired:
             if not acquired:
@@ -630,6 +652,7 @@ class PysmurfController:
             return True, "Finished taking bgmap"
 
     @ocs_agent.param('kwargs', default=None)
+    @ocs_agent.param('tag', default=None)
     def take_iv(self, session, params):
         """take_iv(kwargs=None)
 
@@ -644,6 +667,9 @@ class PysmurfController:
         ----
         kwargs : dict
             Additional kwargs to pass to the ``take_iv`` function.
+        tag : Optional[str]
+            String containing a tag or comma-separated list of tags to attach
+            to the g3 stream.
 
         Notes
         ------
@@ -660,6 +686,9 @@ class PysmurfController:
         """
         if params['kwargs'] is None:
             params['kwargs'] = {}
+
+        if params['tag'] is not None:
+            params['kwargs']['g3_tag'] = params['tag']
 
         with self.lock.acquire_timeout(0, job='take_iv') as acquired:
             if not acquired:
@@ -679,6 +708,7 @@ class PysmurfController:
 
     @ocs_agent.param('kwargs', default=None)
     @ocs_agent.param('rfrac_range', default=(0.2, 0.9))
+    @ocs_agent.param('tag', default=None)
     def take_bias_steps(self, session, params):
         """take_bias_steps(kwargs=None, rfrac_range=(0.2, 0.9))
 
@@ -694,6 +724,9 @@ class PysmurfController:
         rfrac_range : tuple
             Range of valid rfracs to check against when determining the number
             of good detectors.
+        tag : Optional[str]
+            String containing a tag or comma-separated list of tags to attach
+            to the g3 stream.
 
         Notes
         ------
@@ -717,6 +750,9 @@ class PysmurfController:
 
         if params['kwargs'] is None:
             params['kwargs'] = {}
+
+        if params['tag'] is not None:
+            params['kwargs']['g3_tag'] = params['tag']
 
         with self.lock.acquire_timeout(0, job='bias_steps') as acquired:
             if not acquired:

--- a/socs/agents/pysmurf_controller/agent.py
+++ b/socs/agents/pysmurf_controller/agent.py
@@ -560,7 +560,7 @@ class PysmurfController:
         tag : Optional[str]
             String containing a tag or comma-separated list of tags to attach
             to the g3 stream.
-            
+
 
         Notes
         -------

--- a/socs/agents/pysmurf_controller/agent.py
+++ b/socs/agents/pysmurf_controller/agent.py
@@ -377,11 +377,11 @@ class PysmurfController:
             params['kwargs'] = {}
 
         if params['stream_type']:
-            params['kwarg']['tag'] = params['stream_type']
+            params['kwargs']['tag'] = params['stream_type']
         if params['subtype'] is not None:
-            params['kwarg']['subtype'] = params['subtype']
+            params['kwargs']['subtype'] = params['subtype']
         if params['tag'] is not None:
-            params['kwarg']['tag'] = params['tag']
+            params['kwargs']['tag'] = params['tag']
 
         with self.lock.acquire_timeout(0, job='stream') as acquired:
             if not acquired:

--- a/socs/agents/pysmurf_controller/agent.py
+++ b/socs/agents/pysmurf_controller/agent.py
@@ -331,7 +331,7 @@ class PysmurfController:
     @ocs_agent.param("duration", default=None, type=float)
     @ocs_agent.param('kwargs', default=None)
     @ocs_agent.param('load_tune', default=True, type=bool)
-    @ocs_agent.param('stream_type', default='obs')
+    @ocs_agent.param('stream_type', default='obs', choices=['obs', 'oper'])
     @ocs_agent.param('subtype', default=None)
     @ocs_agent.param('tag', default=None)
     @ocs_agent.param('test_mode', default=False, type=bool)

--- a/socs/agents/pysmurf_controller/agent.py
+++ b/socs/agents/pysmurf_controller/agent.py
@@ -331,6 +331,8 @@ class PysmurfController:
     @ocs_agent.param("duration", default=None, type=float)
     @ocs_agent.param('kwargs', default=None)
     @ocs_agent.param('load_tune', default=True, type=bool)
+    @ocs_agent.param('stream_type', default='obs')
+    @ocs_agent.param('subtype', default=None)
     @ocs_agent.param('tag', default=None)
     @ocs_agent.param('test_mode', default=False, type=bool)
     def stream(self, session, params):
@@ -351,7 +353,13 @@ class PysmurfController:
         load_tune : bool
             If true, will load a tune-file to the pysmurf object on
             instantiation.
-        tag : Optional[string]
+        stream_type : string, optional
+            Stream type. This can be either 'obs' or 'oper', and will be 'obs'
+            by default. The tags attached to the stream will be
+            ``<stream_type>,<subtype>,<tag>``.
+        subtype : string, optional
+            Operation subtype used tot tag the stream.
+        tag : string, optional
             Tag (or comma-separated list of tags) to attach to the G3 stream.
             This has precedence over the `tag` key in the kwargs dict.
 
@@ -368,6 +376,10 @@ class PysmurfController:
         if params['kwargs'] is None:
             params['kwargs'] = {}
 
+        if params['stream_type']:
+            params['kwarg']['tag'] = params['stream_type']
+        if params['subtype'] is not None:
+            params['kwarg']['subtype'] = params['subtype']
         if params['tag'] is not None:
             params['kwarg']['tag'] = params['tag']
 
@@ -557,9 +569,9 @@ class PysmurfController:
         kwargs : dict
             Dict containing additional keyword args to pass to the take_noise
             function.
-        tag : Optional[str]
-            String containing a tag or comma-separated list of tags to attach
-            to the g3 stream.
+        tag : string, optional
+            Tag (or comma-separated list of tags) to attach to the G3 stream.
+            This has precedence over the `tag` key in the kwargs dict.
 
 
         Notes

--- a/tests/agents/test_pysmurf_controller_agent.py
+++ b/tests/agents/test_pysmurf_controller_agent.py
@@ -378,7 +378,7 @@ def test_stream(agent):
     """
     session = create_session('stream')
     res = agent.stream(session, {'duration': None, 'load_tune': False,
-                                  'kwargs': None, 'test_mode': True, 'tag': None})
+                                 'kwargs': None, 'test_mode': True, 'tag': None})
     assert res[0] is True
 
 

--- a/tests/agents/test_pysmurf_controller_agent.py
+++ b/tests/agents/test_pysmurf_controller_agent.py
@@ -378,7 +378,8 @@ def test_stream(agent):
     """
     session = create_session('stream')
     res = agent.stream(session, {'duration': None, 'load_tune': False,
-                                 'kwargs': None, 'test_mode': True, 'tag': None})
+                                 'kwargs': None, 'test_mode': True, 'tag': None,
+                                 'stream_type': 'obs', 'subtype': None})
     assert res[0] is True
 
 

--- a/tests/agents/test_pysmurf_controller_agent.py
+++ b/tests/agents/test_pysmurf_controller_agent.py
@@ -283,7 +283,7 @@ def test_take_bgmap(agent):
     **Test** - Tests take_bgmap task.
     """
     session = create_session('take_bgmap')
-    res = agent.take_bgmap(session, {'kwargs': {'high_current_mode': False}})
+    res = agent.take_bgmap(session, {'kwargs': {'high_current_mode': False}, 'tag': None})
     assert res[0] is True
     assert session.data['nchans_per_bg'] == [NCHANS, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0]
     assert session.data['filepath'] == 'bias_step_analysis.npy'
@@ -307,7 +307,7 @@ def test_take_iv(agent):
     **Test** - Tests take_iv task.
     """
     session = create_session('take_iv')
-    res = agent.take_iv(session, {'kwargs': {'run_analysis': False}})
+    res = agent.take_iv(session, {'kwargs': {'run_analysis': False}, 'tag': None})
     assert res[0] is True
     assert session.data['bands'] == np.zeros(NCHANS).tolist()
     assert session.data['channels'] == np.arange(NCHANS).tolist()
@@ -330,7 +330,7 @@ def test_take_bias_steps(agent):
     **Test** - Tests take_bias_steps task.
     """
     session = create_session('take_bias_steps')
-    res = agent.take_bias_steps(session, {'kwargs': None, 'rfrac_range': (0.3, 0.9)})
+    res = agent.take_bias_steps(session, {'kwargs': None, 'rfrac_range': (0.3, 0.9), 'tag': None})
     assert res[0] is True
     assert session.data['filepath'] == 'bias_step_analysis.npy'
 
@@ -344,7 +344,7 @@ def test_take_noise(agent):
     **Test** - Tests take_noise task.
     """
     session = create_session('take_noise')
-    res = agent.take_noise(session, {'duration': 30, 'kwargs': None})
+    res = agent.take_noise(session, {'duration': 30, 'kwargs': None, 'tag': None})
     assert res[0] is True
 
 
@@ -377,7 +377,8 @@ def test_stream(agent):
     **Test** - Tests stream process.
     """
     session = create_session('stream')
-    res = agent.stream(session, {'duration': None, 'load_tune': False, 'kwargs': None, 'test_mode': True})
+    res = agent.stream(session, {'duration': None, 'load_tune': False,
+                                  'kwargs': None, 'test_mode': True, 'tag': None})
     assert res[0] is True
 
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Adds `tag` param to pysmurf-controller operations, which will append a user-provided tag to the end of the g3 stream tag.

This + https://github.com/simonsobs/sodetlib/pull/336 resolves https://github.com/simonsobs/socs/issues/385

## Motivation and Context
Helpful for the scheduler to be able to append tags to streams or other sodetlib operations.

## How Has This Been Tested?
Not tested yet. This should be tested with https://github.com/simonsobs/sodetlib/pull/336 before merging.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project.
- [X] My change requires a change to the documentation.
- [X] I have updated the documentation accordingly.
