### PR TITLE
Add OCSClient crossbar address override to wg kikusui agent

### DIFF
--- a/docs/agents/wiregrid_kikusui.rst
+++ b/docs/agents/wiregrid_kikusui.rst
@@ -42,6 +42,8 @@ An example site-config-file block::
   Communicating device is determined by the ethernet port number of the converter.)
 - encoder-agent is an instance ID of the wiregrid encoder agent (wiregrid-encoder).
   This is necessary to get the position recorded by the encoder for controlling the rotation.
+- crossbar-http is available (but not shown here) and can be used to set the
+  crossbar address used for the OCSClient connection to the encoder agent.
 
 Docker Compose
 ``````````````
@@ -54,6 +56,8 @@ An example docker-compose configuration::
       network_mode: "host"
       command:
         - INSTANCE_ID=wgkikusui
+        - SITE_HUB=ws://127.0.0.1:8001/ws
+        - SITE_HTTP=http://127.0.0.1:8001/call
       volumes:
         - ${OCS_CONFIG_DIR}:/config:ro
         - "<local directory to record log file>:/data/wg-data"

--- a/socs/agents/wiregrid_kikusui/agent.py
+++ b/socs/agents/wiregrid_kikusui/agent.py
@@ -139,7 +139,7 @@ class WiregridKikusuiAgent:
             return False, msg
 
     def _connect_encoder(self):
-        site_http_env = os.env.get("SITE_HTTP")
+        site_http_env = os.environ.get("SITE_HTTP")
         if site_http_env:
             args = ['--site-http', site_http_env]
         if self.crossbar_http is not None:


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
This adds the ability for the Wiregrid Kikusui agent to pull the `SITE_HTTP` environment variable and use it for the `OCSClient` connection to the wiregrid encoder agent. It also adds an argument to the agent that allows overriding the env var.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
At site the docker host running the wiregrid kikusui agent has a host wide configuration in the SCF for the docker network based address for the crossbar server, while the container runs in network mode host and uses the `SITE_HTTP` env var to override the host wide config, allowing the kikusui agent to start.

However, it then crashes when trying to connect a client to interact with the encoder agent because that client connection tries to use the host wide configuration pointing to a name that can't be resolved.

As I write this I realize this could probably also be fixed by putting the internal docker domain name for the crossbar server in the hosts file...I'm going to try that too before merging this.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
This was tested at site.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
