### PR TITLE
ACU Agent -- two features (LAT support)

### DIFF
--- a/socs/agents/acu/agent.py
+++ b/socs/agents/acu/agent.py
@@ -54,13 +54,12 @@ class ACUAgent:
         startup (bool):
             If True, immediately start the main monitoring processes
             for status and UDP data.
-        ignore_axes (str or list of str):
+        ignore_axes (list of str):
             List of axes to "ignore". "ignore" means that the axis
             will not be commanded.  If a user requests an action that
             would otherwise move the axis, it is not moved but the
             action is assumed to have succeeded.  The values in this
-            list should be drawn from "az", "el", and "third".  A single
-            comma-delimited string (e.g. "az,el" is also accepted.
+            list should be drawn from "az", "el", and "third".
         disable_idle_reset (bool):
             If True, don't auto-start idle_reset process for LAT.
 
@@ -96,8 +95,6 @@ class ACUAgent:
         startup_idle_reset = (self.acu_config['platform'] in ['lat', 'ccat']
                               and not disable_idle_reset)
 
-        if isinstance(ignore_axes, str):
-            ignore_axes = [x.strip() for x in ignore_axes.split(',')]
         if ignore_axes is None:
             ignore_axes = []
         assert all([x in ['az', 'el', 'third'] for x in ignore_axes])
@@ -314,6 +311,7 @@ class ACUAgent:
             },
             "StatusResponseRate": 19.237531827325963,
             "PlatformType": "satp",
+            "IgnoredAxes": [],
             "DefaultScanParams": {
               "az_speed": 2.0,
               "az_accel": 1.0,
@@ -1850,9 +1848,8 @@ def add_agent_args(parser_in=None):
     pgroup.add_argument("--exercise-plan")
     pgroup.add_argument("--no-processes", action='store_true',
                         default=False)
-    pgroup.add_argument("--ignore-axes",
-                        help="Comma-delimited list of axes to ignore "
-                        "(el, az, third).")
+    pgroup.add_argument("--ignore-axes", choices=['el', 'az', 'third'],
+                        nargs='+', help="One or more axes to ignore.")
     pgroup.add_argument("--disable-idle-reset", action='store_true',
                         help="Disable idle_reset, even for LAT.")
     return parser_in


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

1. By passing `--ignore-axis=...`, the agent will decline to command one or more axes, and pretend that all moves on the axis succeed.  This is useful in cases where an axis needs to be disabled for some reason, but you still want to run scans and stuff.
2. The "idle stow" feature of LAT ACU requires using the command interface every minute, to prevent Survival Mode.  This renames the process that does it, and makes sure to start that process if platform is LAT type.  Can be disabled with cmdline option.

## Motivation and Context

Both of these came up on LAT last week.

These changes will remove the need for me to run the LAT agent out of my user dir ... agent config should include args `--ignore-axis el` for now.

## How Has This Been Tested?

I've tested these on SATP2.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
