### PR TITLE
Add protection mode monitoring to pmx agent

### DIFF
--- a/docs/agents/hwp_pmx.rst
+++ b/docs/agents/hwp_pmx.rst
@@ -51,6 +51,48 @@ An example docker-compose configuration::
     system. In this example the crossbar server is running on localhost,
     ``127.0.0.1``, but on your network this may be different.
 
+Description
+-----------
+
+The HWP PMX Agent interfaces with the PMX Kikusui power supply and allows
+control of the current and voltage that drives the CHWP rotation. The PMX
+provides several connection options for communicating remotely with the
+hardware. For the HWP PMX Agent we have written the interface for
+communication via Ethernet cable.
+
+Protection Mode
+````````````````
+The PMX enters protection mode and stops outputting when something harmful
+occurs. The HWP PMX Agent monitors the state of the protection mode and
+outputs a protection code and message to ``prot_code`` and ``prot_msg`` for
+each data acquisition. There are several possible situations that can cause
+entering the protection mode. Below is a table showing the protection codes
+and corresponding situations.
+
++--------------+--------------------------------------------+
+| prot_code    | Description                                |
++==============+============================================+
+| 0            | not in protection mode                     |
++--------------+--------------------------------------------+
+| 1            | overcurrent protection                     |
++--------------+--------------------------------------------+
+| 2            | overvoltage protection                     |
++--------------+--------------------------------------------+
+| 3            | AC power failure or power interuption      |
++--------------+--------------------------------------------+
+| 5            | over temperature protection                |
++--------------+--------------------------------------------+
+| 7            | IOC communication error                    |
++--------------+--------------------------------------------+
+
+When the PMX enters the protection mode, the cause must be removed and the
+protection mode must be deactivated in order to resume output. After removing
+the cause of the protection, output can be resumed by executing the following
+API tasks via the HWP PMX Agent::
+
+    pmx.clear_alarm()
+    pmx.set_on()
+
 Agent API
 ---------
 

--- a/socs/agents/hwp_pmx/agent.py
+++ b/socs/agents/hwp_pmx/agent.py
@@ -324,6 +324,7 @@ def main(args=None):
     agent.register_process('acq', PMX.acq, PMX._stop_acq)
     agent.register_task('set_on', PMX.set_on)
     agent.register_task('set_off', PMX.set_off)
+    agent.register_task('clear_alarm', PMX.clear_alarm)
     agent.register_task('set_i', PMX.set_i)
     agent.register_task('set_v', PMX.set_v)
     agent.register_task('set_i_lim', PMX.set_i_lim)

--- a/socs/agents/hwp_pmx/agent.py
+++ b/socs/agents/hwp_pmx/agent.py
@@ -107,7 +107,7 @@ class HWPPMXAgent:
                     'Could not clear alarm because {} is already running'.format(self.lock.job))
                 return False, 'Could not acquire lock'
             self.dev.clear_alarm()
-            self.prot_mode = 0
+            self.prot = 0
         return True, 'Clear alarm'
 
     @ocs_agent.param('curr', default=0, type=float, check=lambda x: 0 <= x <= 3)

--- a/socs/agents/hwp_pmx/agent.py
+++ b/socs/agents/hwp_pmx/agent.py
@@ -235,10 +235,16 @@ class HWPPMXAgent:
                 data['data']['current'] = curr
                 msg, volt = self.dev.meas_voltage()
                 data['data']['voltage'] = volt
+                msg, code = self.dev.check_error()
+                data['data']['err_code'] = code
+                data['data']['err_msg'] = msg
+                prot = self.dev.check_prot()
+                data['data']['prot'] = prot
 
                 self.agent.publish_to_feed('hwppmx', data)
                 session.data = {'curr': curr,
                                 'volt': volt,
+                                'prot': prot,
                                 'last_updated': current_time}
 
                 time.sleep(sleep_time)

--- a/socs/agents/hwp_pmx/agent.py
+++ b/socs/agents/hwp_pmx/agent.py
@@ -107,7 +107,7 @@ class HWPPMXAgent:
                     'Could not clear alarm because {} is already running'.format(self.lock.job))
                 return False, 'Could not acquire lock'
             self.dev.clear_alarm()
-            self.prot_mode = False
+            self.prot_mode = 0
         return True, 'Clear alarm'
 
     @ocs_agent.param('curr', default=0, type=float, check=lambda x: 0 <= x <= 3)

--- a/socs/agents/hwp_pmx/agent.py
+++ b/socs/agents/hwp_pmx/agent.py
@@ -203,6 +203,7 @@ class HWPPMXAgent:
                 >>> response.session['data']
                 {'curr': 0,
                  'volt': 0,
+                 'prot': 0,
                  'last_updated': 1649085992.719602}
 
         """

--- a/socs/agents/hwp_pmx/agent.py
+++ b/socs/agents/hwp_pmx/agent.py
@@ -96,6 +96,18 @@ class HWPPMXAgent:
             self.dev.turn_off()
         return True, 'Set PMX Kikusui off'
 
+    def clear_alarm(self, session, params):
+        """clear_alarm()
+        **Task** - Clear alarm and exit protection mode.
+        """
+        with self.lock.acquire_timeout(3, job='clear_alarm') as acquired:
+            if not acquired:
+                self.log.warn(
+                    'Could not clear alarm because {} is already running'.format(self.lock.job))
+                return False, 'Could not acquire lock'
+            self.dev.clear_alarm()
+        return True, 'Clear alarm'
+
     @ocs_agent.param('curr', default=0, type=float, check=lambda x: 0 <= x <= 3)
     def set_i(self, session, params):
         """set_i(curr=0)

