### PR TITLE
adds oper tags to smurf-file-emulator

### DIFF
--- a/socs/agents/smurf_file_emulator/agent.py
+++ b/socs/agents/smurf_file_emulator/agent.py
@@ -489,7 +489,8 @@ class SmurfFileEmulator:
         self._write_smurf_file(fname, action, action_time=action_time, prepend_ctime=False)
 
         # Short g3 stream
-        streamer = self._new_streamer(action=action, action_time=action_time)
+        streamer = self._new_streamer(action=action, action_time=action_time,
+                                      tag='oper,noise')
         now = time.time()
         streamer.stream_between(now, now + 30, wait=False)
         if session is not None:
@@ -528,7 +529,8 @@ class SmurfFileEmulator:
         action = 'take_noise'
         action_time = time.time()
 
-        streamer = self._new_streamer(action=action, action_time=action_time)
+        streamer = self._new_streamer(action=action, action_time=action_time,
+                                      tag='oper,noise')
         now = time.time()
         streamer.stream_between(now, now + 30, wait=False)
         session.data['noise_file'] = streamer.file_list[0]
@@ -556,7 +558,8 @@ class SmurfFileEmulator:
         action_time = time.time()
         files = ['iv_analyze.npy', 'iv_bias_all.npy', 'iv_info.npy']
 
-        streamer = self._new_streamer(action=action, action_time=action_time)
+        streamer = self._new_streamer(action=action, action_time=action_time,
+                                      tag='oper,iv')
         now = time.time()
         streamer.stream_between(now, now + 5, wait=params['wait'])
 
@@ -575,7 +578,8 @@ class SmurfFileEmulator:
         action_time = time.time()
         files = ['bias_step_analysis.npy']
 
-        streamer = self._new_streamer(action=action, action_time=action_time)
+        streamer = self._new_streamer(action=action, action_time=action_time,
+                                      tag='oper,bias_steps')
         now = time.time()
         streamer.stream_between(now, now + 5, wait=params['wait'])
 
@@ -593,7 +597,8 @@ class SmurfFileEmulator:
         action = 'take_bgmap'
         action_time = time.time()
 
-        streamer = self._new_streamer(action=action, action_time=action_time)
+        streamer = self._new_streamer(action=action, action_time=action_time,
+                                      tag='oper,bgmap')
         now = time.time()
         streamer.stream_between(now, now + 5, wait=params['wait'])
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Adds operation tags for the smurf-file-emulator.

## Description
<!--- Describe your changes in detail -->
Adds `oper` tags to the smurf-file-emulator, based on the tags from this PR: https://github.com/simonsobs/socs/pull/424/files. This has not been tested, but should be a good starting point for testing on the e2e system.

## Motivation and Context
So we can have smurf operation books on the end2end system.

## How Has This Been Tested?
Not tested yet

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
