### PR TITLE
Small change to make vantage agent more robust to hardware dropouts

### DIFF
--- a/socs/agents/vantagepro2/agent.py
+++ b/socs/agents/vantagepro2/agent.py
@@ -142,7 +142,6 @@ class VantagePro2Agent:
                 except TimeoutError as e:
                     self.log.warn(f"TimeoutError: {e}")
                     self.module = None
-                    time.sleep(30)
                     continue
 
                 self.agent.publish_to_feed('weather_data', data)

--- a/socs/agents/vantagepro2/agent.py
+++ b/socs/agents/vantagepro2/agent.py
@@ -46,7 +46,7 @@ class VantagePro2Agent:
         self.agent.register_feed('weather_data',
                                  record=True,
                                  agg_params=agg_params)
-    
+
     def _initialize_module(self):
         """Initialize the VantagePro2 module."""
         try:
@@ -127,7 +127,7 @@ class VantagePro2Agent:
             while self.take_data:
                 pm.sleep()
 
-                if self.module is None: # Try to re-initialize module if it fails
+                if self.module is None:  # Try to re-initialize module if it fails
                     if not self._initialize_module():
                         time.sleep(30)  # wait 30 sec before trying to re-initialize
                         continue

--- a/socs/agents/vantagepro2/agent.py
+++ b/socs/agents/vantagepro2/agent.py
@@ -37,7 +37,6 @@ class VantagePro2Agent:
             sample_freq = 0.5
         self.sample_freq = sample_freq
 
-        self.initialized = False
         self.take_data = False
 
         # Registers weather data feed
@@ -47,6 +46,17 @@ class VantagePro2Agent:
         self.agent.register_feed('weather_data',
                                  record=True,
                                  agg_params=agg_params)
+    
+    def _initialize_module(self):
+        """Initialize the VantagePro2 module."""
+        try:
+            self.module = VantagePro2(self.port)
+            self.log.info(f"Initialized Vantage Pro2 module: {self.module}")
+            return True
+        except Exception as e:
+            self.log.error(f"Failed to initialize Vantage Pro2 module: {e}")
+            self.module = None
+            return False
 
     @ocs_agent.param('auto_acquire', default=False, type=bool)
     def init(self, session, params=None):
@@ -59,7 +69,7 @@ class VantagePro2Agent:
                 initialization if True. Defaults to False.
 
         """
-        if self.initialized:
+        if self.module is not None:
             return True, "Already Initialized Module"
 
         with self.lock.acquire_timeout(0, job='init') as acquired:
@@ -70,11 +80,7 @@ class VantagePro2Agent:
 
             session.set_status('starting')
 
-            self.module = VantagePro2(self.port)
-            print("Initialized Vantage Pro2 module: {!s}".format(
-                self.module))
-
-        self.initialized = True
+            self._initialize_module()
 
         # Start data acquisition if requested
         if params['auto_acquire']:
@@ -120,12 +126,25 @@ class VantagePro2Agent:
 
             while self.take_data:
                 pm.sleep()
+
+                if self.module is None: # Try to re-initialize module if it fails
+                    if not self._initialize_module():
+                        time.sleep(30)  # wait 30 sec before trying to re-initialize
+                        continue
+
                 data = {
                     'timestamp': time.time(),
                     'block_name': 'weather',
                     'data': {}
                 }
-                data['data'] = self.module.weather_daq()
+                try:
+                    data['data'] = self.module.weather_daq()
+                except TimeoutError as e:
+                    self.log.warn(f"TimeoutError: {e}")
+                    self.module = None
+                    time.sleep(30)
+                    continue
+
                 self.agent.publish_to_feed('weather_data', data)
                 time.sleep(wait_time)
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Some small changes to make sure the Vantage agent is robust to hardware dropouts. 

Unfortunately Weather station boots into a mode where it's uninitialized and returns junk data until someone holds down "Done" for two seconds... @RemingtonGerras do you have any idea if it's possible to automatically bypass this? We should also install batteries in the console regardless to try to avoid drop outs.



## Description
<!--- Describe your changes in detail -->
Makes the `acq` process attempts to re-initizlize connection on timeout

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Required so `acq` can recover after hardware dropout

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
Tested with hardware at site

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
