### PR TITLE
Adds shutdown procedure and logic to HWP PMX agent

### DIFF
--- a/socs/agents/hwp_pmx/agent.py
+++ b/socs/agents/hwp_pmx/agent.py
@@ -359,11 +359,10 @@ class HWPPMXAgent:
             }
 
             self.agent.publish_to_feed('gripper_action', data)
-            session.data =  {
+            session.data = {
                 'rotation_action': action,
                 'time': time.time()
             }
-
 
             time.sleep(0.2)
 

--- a/socs/agents/hwp_pmx/agent.py
+++ b/socs/agents/hwp_pmx/agent.py
@@ -361,7 +361,11 @@ class HWPPMXAgent:
             }
 
             self.agent.publish_to_feed('gripper_action', data)
-            session.data = data['data']
+            session.data =  {
+                'rotation_action': action,
+                'time': time.time()
+            }
+
 
             time.sleep(0.2)
 

--- a/socs/agents/hwp_pmx/agent.py
+++ b/socs/agents/hwp_pmx/agent.py
@@ -21,13 +21,13 @@ class HWPPMXAgent:
         ip (str): IP address for the PMX Kikusui power supply
         port (str): Port for the PMX Kikusui power supply
         f_sample (float): sampling frequency (Hz)
-        supervisor_id (str): ID of HWP supervisor 
-        no_data_timeout (float): Time (in seconds) to wait between receiving 
+        supervisor_id (str): ID of HWP supervisor
+        no_data_timeout (float): Time (in seconds) to wait between receiving
             'no_data' actions from the supervisro and triggering a shutdown
     """
 
-    def __init__(self, agent, ip, port, f_sample=1, supervisor_id=None, 
-                 no_data_timeout=15*60):
+    def __init__(self, agent, ip, port, f_sample=1, supervisor_id=None,
+                 no_data_timeout=15 * 60):
 
         self.agent: ocs_agent.OCSAgent = agent
         self.log = agent.log
@@ -48,7 +48,7 @@ class HWPPMXAgent:
         agg_params = {'frame_length': 60}
         self.agent.register_feed(
             'hwppmx', record=True, agg_params=agg_params, buffer_time=1)
-        
+
         self.agent.register_feed('rotation_action', record=True)
 
     @ocs_agent.param('auto_acquire', default=False, type=bool)
@@ -92,7 +92,7 @@ class HWPPMXAgent:
                 self.log.warn(
                     'Could not set on because {} is already running'.format(self.lock.job))
                 return False, 'Could not acquire lock'
-            
+
             if self.shutdown_mode:
                 return False, "Shutdown mode is in effect"
 
@@ -108,7 +108,7 @@ class HWPPMXAgent:
                 self.log.warn(
                     'Could not set on because {} is already running'.format(self.lock.job))
                 return False, 'Could not acquire lock'
-            
+
             if self.shutdown_mode:
                 return False, "Shutdown mode is in effect"
 
@@ -128,7 +128,7 @@ class HWPPMXAgent:
                 self.log.warn(
                     'Could not set i because {} is already running'.format(self.lock.job))
                 return False, 'Could not acquire lock'
-            
+
             if self.shutdown_mode:
                 return False, "Shutdown mode is in effect"
 
@@ -148,7 +148,7 @@ class HWPPMXAgent:
                 self.log.warn(
                     'Could not set v because {} is already running'.format(self.lock.job))
                 return False, 'Could not acquire lock'
-            
+
             if self.shutdown_mode:
                 return False, "Shutdown mode is in effect"
 
@@ -197,7 +197,7 @@ class HWPPMXAgent:
                 self.log.warn(
                     'Could not use external voltage because {} is already running'.format(self.lock.job))
                 return False, 'Could not acquire lock'
-            
+
             if self.shutdown_mode:
                 return False, "Shutdown mode is in effect"
 
@@ -214,7 +214,7 @@ class HWPPMXAgent:
                 self.log.warn(
                     'Could not ignore external voltage because {} is already running'.format(self.lock.job))
                 return False, 'Could not acquire lock'
-            
+
             if self.shutdown_mode:
                 return False, "Shutdown mode is in effect"
 
@@ -294,7 +294,7 @@ class HWPPMXAgent:
             return True, 'requested to stop taking data.'
         else:
             return False, 'acq is not currently running'
-    
+
     def initiate_shutdown(self, session, params):
         """
         Initiate the shutdown of the agent.
@@ -309,7 +309,6 @@ class HWPPMXAgent:
             self.shutdown_mode = True
             self.dev.ign_external_voltage()
             self.dev.stop()
-    
 
     def reverse_shutdown(self, session, params):
         """
@@ -318,7 +317,6 @@ class HWPPMXAgent:
         self.shutdown_mode = False
         return True, "Reversed shutdown mode"
 
-    
     def monitor_shutdown(self, session, params):
         """
         Monitor the shutdown of the agent.
@@ -350,10 +348,10 @@ class HWPPMXAgent:
                         self.agent.start('initiate_shutdown')
 
             # If action is 'shutdown', trigger shutdown
-            elif action == 'stop': 
+            elif action == 'stop':
                 if not self.shutdown_mode:
                     self.agent.start('initiate_shutdown')
-            
+
             data = {
                 'data': {'rotation_action': action},
                 'block_name': 'rotation_action',
@@ -370,7 +368,7 @@ class HWPPMXAgent:
             time.sleep(0.2)
 
         return True, 'PMX Kikusui monitor shutdown.'
-    
+
     def _stop_monitor_shutdown(self, session, params):
         session.set_status('stopping')
         return True, "Stopping monitor shutdown."
@@ -389,9 +387,9 @@ def make_parser(parser=None):
                         help="Starting action for the agent.")
     pgroup.add_argument('--sampling-frequency', type=float,
                         help="Sampling frequency for data acquisition")
