### PR TITLE
Improve ACU scanning fault tolerance and logging

### DIFF
--- a/socs/agents/acu/agent.py
+++ b/socs/agents/acu/agent.py
@@ -1076,6 +1076,10 @@ class ACUAgent:
             if not acquired:
                 return False, f"Operation failed: {self.azel_lock.job} is running."
 
+            self.log.info('Clearing faults to prepare for motion.')
+            yield self.acu_control.clear_faults()
+            yield dsleep(1)
+
             ok, msg = yield self._check_ready_motion(session)
             if not ok:
                 return False, msg
@@ -1434,6 +1438,13 @@ class ACUAgent:
             point_batch_count = scan_upload_len / step_time
 
         session.set_status('running')
+        self.log.info('Scan params: {params}', params=params)
+        self.log.info('The plan: {plan}', plan=plan)
+
+        # Clear faults.
+        self.log.info('Clearing faults to prepare for motion.')
+        yield self.acu_control.clear_faults()
+        yield dsleep(1)
 
         # Verify we're good to move
         ok, msg = yield self._check_ready_motion(session)

--- a/socs/agents/acu/agent.py
+++ b/socs/agents/acu/agent.py
@@ -1120,6 +1120,10 @@ class ACUAgent:
             if not acquired:
                 return False, f"Operation failed: {self.boresight_lock.job} is running."
 
+            self.log.info('Clearing faults to prepare for motion.')
+            yield self.acu_control.clear_faults()
+            yield dsleep(1)
+
             ok, msg = yield self._check_ready_motion(session)
             if not ok:
                 return False, msg

--- a/socs/agents/acu/agent.py
+++ b/socs/agents/acu/agent.py
@@ -1391,7 +1391,7 @@ class ACUAgent:
           Process .stop method is called)..
 
         """
-        log.info('User scan params: {params}', params=params)
+        self.log.info('User scan params: {params}', params=params)
 
         az_endpoint1 = params['az_endpoint1']
         az_endpoint2 = params['az_endpoint2']
@@ -1405,6 +1405,16 @@ class ACUAgent:
             az_speed = self.scan_params['az_speed']
         if az_accel is None:
             az_accel = self.scan_params['az_accel']
+
+        # Do we need to limit the az_accel?  This limit comes from a
+        # maximum jerk parameter; the equation below (without the
+        # empirical 0.85 adjustment) is stated in the SATP ACU ICD.
+        min_turnaround_time = (0.85 * az_speed / 9 * 11.616)**.5
+        max_turnaround_accel = 2 * az_speed / min_turnaround_time
+        if az_accel > max_turnaround_accel:
+            self.log.warn('WARNING: user requested accel=%.2f; limiting to %.2f' %
+                          (az_accel, max_turnaround_accel))
+            az_accel = max_turnaround_accel
 
         # If el is not specified, drop in the current elevation.
         init_el = None


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

A few important things pertinent to constant elevation scanning:
- Limit the turnaround acceleration according to the maximum jerk constraint described in the SATP ICD.
- Log the parameters passed in by the user, and computed params.  For forensic tracking on failed scans.
- Monitor key program track error bits, and state them in the log if they fire during scan.
- Return False from the Process, if it appears to have exited due to error.
- Clear Faults before starting a scan (-- and also before a go_to).

## Motivation and Context

These are all to make real usage smoother, and forensic analysis possible (why didn't the scan several hours ago work?).  And the max jerk constraint basically came out because it was very easy to trigger a "Turnaround time too short" fault.

## How Has This Been Tested?

I developed this actively on SATP2.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
