### PR TITLE
Suprsync CLI

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -74,6 +74,9 @@ setup(
         'agents/labjack/cal_curves/*.txt',
     ]},
     entry_points={
+        'console_scripts': [
+            'suprsync=socs.db.suprsync_cli:main'
+        ],
         'ocs.plugins': [
             'socs = socs.plugin',
         ],

--- a/socs/db/suprsync_cli.py
+++ b/socs/db/suprsync_cli.py
@@ -85,7 +85,7 @@ def main():
     add_local_files_parser = subparsers.add_parser(
         'add-local-files',
         help="Adds all files from a local directory to the suprsync db"
-    ) 
+    )
     add_local_files_parser.set_defaults(func=add_local_files_func)
     add_local_files_parser.add_argument(
         'local_root', help="Root directory to search for files")

--- a/socs/db/suprsync_cli.py
+++ b/socs/db/suprsync_cli.py
@@ -5,8 +5,9 @@ Utility script for interacting with the suprsync db.
 import argparse
 import os
 
-from socs.db.suprsync import SupRsyncFile, SupRsyncFilesManager
 from tqdm.auto import trange
+
+from socs.db.suprsync import SupRsyncFile, SupRsyncFilesManager
 
 
 def check_func(args):
@@ -61,7 +62,7 @@ def add_local_files_func(args):
                 remote_paths.append(os.path.relpath(path, args.local_root))
 
     if args.dry:
-        print("Dry run\n"+ 40 * '-')
+        print("Dry run\n" + 40 * '-')
         print(f"Would add {len(local_paths)} files, including:")
         n = min(len(local_paths), 20)
         for i in range(10):
@@ -116,8 +117,7 @@ def main():
         help="Create the db if it doesn't exist"
     )
     add_local_files_parser.add_argument('--dry', action='store_true',
-        help="Does a dry run and prints what files would be added")
-
+                                        help="Does a dry run and prints what files would be added")
 
     args = parser.parse_args()
 

--- a/socs/db/suprsync_cli.py
+++ b/socs/db/suprsync_cli.py
@@ -41,17 +41,30 @@ def list_func(args):
         print(f"{i}: {f.local_path}")
 
 
-if __name__ == '__main__':
+def add_local_files_func(args):
+    srfm = SupRsyncFilesManager(args.db, create_all=args.create_db)
+    known_files = srfm.get_known_files(args.archive_name)
+    known_paths = [f.local_path for f in known_files]
+    for root, _, files in os.walk(args.local_root):
+        for file in files:
+            path = os.path.join(root, file)
+            path = os.path.abspath(path)
+            if path not in known_paths:
+                remote_path = os.path.relpath(path, args.local_root)
+                srfm.add_file(path, remote_path, args.archive_name)
+
+
+def main():
     parser = argparse.ArgumentParser()
     subparsers = parser.add_subparsers()
 
-    default_db = '/data/so/dbs/suprsync.db'
+    default_db = os.environ.get("SUPRSYNC_DB")
 
     check_parser = subparsers.add_parser(
         'check', help="Checks suprsync file entry for a given local file.")
     check_parser.set_defaults(func=check_func)
     check_parser.add_argument('file', type=str,
-                              help="File path to check in the suprsync db")
+                              help="local path to check in the suprsync db")
     check_parser.add_argument('--db', default=default_db, help='db path')
 
     next_parser = subparsers.add_parser(
@@ -69,11 +82,33 @@ if __name__ == '__main__':
                              help='Name of archive to get next file')
     list_parser.add_argument('--db', default=default_db)
 
-    args = parser.parse_args()
-    if not os.path.exists(args.db):
-        raise Exception(f"Could not find file {args.db}")
+    add_local_files_parser = subparsers.add_parser(
+        'add-local-files',
+        help="Adds all files from a local directory to the suprsync db"
+    ) 
+    add_local_files_parser.set_defaults(func=add_local_files_func)
+    add_local_files_parser.add_argument(
+        'local_root', help="Root directory to search for files")
+    add_local_files_parser.add_argument(
+        'archive_name', help="Archive to add files to")
+    add_local_files_parser.add_argument('--db', default=default_db)
+    add_local_files_parser.add_argument(
+        '--create-db', action='store_true',
+        help="Create the db if it doesn't exist"
+    )
 
-    if hasattr(args, 'func'):
-        args.func(args)
-    else:
+    args = parser.parse_args()
+
+    if not hasattr(args, 'func'):
         parser.print_help()
+        return
+
+    if args.db is None:
+        raise FileNotFoundError("Suprsync DB must be specified either through the --db "
+                                "cli-arg or the SUPRSYNC_DB env var")
+
+    args.func(args)
+
+
+if __name__ == '__main__':
+    main()

--- a/socs/db/suprsync_cli.py
+++ b/socs/db/suprsync_cli.py
@@ -63,9 +63,14 @@ def add_local_files_func(args):
 
     if args.dry:
         print("Dry run\n" + 40 * '-')
+
+        if len(local_paths) == 0:
+            print("No files to add")
+            return
+
         print(f"Would add {len(local_paths)} files, including:")
-        n = min(len(local_paths), 20)
-        for i in range(10):
+        n = min(len(local_paths), 10)
+        for i in range(n):
             print(f"{i}: {local_paths[i]} --> {remote_paths[i]}")
         return
 

--- a/tests/agents/test_suprsync_agent.py
+++ b/tests/agents/test_suprsync_agent.py
@@ -79,7 +79,6 @@ def test_timecode_dirs(tmp_path):
                 finalize_files.append(os.path.join(root, f))
 
     assert (len(finalize_files) == len(tcs) - 1)
-    assert (False)
 
 
 def test_suprsync_handle_files(tmp_path):


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
This moves the suprsync script in `bin` to an socs entrypoint. It also adds an additional sub-command to add files from a local directory to the suprsync db.

Since the timecode dir finalization has already been reviewed, I figured we could review this in its own PR, and then merge both together to main  once tested on the e2e system.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
This is a nice user interface for checking the status of the suprsync db. The `add-local-files` command is useful for things like setting up hk sync or for the e2e testing system.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
Tested locally.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
