### PR TITLE
SupRsync Stats Bug

### DIFF
--- a/socs/db/suprsync.py
+++ b/socs/db/suprsync.py
@@ -244,7 +244,7 @@ class SupRsyncFilesManager:
         stats = {
             'finalized_until': finalized_until,
             'num_files': len(files),
-            'uncopied_files': len([f for f in files if f.copied is None]),
+            'uncopied_files': num_files_to_copy,
             'last_file_added': last_file_added,
             'last_file_copied': last_file_copied,
         }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Found file trying to figure out what's going on the the LAT finalization at the site

## Motivation and Context
Looks like we were adding up the non-copied files in the way the logic actually works and then weren't actually reporting it. Using this `num_files_to_copy` variable will make the logic on what's going on with the finalization time match the number of files we need to copy number. Note, this won't actually fix the current issue with the LAT times.

## How Has This Been Tested?
I haven't actually tested it because I'm not sure how

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
