### PR TITLE
Fix failing docs builds

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -3,7 +3,7 @@ version: 2
 build:
   os: ubuntu-22.04
   tools:
-    python: "3.10"
+    python: "3.11"
 
 sphinx:
     configuration: docs/conf.py

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 # core dependencies
 autobahn[serialization]
-ocs
+ocs>=0.10.0
 sqlalchemy>=1.4
 twisted
 
@@ -12,7 +12,8 @@ pyasn1==0.4.8
 
 # common dependencies - used by multiple agents
 numpy
-pyyaml
+astropy>=5.1.1
+pyyaml>=6.0.1
 
 # acu agent
 soaculib @ git+https://github.com/simonsobs/soaculib.git@master

--- a/requirements/testing.txt
+++ b/requirements/testing.txt
@@ -1,6 +1,5 @@
 pytest
 pytest-cov
-pytest-docker-compose
 pytest-dependency
 pytest-order
 so3g


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Started in #477. This follows that thread, ultimately leading to dropping the `pytest-docker-compose` dependency.

I'm opening this PR because I know the docs build will work, but expect the tests to fail. I think we'll need to actually drop our use of `pytest-docker-compose`. Since there's more to do, I'll open this as a draft.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Fixes #478.

Installation of socs itself is currently broken by this dependency conflict.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
Tested installation of socs locally, then pushed to a hidden readthedocs build which is currently working. Haven't tested the tests locally yet.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
