### PR TITLE
Fix docs build warnings in ups agent docstring

### DIFF
--- a/socs/agents/ups/agent.py
+++ b/socs/agents/ups/agent.py
@@ -106,10 +106,13 @@ def update_cache(get_result, timestamp):
     The cache consists of a dictionary, with the unique OIDs as keys, and
     another dictionary as the value. Each of these nested dictionaries contains the
     OID values, name, and description (decoded string). An example for a single OID::
+
         {"upsBatteryStatus":
             {"status": 2,
                 "description": "batteryNormal"}}
+
     Additionally there is connection status and timestamp information under::
+
         {"ups_connection":
             {"last_attempt": 1598543359.6326838,
             "connected": True}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Quick PR to fix some build warnings in the docs that I just noticed.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
```
/home/koopman/git/socs/socs/agents/ups/agent.py:docstring of socs.agents.ups.agent.update_cache:9: ERROR: Unexpected indentation.
/home/koopman/git/socs/socs/agents/ups/agent.py:docstring of socs.agents.ups.agent.update_cache:7: WARNING: Literal block ends without a blank line; unexpected unindent.
/home/koopman/git/socs/socs/agents/ups/agent.py:docstring of socs.agents.ups.agent.update_cache:11: WARNING: Definition list ends without a blank line; unexpected unindent.
```

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
Tested new build.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
