### PR TITLE
Add Autorange Task to 372 Agent

### DIFF
--- a/socs/agents/lakeshore372/agent.py
+++ b/socs/agents/lakeshore372/agent.py
@@ -847,7 +847,7 @@ class LS372_Agent:
                 self.module.channels[channel].disable_autorange()
 
         return True, "Channel {} autorange status is {}".format(channel, state)
-    
+
     @ocs_agent.param('channel', type=int, check=lambda x: 0 <= x <= 16)
     @ocs_agent.param('curve_number', type=int, check=lambda x: 21 <= x <= 59)
     def set_calibration_curve(self, session, params):

--- a/socs/agents/lakeshore372/agent.py
+++ b/socs/agents/lakeshore372/agent.py
@@ -820,6 +820,34 @@ class LS372_Agent:
 
         return True, "Channel {} powered {}".format(channel, state)
 
+    @ocs_agent.param('channel', type=int)
+    @ocs_agent.param('state', type=str, choices=['on', 'off'])
+    def engage_autorange(self, session, params):
+        """engage_autorange(channel, state)
+
+        **Task** - Enables/disables autorange for a channel on the LS372
+
+        Parameters:
+            channel (int): Channel number for enabling autorange
+            state (str): Desired autorange state of channel: 'on' or 'off'
+        """
+        with self._lock.acquire_timeout(job='engage_channel') as acquired:
+            if not acquired:
+                self.log.warn(f"Could not start Task because "
+                              f"{self._lock.job} is already running")
+                return False, "Could not acquire lock"
+
+            session.set_status('running')
+
+            channel = params['channel']
+            state = params['state']
+            if state == 'on':
+                self.module.channels[channel].enable_autorange()
+            else:
+                self.module.channels[channel].disable_autorange()
+
+        return True, "Channel {} autorange status is {}".format(channel, state)
+    
     @ocs_agent.param('channel', type=int, check=lambda x: 0 <= x <= 16)
     @ocs_agent.param('curve_number', type=int, check=lambda x: 21 <= x <= 59)
     def set_calibration_curve(self, session, params):
@@ -1436,6 +1464,7 @@ def main(args=None):
     agent.register_task('set_dwell', lake_agent.set_dwell)
     agent.register_task('get_dwell', lake_agent.get_dwell)
     agent.register_task('engage_channel', lake_agent.engage_channel)
+    agent.register_task('engage_autorange', lake_agent.engage_autorange)
     agent.register_task('get_input_setup', lake_agent.get_input_setup)
     agent.register_task('set_calibration_curve', lake_agent.set_calibration_curve)
     agent.register_task('set_pid', lake_agent.set_pid)

--- a/tests/integration/test_ls372_agent_integration.py
+++ b/tests/integration/test_ls372_agent_integration.py
@@ -234,6 +234,14 @@ def test_ls372_engage_channel(wait_for_crossbar, emulator, run_agent, client):
 
 
 @pytest.mark.integtest
+def test_ls372_engage_autorange(wait_for_crossbar, emulator, run_agent, client):
+    client.init_lakeshore()
+    resp = client.engage_autorange(channel=3, state='on')
+    assert resp.status == ocs.OK
+    assert resp.session['op_code'] == OpCode.SUCCEEDED.value
+
+
+@pytest.mark.integtest
 def test_ls372_set_calibration_curve(wait_for_crossbar, emulator, run_agent, client):
     client.init_lakeshore()
     resp = client.set_calibration_curve(channel=4, curve_number=28)


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Added a separate task that can change autorange settings for a 372 channel outside of the `input_configfile` task

## Motivation and Context
This change is required for adding the capability to individually change this setting as well as add it to ocs-web

## How Has This Been Tested?
Tested successfully on a 372 in the lab at Yale

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
