### PR TITLE
LS372 Agent: Add ability in config file to set channel resistance range

### DIFF
--- a/docs/agents/lakeshore372.rst
+++ b/docs/agents/lakeshore372.rst
@@ -72,7 +72,7 @@ Lakeshore 372 configuration file::
              resistance_range: 2e3
              dwell: 10 # seconds
              pause: 3 # seconds
-             calibruation_curve_num: 28
+             calibration_curve_num: 28
              temperature_coeff: 'negative'
     LSA2761:
         device_settings:
@@ -96,7 +96,7 @@ Lakeshore 372 configuration file::
              resistance_range: 2e3
              dwell: 10 # seconds
              pause: 3 # seconds
-             calibruation_curve_num: 36
+             calibration_curve_num: 36
              temperature_coeff: 'negative'
           3:
              enable: 'on'
@@ -116,13 +116,13 @@ Lakeshore 372 configuration file::
              resistance_range: 2e3
              dwell: 10 # seconds
              pause: 3 # seconds
-             calibruation_curve_num: 35
+             calibration_curve_num: 35
              temperature_coeff: 'negative'
 
 .. note::
    For setting a 372 channel to a specific resistance range, be sure to check
-   that autorange is set to 'off'. Else, the autorange resistance setting will
-   persist.
+   that autorange is set to 'off'. Else, the autorange setting will persist
+   over your desired resistance range.
 
 Docker Compose
 ``````````````

--- a/docs/agents/lakeshore372.rst
+++ b/docs/agents/lakeshore372.rst
@@ -83,6 +83,7 @@ Lakeshore 372 configuration file::
              excitation_mode: 'voltage'
              excitation_value: 2.0e-6
              autorange: 'on'
+             resistance_range: 2e3
              dwell: 15 # seconds
              pause: 10 # seconds
              calibration_curve_num: 33
@@ -92,6 +93,7 @@ Lakeshore 372 configuration file::
              excitation_mode: 'voltage'
              excitation_value: 2.0e-6
              autorange: 'off'
+             resistance_range: 2e3
              dwell: 10 # seconds
              pause: 3 # seconds
              calibruation_curve_num: 36
@@ -101,6 +103,7 @@ Lakeshore 372 configuration file::
              excitation_mode: 'voltage'
              excitation_value: 2.0e-6
              autorange: 'on'
+             resistance_range: 2e3
              dwell: 15 # seconds
              pause: 10 # seconds
              calibration_curve_num: 34
@@ -110,6 +113,7 @@ Lakeshore 372 configuration file::
              excitation_mode: 'voltage'
              excitation_value: 2.0e-6
              autorange: 'off'
+             resistance_range: 2e3
              dwell: 10 # seconds
              pause: 3 # seconds
              calibruation_curve_num: 35

--- a/docs/agents/lakeshore372.rst
+++ b/docs/agents/lakeshore372.rst
@@ -69,7 +69,7 @@ Lakeshore 372 configuration file::
              excitation_mode: 'voltage'
              excitation_value: 2.0e-6
              autorange: 'off'
-             resistance_range: 2e3
+             resistance_range: 2.0e+3
              dwell: 10 # seconds
              pause: 3 # seconds
              calibration_curve_num: 28
@@ -83,7 +83,7 @@ Lakeshore 372 configuration file::
              excitation_mode: 'voltage'
              excitation_value: 2.0e-6
              autorange: 'on'
-             resistance_range: 2e3
+             resistance_range: 2.0e+3
              dwell: 15 # seconds
              pause: 10 # seconds
              calibration_curve_num: 33
@@ -93,7 +93,7 @@ Lakeshore 372 configuration file::
              excitation_mode: 'voltage'
              excitation_value: 2.0e-6
              autorange: 'off'
-             resistance_range: 2e3
+             resistance_range: 2.0e+3
              dwell: 10 # seconds
              pause: 3 # seconds
              calibration_curve_num: 36
@@ -103,7 +103,7 @@ Lakeshore 372 configuration file::
              excitation_mode: 'voltage'
              excitation_value: 2.0e-6
              autorange: 'on'
-             resistance_range: 2e3
+             resistance_range: 2.0e+3
              dwell: 15 # seconds
              pause: 10 # seconds
              calibration_curve_num: 34
@@ -113,7 +113,7 @@ Lakeshore 372 configuration file::
              excitation_mode: 'voltage'
              excitation_value: 2.0e-6
              autorange: 'off'
-             resistance_range: 2e3
+             resistance_range: 2.0e+3
              dwell: 10 # seconds
              pause: 3 # seconds
              calibration_curve_num: 35
@@ -123,6 +123,10 @@ Lakeshore 372 configuration file::
    For setting a 372 channel to a specific resistance range, be sure to check
    that autorange is set to 'off'. Else, the autorange setting will persist
    over your desired resistance range.
+
+.. note::
+   Make sure values like excitation and resistance are in float form as shown
+   in the example. Ex: always 2.0e+3, never 2e3
 
 Docker Compose
 ``````````````

--- a/docs/agents/lakeshore372.rst
+++ b/docs/agents/lakeshore372.rst
@@ -59,6 +59,7 @@ Lakeshore 372 configuration file::
              excitation_mode: 'voltage'
              excitation_value: 2.0e-6
              autorange: 'on'
