### PR TITLE
Sets PID freq to 0 when PMX is turned off

### DIFF
--- a/socs/agents/hwp_supervisor/agent.py
+++ b/socs/agents/hwp_supervisor/agent.py
@@ -558,6 +558,9 @@ class ControlStateMachine:
 
             elif isinstance(self.state, ControlState.PmxOff):
                 self.run_and_validate(clients.pmx.set_off)
+                self.run_and_validate(clients.pid.declare_freq,
+                                      kwargs={'freq': 0})
+                self.run_and_validate(clients.pid.tune_freq)
                 self._set_state(ControlState.WaitForTargetFreq(
                     target_freq=0,
                     freq_tol=self.state.freq_tol,


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Small change to the supervisor that sets the PID freq to zero when you call PmxOff

## Description
<!--- Describe your changes in detail -->
Small change just to ensure you don't leave the PID set to a weird state, and to make it more clear in grafana that things are off.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Mainly to make grafana panels look more consistent

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
Tested on satp1

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
