### PR TITLE
Fix link to docker hub socs image

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -14,7 +14,7 @@ SOCS - Simons Observatory Control System
     :target: https://coveralls.io/github/simonsobs/socs
 
 .. image:: https://img.shields.io/badge/dockerhub-latest-blue
-    :target: https://hub.docker.com/r/simonsobs/ocs/tags
+    :target: https://hub.docker.com/r/simonsobs/socs
 
 .. image:: https://img.shields.io/pypi/v/socs
    :target: https://pypi.org/project/socs/


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
See title.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
I often follow this link and it's pointing currently to the ocs image.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