+             resistance_range: 2e3
              dwell: 15 # seconds
              pause: 10 # seconds
              calibration_curve_num: 23
@@ -68,6 +69,7 @@ Lakeshore 372 configuration file::
              excitation_mode: 'voltage'
              excitation_value: 2.0e-6
              autorange: 'off'
+             resistance_range: 2e3
              dwell: 10 # seconds
              pause: 3 # seconds
              calibruation_curve_num: 28
@@ -113,6 +115,10 @@ Lakeshore 372 configuration file::
              calibruation_curve_num: 35
              temperature_coeff: 'negative'
 
+.. note::
+   For setting a 372 channel to a specific resistance range, be sure to check
+   that autorange is set to 'off'. Else, the autorange resistance setting will
+   persist.
 
 Docker Compose
 ``````````````

--- a/socs/agents/lakeshore372/agent.py
+++ b/socs/agents/lakeshore372/agent.py
@@ -1369,7 +1369,7 @@ class LS372_Agent:
                     # set to desired resistance range after disabling autorange
                     resistance_range = ls_chann_settings[i]['resistance_range']
                     ls.channels[i].set_resistance_range(resistance_range)
-                    self.log.info("resistance for CH.{channel} set to {res}".format(channel=i, res=resistance_range))
+                    self.log.info("resistance range for CH.{channel} set to {get_res}, the closest valid range to {res}".format(channel=i, get_res=ls.channels[i].get_resistance_range(), res=resistance_range))
 
                 excitation_mode = ls_chann_settings[i]['excitation_mode']
                 ls.channels[i].set_excitation_mode(excitation_mode)

--- a/socs/agents/lakeshore372/agent.py
+++ b/socs/agents/lakeshore372/agent.py
@@ -1369,6 +1369,7 @@ class LS372_Agent:
                     # set to desired resistance range after disabling autorange
                     resistance_range = ls_chann_settings[i]['resistance_range']
                     ls.channels[i].set_resistance_range(resistance_range)
+                    self.log.info("resistance for CH.{channel} set to {res}".format(channel=i, res=resistance_range))
 
                 excitation_mode = ls_chann_settings[i]['excitation_mode']
                 ls.channels[i].set_excitation_mode(excitation_mode)
@@ -1377,8 +1378,6 @@ class LS372_Agent:
                 excitation_value = ls_chann_settings[i]['excitation_value']
                 ls.channels[i].set_excitation(excitation_value)
                 self.log.info("excitation for CH.{channel} set to {exc}".format(channel=i, exc=excitation_value))
-
-                self.log.info("resistance for CH.{channel} set to {res}".format(channel=i, res=resistance_range))
 
                 dwell = ls_chann_settings[i]['dwell']
                 ls.channels[i].set_dwell(dwell)

--- a/socs/agents/lakeshore372/agent.py
+++ b/socs/agents/lakeshore372/agent.py
@@ -1366,6 +1366,9 @@ class LS372_Agent:
                 elif ls_chann_settings[i]['autorange'] == 'off':
                     ls.channels[i].disable_autorange()
                     self.log.info("autorange off")
+                    # set to desired resistance range after disabling autorange
+                    resistance_range = ls_chann_settings[i]['resistance_range']
+                    ls.channels[i].set_resistance_range(resistance_range)
 
                 excitation_mode = ls_chann_settings[i]['excitation_mode']
                 ls.channels[i].set_excitation_mode(excitation_mode)
@@ -1375,8 +1378,6 @@ class LS372_Agent:
                 ls.channels[i].set_excitation(excitation_value)
                 self.log.info("excitation for CH.{channel} set to {exc}".format(channel=i, exc=excitation_value))
 
-                resistance_range = ls_chann_settings[i]['resistance_range']
-                ls.channels[i].set_resistance_range(resistance_range)
                 self.log.info("resistance for CH.{channel} set to {res}".format(channel=i, res=resistance_range))
 
                 dwell = ls_chann_settings[i]['dwell']

--- a/socs/agents/lakeshore372/agent.py
+++ b/socs/agents/lakeshore372/agent.py
@@ -1375,6 +1375,10 @@ class LS372_Agent:
                 ls.channels[i].set_excitation(excitation_value)
                 self.log.info("excitation for CH.{channel} set to {exc}".format(channel=i, exc=excitation_value))
 
+                resistance_range = ls_chann_settings[i]['resistance_range']
+                ls.channels[i].set_resistance_range(resistance_range)
+                self.log.info("resistance for CH.{channel} set to {res}".format(channel=i, res=resistance_range))
+
                 dwell = ls_chann_settings[i]['dwell']
                 ls.channels[i].set_dwell(dwell)
                 self.log.info("dwell for CH.{channel} is set to {dwell}".format(channel=i, dwell=dwell))


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Allows the user to choose between autorange or a set resistance range for a 372 channel.

## Motivation and Context
Resolves #495 

## How Has This Been Tested?
Tested in the lab on a 372 at Yale 

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project.
- [X] My change requires a change to the documentation.
- [X] I have updated the documentation accordingly.
