### PR TITLE
Replace pytest-docker-compose with pytest-docker plugin

### DIFF
--- a/requirements/testing.txt
+++ b/requirements/testing.txt
@@ -1,6 +1,6 @@
 pytest
 pytest-cov
-pytest-docker-compose
+pytest-docker
 pytest-dependency
 pytest-order
 so3g

--- a/tests/integration/test_cryomech_cpa_agent_integration.py
+++ b/tests/integration/test_cryomech_cpa_agent_integration.py
@@ -2,13 +2,12 @@ import os
 
 import ocs
 import pytest
+from integration.util import docker_compose_file  # noqa: F401
 from integration.util import create_crossbar_fixture
 from ocs.base import OpCode
 from ocs.testing import create_agent_runner_fixture, create_client_fixture
 
 from socs.testing.device_emulator import create_device_emulator
-
-pytest_plugins = ("docker_compose")
 
 # Set the OCS_CONFIG_DIR so we read the local default.yaml file always
 os.environ['OCS_CONFIG_DIR'] = os.getcwd()

--- a/tests/integration/test_hwp_pid_agent_integration.py
+++ b/tests/integration/test_hwp_pid_agent_integration.py
@@ -1,12 +1,11 @@
 import ocs
 import pytest
+from integration.util import docker_compose_file  # noqa: F401
 from integration.util import create_crossbar_fixture
 from ocs.base import OpCode
 from ocs.testing import create_agent_runner_fixture, create_client_fixture
 
 from socs.testing.device_emulator import create_device_emulator
