### PR TITLE
Fixed LS240 connection drop crashing acq process

### DIFF
--- a/socs/agents/lakeshore240/agent.py
+++ b/socs/agents/lakeshore240/agent.py
@@ -58,7 +58,7 @@ class LS240_Agent:
         if self.initialized:
             return True, "Already Initialized Module"
 
-        with self.lock.acquire_timeout(0, job='init') as acquired:
+        with self.lock.acquire_timeout(3, job='init') as acquired:
             if not acquired:
                 self.log.warn("Could not start init because "
                               "{} is already running".format(self.lock.job))
@@ -211,27 +211,55 @@ class LS240_Agent:
                 current_time = time.time()
                 data = {
                     'timestamp': current_time,
+                    'connection': {},
                     'block_name': 'temps',
                     'data': {}
                 }
 
-                for chan in self.module.channels:
-                    # Read sensor on channel
-                    chan_string = "Channel_{}".format(chan.channel_num)
-                    temp_reading = chan.get_reading(unit='K')
-                    sensor_reading = chan.get_reading(unit='S')
+                # Try to re-initialize if connection lost
+                if not self.initialized:
+                    if not self.lock.release_and_acquire(timeout=10):
+                        self.log.warn(f"Could not re-acquire lock now held by {self.lock.job}.")
+                        return False
+                    self.agent.start('init_lakeshore')
+                    self.agent.wait('init_lakeshore')
 
-                    # For data feed
-                    data['data'][chan_string + '_T'] = temp_reading
-                    data['data'][chan_string + '_V'] = sensor_reading
+                # Only get readings if connected    
+                if self.initialized:
+                    session.data.update({'connection': {'last_attempt': time.time(),
+                                                        'connected': True}})
+                    for chan in self.module.channels:
+                        # Read sensor on channel
+                        chan_string = "Channel_{}".format(chan.channel_num)
 
-                    # For session.data
-                    field_dict = {chan_string: {"T": temp_reading, "V": sensor_reading}}
-                    session.data['fields'].update(field_dict)
+                        try:
+                            temp_reading = chan.get_reading(unit='K')
+                            sensor_reading = chan.get_reading(unit='S')
+                        except:
+                            self.log.info('No reponse. Check your connection.')
+                            self.initialized = False
+                            time.sleep(1)
+                            break
+                        
+                        # For data feed
+                        data['data'][chan_string + '_T'] = temp_reading
+                        data['data'][chan_string + '_V'] = sensor_reading
 
-                self.agent.publish_to_feed('temperatures', data)
+                        # For session.data
+                        field_dict = {chan_string: {"T": temp_reading, "V": sensor_reading}}
+                        session.data['fields'].update(field_dict)
 
                 session.data.update({'timestamp': current_time})
+
+                # Continue trying to connect
+                if not self.initialized:
+                    session.data.update({'connection': {'last_attempt': time.time(),
+                                                        'connected': False}})
+                    self.log.info('Trying to reconnect.')
+                    time.sleep(1)
+                    continue
+
+                self.agent.publish_to_feed('temperatures', data)
 
                 time.sleep(sleep_time)
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Changed agent code to handle connection drops without crashing the acq process.

## Description
<!--- Describe your changes in detail -->
When a connection drop occurs, the process will stop the current loop and attempt to run `init_lakeshore` to re-initialize the data fields. The re-initialization will try once every second until reconnection and then the loop continues.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Addresses connection drop issues seen across all groups using LS240's.
Possibly fixes #418 and any other old issues?

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
Tested by pulling USB connection and re-connecting. Testing environment is a nuc machine at Yale running Ubuntu 18.04 (required for Anyplace coolgear drivers to work). Works on LS240's connected either directly to nuc or to the Anyplace device.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
