### PR TITLE
Suprsync update tcdirs

### DIFF
--- a/socs/agents/suprsync/agent.py
+++ b/socs/agents/suprsync/agent.py
@@ -140,6 +140,10 @@ class SupRsync:
 
         next_feed_update = 0
 
+        # update tcdirs every six-hours
+        last_tcdir_update = 0
+        tcdir_update_interval = 6*3600
+
         while self.running:
             counters['iterations'] += 1
 
@@ -160,6 +164,12 @@ class SupRsync:
                 counters['errors_nonzero'] += 1
 
             now = time.time()
+
+            if now - last_tcdir_update > tcdir_update_interval:
+                # add timecode-dirs for all files from the last week
+                srfm.create_all_timecode_dirs(
+                    self.archive_name, min_ctime=now - (7*24*3600)
+                )
 
             archive_stats = srfm.get_archive_stats(self.archive_name)
             if archive_stats is not None:

--- a/socs/agents/suprsync/agent.py
+++ b/socs/agents/suprsync/agent.py
@@ -142,7 +142,7 @@ class SupRsync:
 
         # update tcdirs every six-hours
         last_tcdir_update = 0
-        tcdir_update_interval = 6*3600
+        tcdir_update_interval = 6 * 3600
 
         while self.running:
             counters['iterations'] += 1
@@ -169,7 +169,7 @@ class SupRsync:
                 # add timecode-dirs for all files from the last week
                 self.log.info("Creating timecode dirs for recent files.....")
                 srfm.create_all_timecode_dirs(
-                    self.archive_name, min_ctime=now - (7*24*3600)
+                    self.archive_name, min_ctime=now - (7 * 24 * 3600)
                 )
                 self.log.info("Finished creating tcdirs")
                 last_tcdir_update = now

--- a/socs/agents/suprsync/agent.py
+++ b/socs/agents/suprsync/agent.py
@@ -171,6 +171,8 @@ class SupRsync:
                 srfm.create_all_timecode_dirs(
                     self.archive_name, min_ctime=now - (7*24*3600)
                 )
+                self.log.info("Finished creating tcdirs")
+                last_tcdir_update = now
 
             archive_stats = srfm.get_archive_stats(self.archive_name)
             if archive_stats is not None:

--- a/socs/agents/suprsync/agent.py
+++ b/socs/agents/suprsync/agent.py
@@ -167,6 +167,7 @@ class SupRsync:
 
             if now - last_tcdir_update > tcdir_update_interval:
                 # add timecode-dirs for all files from the last week
+                self.log.info("Creating timecode dirs for recent files.....")
                 srfm.create_all_timecode_dirs(
                     self.archive_name, min_ctime=now - (7*24*3600)
                 )

--- a/socs/db/suprsync.py
+++ b/socs/db/suprsync.py
@@ -394,7 +394,7 @@ class SupRsyncFilesManager:
 
         return files
 
-    def get_known_files(self, archive_name, session=None):
+    def get_known_files(self, archive_name, session=None, min_ctime=None):
         """Gets all files.  This can be used to help avoid
         double-registering files.
 
@@ -404,12 +404,18 @@ class SupRsyncFilesManager:
                 Name of archive to pull files from
             session : sqlalchemy session
                 Session to use to query files.
+            min_ctime : float, optional
+
         """
         if session is None:
             session = self.Session()
 
+        if min_ctime is None:
+            min_ctime = 0
+
         query = session.query(SupRsyncFile).filter(
             SupRsyncFile.archive_name == archive_name,
+            SupRsyncFile.timestamp > min_ctime,
         ).order_by(asc(SupRsyncFile.timestamp))
 
         return list(query.all())
@@ -437,9 +443,10 @@ class SupRsyncFilesManager:
         session.add(tcdir)
         return tcdir
 
-    def create_all_timecode_dirs(self, archive_name):
+    def create_all_timecode_dirs(self, archive_name, min_ctime=None):
         with self.Session.begin() as session:
-            files = self.get_known_files(archive_name, session=session)
+            files = self.get_known_files(
+                archive_name, session=session, min_ctime=min_ctime)
             for file in files:
                 self._add_file_tcdir(file, session)
 

--- a/socs/db/suprsync.py
+++ b/socs/db/suprsync.py
@@ -405,6 +405,7 @@ class SupRsyncFilesManager:
             session : sqlalchemy session
                 Session to use to query files.
             min_ctime : float, optional
+                minimum ctime to use when querying files.
 
         """
         if session is None:


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Adds routine in suprsync main function to regularly update timecode-directories for files that have not been added with the `add_file` interface.


## Description
<!--- Describe your changes in detail -->
There is currently an issue with the suprsync finalization, where timecode directories are not being added for files added by the pysmurf-monitor, since it does not use the `add_file` function in suprsync. This fixes that issue, by having the suprsync agents regularly (like every 6 hrs) add the TimecodeDir if it does not exist for any file added in the last week.

## Motivation and Context
Required to fix finalization and smurf bookbinding.

Resolves #562

## How Has This Been Tested?
Tested with smurf-sync on smurf-srv20

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