-
-pytest_plugins = ("docker_compose")
 
 wait_for_crossbar = create_crossbar_fixture()
 run_agent = create_agent_runner_fixture(

--- a/tests/integration/test_hwp_pmx_agent_integration.py
+++ b/tests/integration/test_hwp_pmx_agent_integration.py
@@ -1,12 +1,11 @@
 import ocs
 import pytest
+from integration.util import docker_compose_file  # noqa: F401
 from integration.util import create_crossbar_fixture
 from ocs.base import OpCode
 from ocs.testing import create_agent_runner_fixture, create_client_fixture
 
 from socs.testing.device_emulator import create_device_emulator
-
-pytest_plugins = ("docker_compose")
 
 wait_for_crossbar = create_crossbar_fixture()
 run_agent = create_agent_runner_fixture(

--- a/tests/integration/test_ibootbar_agent_integration.py
+++ b/tests/integration/test_ibootbar_agent_integration.py
@@ -6,6 +6,7 @@ from unittest.mock import patch
 
 import ocs
 import pytest
+from integration.util import docker_compose_file  # noqa: F401
 from integration.util import create_crossbar_fixture
 from ocs.base import OpCode
 from ocs.testing import create_agent_runner_fixture, create_client_fixture
@@ -13,8 +14,6 @@ from snmpsim.commands import responder
 from twisted.internet.defer import inlineCallbacks
 
 from socs.snmp import SNMPTwister
-
-pytest_plugins = "docker_compose"
 
 wait_for_crossbar = create_crossbar_fixture()
 run_agent = create_agent_runner_fixture(

--- a/tests/integration/test_ls240_agent_integration.py
+++ b/tests/integration/test_ls240_agent_integration.py
@@ -2,13 +2,12 @@ import time
 
 import ocs
 import pytest
+from integration.util import docker_compose_file  # noqa: F401
 from integration.util import create_crossbar_fixture
 from ocs.base import OpCode
 from ocs.testing import create_agent_runner_fixture, create_client_fixture
 
 from socs.testing.device_emulator import create_device_emulator
-
-pytest_plugins = ("docker_compose")
 
 wait_for_crossbar = create_crossbar_fixture()
 run_agent = create_agent_runner_fixture(

--- a/tests/integration/test_ls372_agent_integration.py
+++ b/tests/integration/test_ls372_agent_integration.py
@@ -2,13 +2,12 @@ import os
 
 import ocs
 import pytest
+from integration.util import docker_compose_file  # noqa: F401
 from integration.util import create_crossbar_fixture
 from ocs.base import OpCode
 from ocs.testing import create_agent_runner_fixture, create_client_fixture
 
 from socs.testing.device_emulator import create_device_emulator
-
-pytest_plugins = ("docker_compose")
 
 # Set the OCS_CONFIG_DIR so we read the local default.yaml file always
 os.environ['OCS_CONFIG_DIR'] = os.getcwd()

--- a/tests/integration/test_ls425_agent_integration.py
+++ b/tests/integration/test_ls425_agent_integration.py
@@ -2,13 +2,12 @@ import time
 
 import ocs
 import pytest
+from integration.util import docker_compose_file  # noqa: F401
 from integration.util import create_crossbar_fixture
 from ocs.base import OpCode
 from ocs.testing import create_agent_runner_fixture, create_client_fixture
 
 from socs.testing.device_emulator import create_device_emulator
-
-pytest_plugins = ("docker_compose")
 
 wait_for_crossbar = create_crossbar_fixture()
 run_agent = create_agent_runner_fixture(

--- a/tests/integration/test_pfeiffer_tc400_agent_integration.py
+++ b/tests/integration/test_pfeiffer_tc400_agent_integration.py
@@ -2,13 +2,12 @@ import os
 
 import ocs
 import pytest
+from integration.util import docker_compose_file  # noqa: F401
 from integration.util import create_crossbar_fixture
 from ocs.base import OpCode
 from ocs.testing import create_agent_runner_fixture, create_client_fixture
 
 from socs.testing.device_emulator import create_device_emulator
-
-pytest_plugins = ("docker_compose")
 
 # Set the OCS_CONFIG_DIR so we read the local default.yaml file always
 os.environ['OCS_CONFIG_DIR'] = os.getcwd()

--- a/tests/integration/test_pfeiffer_tpg366_agent_integration.py
+++ b/tests/integration/test_pfeiffer_tpg366_agent_integration.py
@@ -1,12 +1,11 @@
 import ocs
 import pytest
+from integration.util import docker_compose_file  # noqa: F401
 from integration.util import create_crossbar_fixture
 from ocs.base import OpCode
 from ocs.testing import create_agent_runner_fixture, create_client_fixture
 
 from socs.testing.device_emulator import create_device_emulator
-
-pytest_plugins = "docker_compose"
 
 wait_for_crossbar = create_crossbar_fixture()
 run_agent = create_agent_runner_fixture(

--- a/tests/integration/test_pysmurf_monitor_integration.py
+++ b/tests/integration/test_pysmurf_monitor_integration.py
@@ -6,11 +6,10 @@ import time
 
 import ocs
 import pytest
+from integration.util import docker_compose_file  # noqa: F401
 from integration.util import create_crossbar_fixture
 from ocs.base import OpCode
 from ocs.testing import create_agent_runner_fixture, create_client_fixture
-
-pytest_plugins = "docker_compose"
 
 TMPFILE = '/tmp/pytest-socs/suprsync.db'
 

--- a/tests/integration/test_scpi_psu_agent_integration.py
+++ b/tests/integration/test_scpi_psu_agent_integration.py
@@ -1,12 +1,11 @@
 import ocs
 import pytest
+from integration.util import docker_compose_file  # noqa: F401
 from integration.util import create_crossbar_fixture
 from ocs.base import OpCode
 from ocs.testing import create_agent_runner_fixture, create_client_fixture
 
 from socs.testing.device_emulator import create_device_emulator
-
-pytest_plugins = "docker_compose"
 
 wait_for_crossbar = create_crossbar_fixture()
 run_agent = create_agent_runner_fixture(

--- a/tests/integration/test_synacc_integration.py
+++ b/tests/integration/test_synacc_integration.py
@@ -2,11 +2,10 @@ import ocs
 import pytest
 from flask import request
 from http_server_mock import HttpServerMock
+from integration.util import docker_compose_file  # noqa: F401
 from integration.util import create_crossbar_fixture
 from ocs.base import OpCode
 from ocs.testing import create_agent_runner_fixture, create_client_fixture
-
-pytest_plugins = "docker_compose"
 
 wait_for_crossbar = create_crossbar_fixture()
 run_agent = create_agent_runner_fixture(

--- a/tests/integration/test_ups_agent_integration.py
+++ b/tests/integration/test_ups_agent_integration.py
@@ -6,12 +6,11 @@ from unittest.mock import patch
 
 import ocs
 import pytest
+from integration.util import docker_compose_file  # noqa: F401
 from integration.util import create_crossbar_fixture
 from ocs.base import OpCode
 from ocs.testing import create_agent_runner_fixture, create_client_fixture
 from snmpsim.commands import responder
-
-pytest_plugins = "docker_compose"
 
 wait_for_crossbar = create_crossbar_fixture()
 run_agent = create_agent_runner_fixture(

--- a/tests/integration/util.py
+++ b/tests/integration/util.py
@@ -1,3 +1,5 @@
+import os
+
 import pytest
 from ocs.testing import check_crossbar_connection
 
@@ -11,7 +13,7 @@ def create_crossbar_fixture():
     # @pytest.fixture(scope="function")
     # def wait_for_crossbar(function_scoped_container_getter):
     @pytest.fixture(scope="session")
-    def wait_for_crossbar(session_scoped_container_getter):
+    def wait_for_crossbar(docker_services):
         """Wait for the crossbar server from docker-compose to become
         responsive.
 
@@ -19,3 +21,10 @@ def create_crossbar_fixture():
         check_crossbar_connection()
 
     return wait_for_crossbar
+
+
+# Overrides the default location that pytest-docker looks for the compose file.
+# https://pypi.org/project/pytest-docker/
+@pytest.fixture(scope="session")
+def docker_compose_file(pytestconfig):
+    return os.path.join(str(pytestconfig.rootdir), "docker-compose.yml")


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
This does as the title says and replaces the use of the pytest plugin `pytest-docker-compose` with the plugin `pytest-docker`. 

The difference is that `pytest-docker-compose` only supports docker-compose v1, while `pytest-docker` supports v2.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
This, together with #482 fixes recent issues with installing socs.

#482 introduces a pin of pyyaml (`pyyaml>6.0.1`) which `pytest-docker-compose` (which pins to `pyyaml<6`) is incompatible with.

After seeing checks run, it turns out dropping this dependency completely fixes #478 without #482.

Fixes #478.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

I ran tests locally with this new plugin.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
