### PR TITLE
set acq session status appropriately

### DIFF
--- a/socs/agents/ifm_sbn246_flowmeter/agent.py
+++ b/socs/agents/ifm_sbn246_flowmeter/agent.py
@@ -102,6 +102,8 @@ class FlowmeterAgent:
         """
         pm = Pacemaker(1, quantize=True)
         self.take_data = True
+        session.set_status('running')
+
         while self.take_data:
             pm.sleep()
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Same as #528: Setting the acq process status to 'running' once a connection is established before the acq loop begins.

## Motivation and Context
So the agent doesn't remain in 'start' mode, which triggers alarms

## How Has This Been Tested?
It hasn't.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
