### PR TITLE
File emulator quantization

### DIFF
--- a/socs/agents/smurf_file_emulator/agent.py
+++ b/socs/agents/smurf_file_emulator/agent.py
@@ -491,8 +491,9 @@ class SmurfFileEmulator:
         if session is not None:
             session.data['noise_file'] = streamer.file_list[0]
 
+    @ocs_agent.param('sleep', default=True)
     def uxm_setup(self, session, params):
-        """uxm_setup(test_mode=False)
+        """uxm_setup(sleep=True)
 
         **Task** - Emulates files that might come from a general tune dets
         function. These are some of the files found on simons1 registered when
@@ -502,6 +503,12 @@ class SmurfFileEmulator:
              2. setup_notches
              3. tracking_setup
              4. short g3 stream
+
+        Parameters:
+            sleep (bool, optional):
+                If True, will sleep for 1 sec after creating the tunefile,
+                which is required for preventing filename collisions in
+                end-to-end testing.
         """
         self._run_setup(action='uxm_setup', action_time=time.time(),
                         session=session)

--- a/socs/agents/smurf_file_emulator/agent.py
+++ b/socs/agents/smurf_file_emulator/agent.py
@@ -149,7 +149,7 @@ class G3FrameGenerator:
     """
 
     def __init__(self, stream_id, sample_rate, tune,
-                 action=None, action_time=None):
+                 action=None, action_time=None, quantize=True, drop_chance=0):
         self.frame_num = 0
         self.sample_num = 0
         self.session_id = int(time.time())
@@ -159,6 +159,8 @@ class G3FrameGenerator:
         self.stream_id = stream_id
         self.action = action
         self.action_time = action_time
+        self.quantize = quantize
+        self.drop_chance = drop_chance
 
     def tag_frame(self, fr):
         fr['frame_num'] = self.frame_num
@@ -181,12 +183,15 @@ class G3FrameGenerator:
         self.tag_frame(fr)
         return fr
 
-    def get_status_frame(self):
+    def get_status_frame(self, tag=''):
         fr = core.G3Frame(core.G3FrameType.Wiring)
         s = get_smurf_status()
 
         tune_key = 'AMCc.FpgaTopLevel.AppTop.AppCore.SysgenCryo.tuneFilePath'
         s[tune_key] = self.tune.tune_path
+
+        tag_key = 'AMCc.SmurfProcessor.SOStream.stream_tag'
+        s[tag_key] = tag
 
         m = self.tune.channels != -1
         chmask = self.tune.channels[m] + self.tune.bands[m] * CHANS_PER_BAND
@@ -206,8 +211,20 @@ class G3FrameGenerator:
         return fr
 
     def get_data_frame(self, start, stop):
+        if self.quantize:
+            # When "quantized", this clamps (start) and (stop) to integers so 
+            # timestamps created by np.arange are lined up when there's an 
+            # integer sample rate
+            t0, t1 = int(start)-1, int(stop) + 1
 
-        times = np.arange(start, stop, 1. / self.sample_rate)
+            # Note that error does build up here due to floating precision of
+            # 1./sample_rate, but for emulation this should be close enough
+            times = np.arange(t0, t1, 1./self.sample_rate, dtype=np.float64)
+            m = (start <= times) & (times < stop)
+            times = times[m]
+        else:
+            times = np.arange(start, stop, 1. / self.sample_rate)
+
         nsamps = len(times)
         frame_counter = np.arange(self.sample_num, self.sample_num + nsamps, dtype=int)
         self.sample_num += nsamps
@@ -219,6 +236,13 @@ class G3FrameGenerator:
         data += count_per_phi0 * chans[:, None]
         data += (count_per_phi0 * 0.2 * np.sin(2 * np.pi * 8 * times)).astype(int)
         data += (count_per_phi0 * np.random.normal(0, 0.03, (self.nchans, nsamps))).astype(int)
+
+        # Toss samples based on drop_chance
+        m = self.drop_chance < np.random.uniform(0, 1, len(times))
+        times = times[m]
+        frame_counter = frame_counter[m]
+        data = data[:, m]
+        nsamps = len(times)
 
         fr = core.G3Frame(core.G3FrameType.Scan)
 
