### PR TITLE
Set M1000 Agent acq session status appropriately

### DIFF
--- a/socs/agents/meinberg_m1000/agent.py
+++ b/socs/agents/meinberg_m1000/agent.py
@@ -412,6 +412,7 @@ class MeinbergM1000Agent:
             reactor.callFromThread(reactor.stop)
             return False, 'acq process failed - No connection to M1000'
 
+        session.set_status('running')
         self.is_streaming = True
 
         while self.is_streaming:


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
This just sets the `acq` process' status to 'running' once a connection is established, just before the acquisition loop occurs.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
@msilvafe pointed out the agent at site was stuck in the 'starting' state.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
It hasn't been tested.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
