### PR TITLE
add ping_BBB function in wiregrid_encoder

### DIFF
--- a/docs/agents/wiregrid_encoder.rst
+++ b/docs/agents/wiregrid_encoder.rst
@@ -40,10 +40,12 @@ An example site-config-file block::
 
     {'agent-class': 'WiregridEncoderAgent',
      'instance-id': 'wgencoder',
-     'arguments': [['--port', 50007]]},
+     'arguments': [['--port', 50007],
+                   ['--ip-address', '192.168.11.29']]},
 
 The port is used to receive the data from the BeagleBoneBlack.
 The port number is determined in the script running in the BeagleBoneBlack.
+The IP address is used to ping to the BeagleBoneBlack for connection check.
 
 Docker Compose
 ``````````````

--- a/requirements.txt
+++ b/requirements.txt
@@ -46,6 +46,9 @@ pyepics
 # xy_stage
 xy_stage_control @ git+https://github.com/kmharrington/xy_stage_control.git@main
 
+# wiregrid encoder agent
+ping3
+
 # pysmurf controller
 pysmurf @ git+https://github.com/slaclab/pysmurf.git@main
 sodetlib @ git+https://github.com/simonsobs/sodetlib.git@master

--- a/socs/agents/wiregrid_encoder/agent.py
+++ b/socs/agents/wiregrid_encoder/agent.py
@@ -353,11 +353,11 @@ class WiregridEncoderAgent:
 
         ret = ping(self.ip)
         if ret:
-            return True, 'Successfully ping to the BBB.'
+            return True, f'Successfully ping to the BBB({self.ip}).'
         elif ret is None:
-            return False, 'Failed to ping to the BBB (No response).'
+            return False, f'Failed to ping to the BBB({self.ip}). No response.'
         else:
-            return False, 'Failed to ping to the BBB (Unknown host).'
+            return False, f'Failed to ping to the BBB({self.ip}). Unknown host.'
 
 
 def make_parser(parser=None):
@@ -369,7 +369,7 @@ def make_parser(parser=None):
                         type=int, default=50007,
                         help='Port of the beaglebone '
                              'running wiregrid encoder DAQ')
-    pgroup.add_argument('--ip', dest='ip',
+    pgroup.add_argument('--ip-address', dest='ip_address',
                         type=str, default='192.168.11.29',
                         help='IP address of the beaglebone '
                              'running wiregrid encoder DAQ')
@@ -385,7 +385,7 @@ def main(args=None):
     agent, runner = ocs_agent.init_site_agent(args)
 
     wg_encoder_agent = WiregridEncoderAgent(
-        agent, bbport=args.port, bbip=args.ip)
+        agent, bbport=args.port, bbip=args.ip_address)
 
     agent.register_process('acq',
                            wg_encoder_agent.acq,


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Add ping_BBB() command in the wiregrid_encoder agent.
This function checks the connection to the beagleboneblack for the wiregrid.
It returns True or False.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
This function is useful for the sorunlib script for wiregrid to check the connection to the BBB before the calibration.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
The new function has not been tested yet.
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
The doc of wiregrid_encoder was modified.
In socs/requirements.txt,  `ping3` was added for `ping_BBB()` function.
`--ip-adderss` is added in the arguments for the wiregrid_encoder agent.
The argument should be added also in the `ocs-site-config`.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
