### PR TITLE
ACU scan stop fix

### DIFF
--- a/socs/agents/acu/agent.py
+++ b/socs/agents/acu/agent.py
@@ -1478,7 +1478,7 @@ class ACUAgent:
         _publish_error(0)
 
         target_instance_id = self.agent.agent_address.split('.')[-1]
-        exercisor.set_client(target_instance_id)
+        exercisor.set_client(target_instance_id, self.agent.site_args)
         settings = super_plan.get('settings', {})
 
         plan_idx = 0

--- a/socs/agents/acu/agent.py
+++ b/socs/agents/acu/agent.py
@@ -172,7 +172,8 @@ class ACUAgent:
         # Automatic exercise program...
         if exercise_plan:
             agent.register_process(
-                'exercise', self.exercise, self._simple_process_stop)
+                'exercise', self.exercise, self._simple_process_stop,
+                stopper_blocking=False)
             # Use longer default frame length ... very low volume feed.
             self.agent.register_feed('activity',
                                      record=True,
@@ -1532,7 +1533,7 @@ class ACUAgent:
 
             plan, info = next(active_plan['iter'])
 
-            self.log.info(f'Launching next scan. plan={plan}')
+            self.log.info('Launching next scan. plan={plan}', plan=plan)
 
             _publish_activity(active_plan['driver'].code)
             ok = None

--- a/socs/agents/acu/drivers.py
+++ b/socs/agents/acu/drivers.py
@@ -8,6 +8,10 @@ import numpy as np
 #: The number of seconds in a day.
 DAY = 86400
 
+#: Minimum number of points to group together on the start of a new
+#leg, to not trigger programtrack error.
+MIN_GROUP_NEW_LEG = 4
+
 
 def constant_velocity_scanpoints(azpts, el, azvel, acc, ntimes):
     """
@@ -129,9 +133,8 @@ def from_file(filename):
 
 
 def ptstack_format(conctimes, concaz, concel, concva, concve, az_flags,
-                   el_flags, start_offset=0, absolute=False):
-    """
-    Produces a list of lines in the format necessary to upload to the ACU
+                   el_flags, group_flag=None, start_offset=0, absolute=False):
+    """Produces a list of lines in the format necessary to upload to the ACU
     to complete a scan. Params are the outputs of from_file,
     constant_velocity_scanpoints, or generate_constant_velocity_scan.
 
@@ -146,6 +149,9 @@ def ptstack_format(conctimes, concaz, concel, concva, concve, az_flags,
             conctimes
         el_flags (list): Flags associated with elevation motions at
             conctimes
+        group_flag (list): If not None, must be a list drawn from [0,
+            1] where 1 indicates that the point should not be uploaded
+            unless the subsequent point is also immediately uploaded.
         start_offset (float): Offset, in seconds, to apply to all
             timestamps.
         absolute (bool): If true, timestamps are taken at face value,
@@ -154,7 +160,10 @@ def ptstack_format(conctimes, concaz, concel, concva, concve, az_flags,
             is 0, then you will need to also pass start_offset > 0).
 
     Returns:
-        list: Lines in the correct format to upload to the ACU
+        list: Lines in the correct format to upload to the ACU.  If
+        group_flag was included, then each upload line is returned as
+        a tuple (group_flag, line_text).
+
     """
 
     fmt = '%j, %H:%M:%S'
@@ -170,6 +179,9 @@ def ptstack_format(conctimes, concaz, concel, concva, concve, az_flags,
                                 el=concel[n], azvel=concva[n], elvel=concve[n],
                                 azflag=az_flags[n], elflag=el_flags[n]))
                  for n in range(len(fmt_times))]
+
+    if group_flag is not None:
+        all_lines = [(i, line) for i, line in zip(group_flag, all_lines)]
 
     return all_lines
 