@@ -247,9 +271,12 @@ class DataStreamer:
     """
 
     def __init__(self, stream_id, sample_rate, tune, timestreamdir,
-                 file_duration, frame_len, action=None, action_time=None):
+                 file_duration, frame_len, action=None, action_time=None, drop_chance=0,
+                 tag=''):
         self.frame_gen = G3FrameGenerator(stream_id, sample_rate, tune,
-                                          action=action, action_time=action_time)
+                                          action=action, action_time=action_time,
+                                          drop_chance=drop_chance)
+
         self.session_id = self.frame_gen.session_id
         self.stream_id = stream_id
         self.timestreamdir = timestreamdir
@@ -259,6 +286,7 @@ class DataStreamer:
         self.writer = None
         self.file_list = []
         self.frame_len = frame_len
+        self.tag = tag
 
     def _get_g3_filename(self):
         """
@@ -281,7 +309,7 @@ class DataStreamer:
         self.writer = core.G3Writer(fname)
         if self.seq == 0:
             self.writer(self.frame_gen.get_obs_start_frame())
-            self.writer(self.frame_gen.get_status_frame())
+            self.writer(self.frame_gen.get_status_frame(tag=self.tag))
         self.file_start = time.time()
         self.file_list.append(fname)
         self.seq += 1
@@ -338,7 +366,7 @@ class DataStreamer:
                 now = time.time()
                 if now < t1:
                     time.sleep(t1 - now)
-            self.writer(self.frame_gen.get_data_frame(start, stop))
+            self.writer(self.frame_gen.get_data_frame(t0, t1))
         self.end_file()
 
 
@@ -360,15 +388,17 @@ class SmurfFileEmulator:
         self.nchans = args.nchans
         self.sample_rate = args.sample_rate
         self.frame_len = args.frame_len
+        self.drop_chance = args.drop_chance
 
         self.streaming = False
         self.tune = None
 
-    def _new_streamer(self, action=None, action_time=None):
+    def _new_streamer(self, action=None, action_time=None, tag=''):
         return DataStreamer(
             self.stream_id, self.sample_rate, self.tune, self.timestreamdir,
             self.file_duration, self.frame_len,
-            action=action, action_time=action_time,
+            action=action, action_time=action_time, drop_chance=self.drop_chance,
+            tag=tag
         )
 
     def _get_action_dir(self, action, action_time=None, is_plot=False):
@@ -475,7 +505,8 @@ class SmurfFileEmulator:
         """
         self._run_setup(action='uxm_setup', action_time=time.time(),
                         session=session)
-        time.sleep(1)
+        if params.get('sleep', True):
+            time.sleep(1)
         return True, "Wrote tune files"
 
     def take_noise(self, session, params=None):
@@ -570,6 +601,8 @@ class SmurfFileEmulator:
         return True, 'Wrote det biasing files'
 
     @ocs_agent.param('duration', default=None)
+    @ocs_agent.param('use_stream_between', default=False, type=bool)
+    @ocs_agent.param('start_offset', default=0, type=float)
     def stream(self, session, params):
         """stream(duration=None)
 
@@ -600,14 +633,19 @@ class SmurfFileEmulator:
         for f in files:
             self._write_smurf_file(f, action, action_time=action_time)
 
+        start_time = time.time() + params['start_offset']
         end_time = None
         if params.get('duration') is not None:
-            end_time = time.time() + params['duration']
+            end_time = start_time + params['duration']
 
         session.set_status('running')
-        streamer = self._new_streamer(action=action, action_time=action_time)
+        streamer = self._new_streamer(action=action, action_time=action_time, tag='obs,cmb')
         session.data['session_id'] = streamer.session_id
         session.data['g3_files'] = streamer.file_list
+
+        if params['use_stream_between']:
+            streamer.stream_between(start_time, end_time)
+            return True, "Finished Stream"
 
         self.streaming = True
         while self.streaming:
