### PR TITLE
Suprsync archive stats

### DIFF
--- a/socs/agents/suprsync/agent.py
+++ b/socs/agents/suprsync/agent.py
@@ -94,13 +94,13 @@ class SupRsync:
                     "files": [],
                     "stop_time": 1661284493.5398622
                   },
-                  'archive_stats': {
-                    'smurf': {
-                        'finalized_until': 1687797424.652119,
-                        'num_files': 3,
-                        'uncopied_files': 0,
-                        'last_file_added': '/path/to/file',
-                        'last_file_copied': '/path/to/file'
+                  "archive_stats": {
+                    "smurf": {
+                        "finalized_until": 1687797424.652119,
+                        "num_files": 3,
+                        "uncopied_files": 0,
+                        "last_file_added": "/path/to/file",
+                        "last_file_copied": "/path/to/file"
                     }
                   },
                   "counters": {
@@ -161,7 +161,7 @@ class SupRsync:
 
             now = time.time()
 
-            archive_stats = srfm.get_archive_stats().get(self.archive_name)
+            archive_stats = srfm.get_archive_stats(self.archive_name)
             if archive_stats is not None:
                 self.agent.publish_to_feed('archive_stats', {
                     'block_name': self.archive_name,

--- a/socs/agents/suprsync/agent.py
+++ b/socs/agents/suprsync/agent.py
@@ -158,7 +158,7 @@ class SupRsync:
                 self.log.error("rsync returned non-zero exit code! {e}", e=e)
                 op['error'] = 'nonzero exit'
                 counters['errors_nonzero'] += 1
-            
+
             now = time.time()
 
             archive_stats = srfm.get_archive_stats().get(self.archive_name)

--- a/socs/agents/suprsync/agent.py
+++ b/socs/agents/suprsync/agent.py
@@ -9,16 +9,6 @@ from ocs import ocs_agent, site_config
 from socs.db.suprsync import SupRsyncFileHandler, SupRsyncFilesManager
 
 
-def format_fieldname(name):
-    """
-    Formats a string so that it can be accepted as an OCS field-name
-    """
-    _name = name
-    for char in ['-', ' ']:
-        _name = _name.replace(char, '_')
-    return _name
-
-
 class SupRsync:
     """
     Agent to rsync files to a remote (or local) destination, verify successful
@@ -171,19 +161,13 @@ class SupRsync:
             
             now = time.time()
 
-            archive_stats = srfm.get_archive_stats()
-
-            # Publish stats to hk fieeds
-            for archive_name, stats in archive_stats.items():
+            archive_stats = srfm.get_archive_stats().get(self.archive_name)
+            if archive_stats is not None:
                 self.agent.publish_to_feed('archive_stats', {
-                    'block_name': archive_name,
+                    'block_name': self.archive_name,
                     'timestamp': now,
-                    'data': {
-                        format_fieldname(f'{archive_name}_{k}'): v
-                        for k, v in stats.items()
-                    }
+                    'data': archive_stats
                 })
-
             session.data['archive_stats'] = archive_stats
 
             op['stop_time'] = now

--- a/socs/db/suprsync.py
+++ b/socs/db/suprsync.py
@@ -6,7 +6,7 @@ import time
 import txaio
 import yaml
 from sqlalchemy import (Boolean, Column, Float, ForeignKey, Integer, String,
-                        create_engine)
+                        create_engine, asc)
 from sqlalchemy.ext.declarative import declarative_base
 from sqlalchemy.orm import sessionmaker
 
@@ -86,6 +86,9 @@ class SupRsyncFile(Base):
             Number of failed copy attempts
         deletable : Bool
             Whether file should be deleted after copying
+        ignore : Bool
+            If true, file will be ignored by SupRsync agent and not
+            included in `finalized_until`.
     """
     __tablename__ = f"supersync_v{TABLE_VERSION}"
 
@@ -100,6 +103,7 @@ class SupRsyncFile(Base):
     removed = Column(Float)
     failed_copy_attempts = Column(Integer, default=0)
     deletable = Column(Boolean, default=True)
+    ignore = Column(Boolean, default=False)
 
     def __str__(self):
         excl = ('_sa_adapter', '_sa_instance_state')
@@ -207,6 +211,62 @@ class SupRsyncFilesManager:
 
         if create_all:
             Base.metadata.create_all(self._engine)
+    
+    def get_archive_stats(self, session=None):
+        if session is None:
+            session = self.Session()
+        
+        archive_names =  session.query(SupRsyncFile.archive_name)\
+                            .distinct().all()
+        
+        stats = {}
+        for name, in archive_names:
+            files = session.query(SupRsyncFile).filter(
+                SupRsyncFile.archive_name == name,
+            ).order_by(asc(SupRsyncFile.timestamp)).all()
+
+            finalized_until = None
+            num_files_to_copy = 0
+
+            for f in files:
+                if (not f.ignore) and (f.local_md5sum != f.remote_md5sum):
+                    num_files_to_copy += 1
+                
+                if finalized_until is None and not (f.ignore):
+                    if f.local_md5sum != f.remote_md5sum:
+                        finalized_until = f.timestamp - 1
+
+            # There are no more uncopied files that aren't ignored
+            if finalized_until is None:  
+                finalized_until = time.time()
+
+            stats[name] = {
+                'finalized_until': finalized_until,
+                'num_files': len(files),
+                'uncopied_files': len([f for f in files if f.copied is None]),
+            }
+
+        return stats
+
+    def get_finalized_until(self, archive_name, session=None):
+        """
+        Returns a timetamp for which all files preceding are either successfully
+        copied, or ignored. If all files are copied, returns the current time.
+        """
+        if session is None:
+            session = self.Session()
+
+        query = session.query(SupRsyncFile).filter(
+            SupRsyncFile.archive_name == archive_name,
+        ).order_by(asc(SupRsyncFile.timestamp))
+
+        for file in query.all():
+            if file.ignore:
+                continue
+            if file.local_md5sum != file.remote_md5sum:
+                return file.timestamp - 1
+        else:
+            return time.time()
 
     def add_file(self, local_path, remote_path, archive_name,
                  local_md5sum=None, timestamp=None, session=None,
@@ -339,7 +399,7 @@ class SupRsyncFilesManager:
 
         query = session.query(SupRsyncFile).filter(
             SupRsyncFile.archive_name == archive_name,
-        )
+        ).order_by(asc(SupRsyncFile.timestamp))
 
         return list(query.all())
 
@@ -430,6 +490,7 @@ class SupRsyncFilesManager:
                 'num_files': len(files),
                 'subdirs': list(subdirs),
                 'finalized_at': now,
+                'finalized_until': self.get_finalized_until(tcdir.archive_name),
                 'archive_name': tcdir.archive_name,
                 'instance_id': sync_id
             }

--- a/socs/db/suprsync.py
+++ b/socs/db/suprsync.py
@@ -6,7 +6,7 @@ import time
 import txaio
 import yaml
 from sqlalchemy import (Boolean, Column, Float, ForeignKey, Integer, String,
-                        create_engine, asc)
+                        asc, create_engine)
 from sqlalchemy.ext.declarative import declarative_base
 from sqlalchemy.orm import sessionmaker
 
@@ -211,14 +211,14 @@ class SupRsyncFilesManager:
 
         if create_all:
             Base.metadata.create_all(self._engine)
-    
+
     def get_archive_stats(self, session=None):
         if session is None:
             session = self.Session()
-        
-        archive_names =  session.query(SupRsyncFile.archive_name)\
-                            .distinct().all()
-        
+
+        archive_names = session.query(SupRsyncFile.archive_name)\
+            .distinct().all()
+
         stats = {}
         for name, in archive_names:
             files = session.query(SupRsyncFile).filter(
@@ -237,13 +237,13 @@ class SupRsyncFilesManager:
 
                 if (not f.ignore) and (f.local_md5sum != f.remote_md5sum):
                     num_files_to_copy += 1
-                
+
                 if finalized_until is None and not (f.ignore):
                     if f.local_md5sum != f.remote_md5sum:
                         finalized_until = f.timestamp - 1
 
             # There are no more uncopied files that aren't ignored
-            if finalized_until is None:  
+            if finalized_until is None:
                 finalized_until = time.time()
 
             stats[name] = {

--- a/socs/db/suprsync.py
+++ b/socs/db/suprsync.py
@@ -227,8 +227,14 @@ class SupRsyncFilesManager:
 
             finalized_until = None
             num_files_to_copy = 0
+            last_file_added = ''
+            last_file_copied = ''
 
             for f in files:
+                last_file_added = f.local_path
+                if (f.local_md5sum == f.remote_md5sum):
+                    last_file_copied = f.local_path
+
                 if (not f.ignore) and (f.local_md5sum != f.remote_md5sum):
                     num_files_to_copy += 1
                 
@@ -244,6 +250,8 @@ class SupRsyncFilesManager:
                 'finalized_until': finalized_until,
                 'num_files': len(files),
                 'uncopied_files': len([f for f in files if f.copied is None]),
+                'last_file_added': last_file_added,
+                'last_file_copied': last_file_copied,
             }
 
         return stats

--- a/socs/db/suprsync_cli.py
+++ b/socs/db/suprsync_cli.py
@@ -4,6 +4,7 @@ Utility script for interacting with the suprsync db.
 """
 import argparse
 import os
+import time
 
 from tqdm.auto import trange
 
@@ -57,7 +58,7 @@ def add_local_files_func(args):
         for file in files:
             path = os.path.join(root, file)
             path = os.path.abspath(path)
-            if path not in known_paths:
+            if path not in known_paths and now-os.stat(path).st_mtime>=args.last_edit:
                 local_paths.append(path)
                 remote_paths.append(os.path.relpath(path, args.local_root))
 
@@ -117,6 +118,8 @@ def main():
     add_local_files_parser.add_argument(
         'archive_name', help="Archive to add files to")
     add_local_files_parser.add_argument('--db', default=default_db)
+    add_local_files_parser.add_argument('--last_edit', default=60,
+        help="Only add files that were last edited more than some seconds ago. Default:60")
     add_local_files_parser.add_argument(
         '--create-db', action='store_true',
         help="Create the db if it doesn't exist"

--- a/socs/db/suprsync_cli.py
+++ b/socs/db/suprsync_cli.py
@@ -58,7 +58,7 @@ def add_local_files_func(args):
         for file in files:
             path = os.path.join(root, file)
             path = os.path.abspath(path)
-            if path not in known_paths and now-os.stat(path).st_mtime>=args.last_edit:
+            if path not in known_paths and now - os.stat(path).st_mtime >= args.last_edit:
                 local_paths.append(path)
                 remote_paths.append(os.path.relpath(path, args.local_root))
 
@@ -119,7 +119,7 @@ def main():
         'archive_name', help="Archive to add files to")
     add_local_files_parser.add_argument('--db', default=default_db)
     add_local_files_parser.add_argument('--last_edit', default=60,
-        help="Only add files that were last edited more than some seconds ago. Default:60")
+                                        help="Only add files that were last edited more than some seconds ago. Default:60")
     add_local_files_parser.add_argument(
         '--create-db', action='store_true',
         help="Create the db if it doesn't exist"

--- a/socs/db/suprsync_cli.py
+++ b/socs/db/suprsync_cli.py
@@ -53,6 +53,7 @@ def add_local_files_func(args):
     known_paths = [f.local_path for f in known_files]
     local_paths = []
     remote_paths = []
+    now = time.time()
 
     for root, _, files in os.walk(args.local_root):
         for file in files:
@@ -118,7 +119,7 @@ def main():
     add_local_files_parser.add_argument(
         'archive_name', help="Archive to add files to")
     add_local_files_parser.add_argument('--db', default=default_db)
-    add_local_files_parser.add_argument('--last_edit', default=60,
+    add_local_files_parser.add_argument('--last-edit', default=60,
                                         help="Only add files that were last edited more than some seconds ago. Default:60")
     add_local_files_parser.add_argument(
         '--create-db', action='store_true',

--- a/tests/agents/test_suprsync_agent.py
+++ b/tests/agents/test_suprsync_agent.py
@@ -76,7 +76,7 @@ def test_timecode_dirs(tmp_path):
         for f in files:
             if f.endswith('finalized.yaml'):
                 finalize_files.append(os.path.join(root, f))
-        
+
     print(f"Finalize timestamp: {srfm.get_finalized_until('test')}")
     print(srfm.get_archive_stats())
 

--- a/tests/agents/test_suprsync_agent.py
+++ b/tests/agents/test_suprsync_agent.py
@@ -76,6 +76,9 @@ def test_timecode_dirs(tmp_path):
         for f in files:
             if f.endswith('finalized.yaml'):
                 finalize_files.append(os.path.join(root, f))
+        
+    print(f"Finalize timestamp: {srfm.get_finalized_until('test')}")
+    print(srfm.get_archive_stats())
 
     assert (len(finalize_files) == len(tcs) - 1)
 

--- a/tests/agents/test_suprsync_agent.py
+++ b/tests/agents/test_suprsync_agent.py
@@ -78,7 +78,7 @@ def test_timecode_dirs(tmp_path):
                 finalize_files.append(os.path.join(root, f))
 
     print(f"Finalize timestamp: {srfm.get_finalized_until('test')}")
-    print(srfm.get_archive_stats())
+    print(srfm.get_archive_stats(archive_name))
 
     assert (len(finalize_files) == len(tcs) - 1)
 


### PR DESCRIPTION
## Description
This adds additional stats for each suprsync archive, which are added to session.data along with hk feeds. This can be used by G3tSmurf to determine the finalization time for each archive, and for grafana monitoring.

## Motivation and Context
Required for G3tSmurf to determine when an archive is complete and books can be created. Also useful for monitoring in grafana.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
Tested by running the agent locally with fake data.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
