### PR TITLE
Separate generator fields into different blocks

### DIFF
--- a/socs/agents/generator/agent.py
+++ b/socs/agents/generator/agent.py
@@ -424,7 +424,13 @@ class GeneratorAgent:
                     self.log.info('Trying to reconnect.')
                     continue
 
-                self.agent.publish_to_feed('generator', data)
+                for field, val in data['data'].items():
+                    _data = {
+                        'timestamp': current_time,
+                        'block_name': field,
+                        'data': {field: val}
+                    }
+                    self.agent.publish_to_feed('generator', _data)
 
             self.agent.feeds['generator'].flush_buffer()
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Separates generator fields into separate blocks.

## Description
<!--- Describe your changes in detail -->

Sometimes the generator is not able to provide data for certain fields, in which case we don't want those fields to be published to grafana. The current version will simply remove those fields from the block, which starts throwing errors due to block structures not matching. To fix this, this PR separates fields into different blocks since they may not be co-sampled.


## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Buxfix for current implementation of the generator agent.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
Not tested yet

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