-    pgroup.add_argument('--supervisor-id', type=str, 
+    pgroup.add_argument('--supervisor-id', type=str,
                         help="Instance ID for HWP Supervisor agent")
-    pgroup.add_argument('--no-data-timeout', type=float, default=15*60,
+    pgroup.add_argument('--no-data-timeout', type=float, default=15 * 60,
                         help="Time (sec) after which a 'no_data' action should "
                              "trigger a shutdown")
     return parser
@@ -411,9 +409,9 @@ def main(args=None):
     elif args.mode == 'acq':
         init_params = {'auto_acquire': True}
 
-    kwargs = {'ip': args.ip, 'port': args.port, 
-              'supervisor_id': args.supervisor_id, 
-              'no_data_timeout': args.no_data_timeout,}
+    kwargs = {'ip': args.ip, 'port': args.port,
+              'supervisor_id': args.supervisor_id,
+              'no_data_timeout': args.no_data_timeout, }
     if args.sampling_frequency is not None:
         kwargs['f_sample'] = args.sampling_frequency
     PMX = HWPPMXAgent(agent, **kwargs)

--- a/socs/agents/hwp_pmx/agent.py
+++ b/socs/agents/hwp_pmx/agent.py
@@ -23,7 +23,7 @@ class HWPPMXAgent:
         f_sample (float): sampling frequency (Hz)
         supervisor_id (str): Instance id of HWP supervisor
         no_data_timeout (float): Time (in seconds) to wait between receiving
-            'no_data' actions from the supervisro and triggering a shutdown
+            'no_data' actions from the supervisor and triggering a shutdown
     """
 
     def __init__(self, agent, ip, port, f_sample=1, supervisor_id=None,
@@ -361,7 +361,7 @@ class HWPPMXAgent:
                 'timestamp': time.time()
             }
 
-            self.agent.publish_to_feed('gripper_action', data)
+            self.agent.publish_to_feed('rotation_action', data)
             session.data = {
                 'rotation_action': action,
                 'time': time.time()

--- a/socs/agents/hwp_pmx/agent.py
+++ b/socs/agents/hwp_pmx/agent.py
@@ -21,7 +21,7 @@ class HWPPMXAgent:
         ip (str): IP address for the PMX Kikusui power supply
         port (str): Port for the PMX Kikusui power supply
         f_sample (float): sampling frequency (Hz)
-        supervisor_id (str): ID of HWP supervisor
+        supervisor_id (str): Instance id of HWP supervisor
         no_data_timeout (float): Time (in seconds) to wait between receiving
             'no_data' actions from the supervisro and triggering a shutdown
     """
@@ -296,8 +296,9 @@ class HWPPMXAgent:
             return False, 'acq is not currently running'
 
     def initiate_shutdown(self, session, params):
-        """
-        Initiate the shutdown of the agent.
+        """ initiate_shutdown()
+
+        **Task** - Initiate the shutdown of the agent.
         """
         self.log.warn("INITIATING SHUTDOWN")
 
@@ -311,15 +312,17 @@ class HWPPMXAgent:
             self.dev.turn_off()
 
     def reverse_shutdown(self, session, params):
-        """
-        Reverses shutdown mode, allowing other tasks to update the power supply
+        """reverse_shutdown()
+
+        **Task** - Reverses shutdown mode, allowing other tasks to update the power supply
         """
         self.shutdown_mode = False
         return True, "Reversed shutdown mode"
 
     def monitor_shutdown(self, session, params):
-        """
-        Monitor the shutdown of the agent.
+        """monitor_shutdown()
+
+        **Process** - Monitor the shutdown of the agent.
         """
 
         session.set_status('running')
@@ -345,12 +348,12 @@ class HWPPMXAgent:
             elif action == 'no_data':
                 if (time.time() - last_ok_time) > self.no_data_timeout:
                     if not self.shutdown_mode:
-                        self.agent.start('initiate_shutdown')
+                        self.agent.start('initiate_shutdown', params=None)
 
             # If action is 'shutdown', trigger shutdown
             elif action == 'stop':
                 if not self.shutdown_mode:
-                    self.agent.start('initiate_shutdown')
+                    self.agent.start('initiate_shutdown', params=None)
 
             data = {
                 'data': {'rotation_action': action},

--- a/socs/agents/hwp_pmx/agent.py
+++ b/socs/agents/hwp_pmx/agent.py
@@ -308,7 +308,7 @@ class HWPPMXAgent:
 
             self.shutdown_mode = True
             self.dev.ign_external_voltage()
-            self.dev.stop()
+            self.dev.turn_off()
 
     def reverse_shutdown(self, session, params):
         """


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
This PR implements a shutdown procedure for the HWP PMX agent.

## Description
<!--- Describe your changes in detail -->
This shows how one may use the hwp-supervisor session data to trigger a shutdown procedure, and how a shutdown might lock out specific tasks or processes until it is reversed.

This implements three additional operations:
- monitor_shutdown is a process that continuously monitors hwp-supervisor rotation action to determine whether or not a shutdown should be triggered. This will trigger a shutdown if either the action is 'stop', or it has been `no_data_timeout` since the last 'ok' action received. The action will be published to grafana, so an alarm can be set that triggers if the action is not 'ok' for a certain amount of time.
- The 'initiate_shutdown' task will set `shutdown_mode=True`, and will tell the PMX to cut power and to ignore external voltage from the PID.
- The `reverse_shutdown` task sets `shutdown_mode=False`

While `shutdown_mode` is True, any task that tries to change the PMX state in a way that might interfere with the shutdown (such as `set_on`, `set_i`, `set_v`...) will fail.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Required for emergency HWP shutdown

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
This has not been tested yet

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
