### PR TITLE
Fix ibootbar agent acq crashing during reconnection

### DIFF
--- a/socs/agents/ibootbar/agent.py
+++ b/socs/agents/ibootbar/agent.py
@@ -199,6 +199,7 @@ class ibootbarAgent:
         self.version = version
         self.address = address
         self.snmp = SNMPTwister(address, port)
+        self.connected = True
 
         self.lastGet = 0
         self.sample_period = 60
@@ -248,6 +249,10 @@ class ibootbarAgent:
         self.is_streaming = True
         while self.is_streaming:
             yield dsleep(1)
+            if not self.connected:
+                self.log.error('No SNMP response. Check your connection!')
+                self.log.info('Trying to reconnect.')
+            
             read_time = time.time()
 
             # Check if sample period has passed before getting status
@@ -263,14 +268,24 @@ class ibootbarAgent:
                 get_list.append(('IBOOTPDU-MIB', 'outletStatus', i))
                 name_list.append(('IBOOTPDU-MIB', 'outletName', i))
 
-            # Issue SNMP GET command
+            # Issue SNMP GET commands
             get_result = yield self.snmp.get(get_list, self.version)
-            name_result = yield self.snmp.get(name_list, self.version)
+            if get_result is None:
+                self.connected = False
+                session.data['ibootbar_connection'] = {'last_attempt': time.time(),
+                                                       'connected': False}
+                continue
+            self.connected = True
 
-            # If device gets disconnected, name_result is None
-            if name_result is not None:
-                for item in name_result:
-                    names.append(item[1].prettyPrint())
+            name_result = yield self.snmp.get(name_list, self.version)
+            if name_result is None:
+                self.connected = False
+                session.data['ibootbar_connection'] = {'last_attempt': time.time(),
+                                                       'connected': False}
+                continue
+            self.connected = True
+            for item in name_result:
+                names.append(item[1].prettyPrint())
 
             # Do not publish if ibootbar connection has dropped
             try:
@@ -280,7 +295,7 @@ class ibootbarAgent:
                 session.data = oid_cache
                 self.log.debug("{data}", data=session.data)
 
-                if get_result is None:
+                if not self.connected:
                     raise ConnectionError('No SNMP response. Check your connection.')
 
                 self.lastGet = time.time()

--- a/socs/agents/ibootbar/agent.py
+++ b/socs/agents/ibootbar/agent.py
@@ -252,7 +252,7 @@ class ibootbarAgent:
             if not self.connected:
                 self.log.error('No SNMP response. Check your connection!')
                 self.log.info('Trying to reconnect.')
-            
+
             read_time = time.time()
 
             # Check if sample period has passed before getting status

--- a/socs/agents/ibootbar/agent.py
+++ b/socs/agents/ibootbar/agent.py
@@ -295,18 +295,14 @@ class ibootbarAgent:
                 session.data = oid_cache
                 self.log.debug("{data}", data=session.data)
 
-                if not self.connected:
-                    raise ConnectionError('No SNMP response. Check your connection.')
-
                 self.lastGet = time.time()
                 # Publish to feed
                 message = _build_message(get_result, names, read_time)
                 self.log.debug("{msg}", msg=message)
                 session.app.publish_to_feed('ibootbar', message)
-            except ConnectionError as e:
+            except Exception as e:
                 self.log.error(f'{e}')
                 yield dsleep(1)
-                self.log.info('Trying to reconnect.')
 
             if params['test_mode']:
                 break


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Fixes agent acq process crashing on reconnection. Continues loop on SNMP disconnect.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Resolves #492 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
Tested in lab on ibootbar.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