--- a/socs/agents/hwp_pmx/drivers/PMX_ethernet.py
+++ b/socs/agents/hwp_pmx/drivers/PMX_ethernet.py
@@ -12,6 +12,7 @@ protection_status_key = [
     '',
 ]
 
+
 class PMX:
     """The PMX object for communicating with the Kikusui PMX power supplies.
     Args:

--- a/socs/agents/hwp_pmx/drivers/PMX_ethernet.py
+++ b/socs/agents/hwp_pmx/drivers/PMX_ethernet.py
@@ -146,6 +146,6 @@ class PMX:
             0: No protection
             1: Protection mode
         """
-        self.sock.sendall(b'stat:prot?\n')
+        self.sock.sendall(b'stat:ques?\n')
         val = int(self.read())
         return val

--- a/socs/agents/hwp_pmx/drivers/PMX_ethernet.py
+++ b/socs/agents/hwp_pmx/drivers/PMX_ethernet.py
@@ -1,6 +1,16 @@
 import time
 from socket import AF_INET, SOCK_STREAM, socket
 
+protection_status_key = [
+    'Over voltage',
+    'Over current',
+    'AC power failure or power interuption',
+    '',
+    'Over temperature',
+    '',
+    'IOC communication error',
+    '',
+]
 
 class PMX:
     """The PMX object for communicating with the Kikusui PMX power supplies.
@@ -143,9 +153,22 @@ class PMX:
     def check_prot(self):
         """ Check the protection status
         Return:
-            0: No protection
-            1: Protection mode
+            val (int): protection status code
         """
         self.sock.sendall(b'stat:ques?\n')
         val = int(self.read())
         return val
+
+    def get_prot_msg(self, val):
+        """ Get the protection status message
+        Args:
+            val (int): protection status code
+        Return:
+            msg (str): protection status message
+        """
+        msg = []
+        for i in range(8):
+            if (val >> i & 1):
+                msg.append(protection_status_key[i])
+        msg = ', '.join(msg)
+        return msg

--- a/socs/agents/hwp_pmx/drivers/PMX_ethernet.py
+++ b/socs/agents/hwp_pmx/drivers/PMX_ethernet.py
@@ -38,6 +38,19 @@ class PMX:
             msg += 'Fail'
         return msg, val
 
+    def check_error(self):
+        """ Check oldest error from error queues. Error queues store up to 255 errors """
+        self.sock.sendall(b':system:error?\n')
+        val = self.read()
+        code, msg = val.split(',')
+        code = int(code)
+        msg = msg[1:-2]
+        return msg, code
+
+    def clear_alarm(self):
+        """ Clear alarm """
+        self.sock.sendall(b'output:protection:clear\n')
+
     def turn_on(self):
         """ Turn the PMX on """
         self.sock.sendall(b'output 1\n')

--- a/socs/agents/hwp_pmx/drivers/PMX_ethernet.py
+++ b/socs/agents/hwp_pmx/drivers/PMX_ethernet.py
@@ -139,3 +139,13 @@ class PMX:
         val = float(self.read())
         msg = "Voltage Limit: {:.3f} V".format(val)
         return msg
+
+    def check_prot(self):
+        """ Check the protection status
+        Return:
+            0: No protection
+            1: Protection mode
+        """
+        self.sock.sendall(b'stat:prot?\n')
+        val = int(self.read())
+        return val

--- a/tests/integration/test_hwp_pmx_agent_integration.py
+++ b/tests/integration/test_hwp_pmx_agent_integration.py
@@ -147,7 +147,9 @@ def test_hwp_rotation_ign_ext(wait_for_crossbar, kikusui_emu, run_agent, client)
 @pytest.mark.integtest
 def test_hwp_rotation_acq(wait_for_crossbar, kikusui_emu, run_agent, client):
     responses = {'meas:volt?': '2',
-                 'meas:curr?': '1'}
+                 'meas:curr?': '1',
+                 ':system:error?': '+0,"No error"\n',
+                 'stat:ques?': '0'}
     kikusui_emu.define_responses(responses)
 
     client.init_connection.wait()  # wait for connection to be made


### PR DESCRIPTION
This adds protection mode and error monitoring to the pmx agent and adds task to clear protection mode.

## Description
With this change, the pmx agent will minitor for error and check if the pmx is in protection mode for every acq runs.
Information about errors and protection mode will be output to data along with voltage and current.
`clear_alarm()` method of the pmx agent can be used to exit the protection mode.

## Motivation and Context
#455 

## How Has This Been Tested?
Tested with chwp-daq pc in UTokyo

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