@@ -316,10 +328,12 @@ def generate_constant_velocity_scan(az_endpoint1, az_endpoint2, az_speed,
     def check_num_scans():
         return num_scans is None or num_scans > 0
 
+    point_group_batch = 0
+
     i = 0
     while i < stop_iter and check_num_scans():
         i += 1
-        point_block = [[], [], [], [], [], [], []]
+        point_block = [[], [], [], [], [], [], [], []]
         for j in range(batch_size):
             point_block[0].append(t + t0)
             point_block[1].append(az)
@@ -328,7 +342,11 @@ def generate_constant_velocity_scan(az_endpoint1, az_endpoint2, az_speed,
             point_block[4].append(el_vel)
             point_block[5].append(az_flag)
             point_block[6].append(el_flag)
+            point_block[7].append(int(point_group_batch > 0))
+
             t += step_time
+            if point_group_batch > 0:
+                point_group_batch -= 1
 
             if increasing:
                 if az <= (az_max - 2 * daz):
@@ -346,6 +364,7 @@ def generate_constant_velocity_scan(az_endpoint1, az_endpoint2, az_speed,
                     el_flag = 0
                     increasing = False
                     dec_num_scans()
+                    point_group_batch = MIN_GROUP_NEW_LEG - 1
                 else:
                     az_remaining = az_max - az
                     time_remaining = az_remaining / az_speed
@@ -372,6 +391,7 @@ def generate_constant_velocity_scan(az_endpoint1, az_endpoint2, az_speed,
                     el_flag = 0
                     increasing = True
                     dec_num_scans()
+                    point_group_batch = MIN_GROUP_NEW_LEG - 1
                 else:
                     az_remaining = az - az_min
                     time_remaining = az_remaining / az_speed
@@ -386,7 +406,7 @@ def generate_constant_velocity_scan(az_endpoint1, az_endpoint2, az_speed,
             if not check_num_scans():
                 # Kill the velocity on the last point and exit -- this
                 # was recommended at LAT FAT for smoothly stopping the
-                # motino at end of program.
+                # motion at end of program.
                 point_block[3][-1] = 0
                 point_block[4][-1] = 0
                 break
@@ -395,12 +415,10 @@ def generate_constant_velocity_scan(az_endpoint1, az_endpoint2, az_speed,
             yield ptstack_format(point_block[0], point_block[1],
                                  point_block[2], point_block[3],
                                  point_block[4], point_block[5],
-                                 point_block[6],
+                                 point_block[6], point_block[7],
                                  start_offset=3, absolute=True)
         else:
-            yield (point_block[0], point_block[1], point_block[2],
-                   point_block[3], point_block[4], point_block[5],
-                   point_block[6])
+            yield tuple(point_block)
 
 
 def plan_scan(az_end1, az_end2, el, v_az=1, a_az=1, az_start=None):

--- a/socs/agents/acu/drivers.py
+++ b/socs/agents/acu/drivers.py
@@ -9,7 +9,7 @@ import numpy as np
 DAY = 86400
 
 #: Minimum number of points to group together on the start of a new
-#leg, to not trigger programtrack error.
+# leg, to not trigger programtrack error.
 MIN_GROUP_NEW_LEG = 4
 
 

--- a/socs/agents/acu/exercisor.py
+++ b/socs/agents/acu/exercisor.py
@@ -351,15 +351,8 @@ def get_plan(config):
 
 
 def set_client(instance_id, args=None):
-    if args is not None:
-        # ocs.site_config.get_config either requires that --site-file
-        # is set, or else OCS_CONFIG_DIR is defined.  Catch and
-        # propagate any --site-file setting to make sure the config is
-        # the same one as the agent is using.
-        if args.site_file:
-            args = ['--site-file', args.site_file]
-        else:
-            args = None
+    # It's a good idea to pass in args in case user has overridden the
+    # default site config file.
     global c
     c = OCSClient(instance_id, args=args)
     return c

--- a/socs/agents/acu/exercisor.py
+++ b/socs/agents/acu/exercisor.py
@@ -350,9 +350,18 @@ def get_plan(config):
     return config
 
 
-def set_client(instance_id):
+def set_client(instance_id, args=None):
+    if args is not None:
+        # ocs.site_config.get_config either requires that --site-file
+        # is set, or else OCS_CONFIG_DIR is defined.  Catch and
+        # propagate any --site-file setting to make sure the config is
+        # the same one as the agent is using.
+        if args.site_file:
+            args = ['--site-file', args.site_file]
+        else:
+            args = None
     global c
-    c = OCSClient(instance_id)
+    c = OCSClient(instance_id, args=args)
     return c
 
 


### PR DESCRIPTION
## Description

Fixes a few bugs:
- In ProgramTrack, always upload at least 4 points of a new scan leg.  Otherwise, a user abort can lead to ACU fault (ProgramTrack error).
- Fix a log message formatting thing.
- Register the "exercise" process stopper with stopper_blocking=False

## How Has This Been Tested?

Tested on SATP1; first confirmed I could reliably reproduce the main ProgramTrack failure.  Then ran a few tests to confirm the issue went away with these changes. 

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
