### PR TITLE
Bumps suprsync table version

### DIFF
--- a/socs/db/suprsync.py
+++ b/socs/db/suprsync.py
@@ -12,7 +12,7 @@ from sqlalchemy.orm import sessionmaker
 
 from socs.util import get_md5sum
 
-TABLE_VERSION = 0
+TABLE_VERSION = 1
 txaio.use_twisted()
 
 
@@ -79,7 +79,7 @@ class SupRsyncFile(Base):
         timestamp : Float
             Timestamp that file was added to db
         copied : Float, optional
-            Time at which file was transfered
+            Time at which file was transferred
         removed : Float, optional
             Time at which file was removed from local server.
         failed_copy_attempts : Int


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Bumps the table version in suprsync to account for the `ignore` column added in https://github.com/simonsobs/socs/pull/467. 

## Description
<!--- Describe your changes in detail -->
Currently, if you try to run suprsync on an existing db file without altering the table as is shown [here](https://github.com/simonsobs/daq-discussions/discussions/27) the agent will crash. bumping the table version (and changing the table name) should prevent this from crashing while keeping data that was written before the change. Note that any un-copied files that were added before bumping the version will not be copied on their own.

## How Has This Been Tested?
has not been tested yet

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