@@ -648,6 +686,9 @@ def make_parser(parser=None):
                         help="Sample rate for streaming data")
     pgroup.add_argument('--frame-len', default=2, type=float,
                         help="Time per G3 data frame (seconds)")
+    pgroup.add_argument('--drop-chance', default=0, type=float,
+                        help="Fractional chance to drop samples")
+                    
 
     return parser
 

--- a/socs/agents/smurf_file_emulator/agent.py
+++ b/socs/agents/smurf_file_emulator/agent.py
@@ -616,6 +616,14 @@ class SmurfFileEmulator:
         Parameters:
             duration (float, optional):
                 If set, will stop stream after specified amount of time (sec).
+            use_stream_between (bool, optional):
+                If True, will use the DataStreamer's `stream_between` function
+                instead of writing frames one at a time. This allows you to write
+                an entire timestream for the specified duration without waiting.
+            start_offset (float, optional):
+                If set, this will add an offset to the start time passed to the
+                `stream_between` function, allowing you to create offsets between
+                streams taken at the same time.
         """
         session.set_status('starting')
 

--- a/socs/agents/smurf_file_emulator/agent.py
+++ b/socs/agents/smurf_file_emulator/agent.py
@@ -212,14 +212,14 @@ class G3FrameGenerator:
 
     def get_data_frame(self, start, stop):
         if self.quantize:
-            # When "quantized", this clamps (start) and (stop) to integers so 
-            # timestamps created by np.arange are lined up when there's an 
+            # When "quantized", this clamps (start) and (stop) to integers so
+            # timestamps created by np.arange are lined up when there's an
             # integer sample rate
-            t0, t1 = int(start)-1, int(stop) + 1
+            t0, t1 = int(start) - 1, int(stop) + 1
 
             # Note that error does build up here due to floating precision of
             # 1./sample_rate, but for emulation this should be close enough
-            times = np.arange(t0, t1, 1./self.sample_rate, dtype=np.float64)
+            times = np.arange(t0, t1, 1. / self.sample_rate, dtype=np.float64)
             m = (start <= times) & (times < stop)
             times = times[m]
         else:
@@ -696,7 +696,6 @@ def make_parser(parser=None):
                         help="Time per G3 data frame (seconds)")
     pgroup.add_argument('--drop-chance', default=0, type=float,
                         help="Fractional chance to drop samples")
-                    
 
     return parser
 

--- a/tests/agents/test_smurf_file_emulator.py
+++ b/tests/agents/test_smurf_file_emulator.py
@@ -84,6 +84,6 @@ def test_stream(tmp_path):
     session = mock.MagicMock()
     session.data = {}
     emulator.uxm_relock(session, {'test_mode': True})
-    emulator.stream(session, params={'duration': 2, 
-                                     'use_stream_between': True, 
+    emulator.stream(session, params={'duration': 2,
+                                     'use_stream_between': True,
                                      'start_offset': 0})

--- a/tests/agents/test_smurf_file_emulator.py
+++ b/tests/agents/test_smurf_file_emulator.py
@@ -84,4 +84,6 @@ def test_stream(tmp_path):
     session = mock.MagicMock()
     session.data = {}
     emulator.uxm_relock(session, {'test_mode': True})
-    emulator.stream(session, params={'duration': 2})
+    emulator.stream(session, params={'duration': 2, 
+                                     'use_stream_between': True, 
+                                     'start_offset': 0})


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Makes several changes to the Smurf File Emulator so that it's better for testing the bookbinder.

## Description
<!--- Describe your changes in detail -->
- Adds "timestamp quantization".  By clamping the start / stop times to integers, `np.arange` with an integer sample freq will create close to co-sampled data, even if the start / stop times are different between streams.
- Adds correct tags to the stream function
- Adds the ability to set a drop-chance, which will toss a subset of data points.
- Adds some params that tell the `stream` task to use the `stream_between` function of the streamer, instead of generating frames one-by-one, allowing for the task to run for a non-zero duration without sleeping.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
This is required to properly test the bookbinder on the emulated data.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
Tested by creating sample data and running it all the way through to books.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
