### PR TITLE
Add speedrate argument for insert/eject functions in wiregrid_actuator agent

### DIFF
--- a/socs/agents/wiregrid_actuator/agent.py
+++ b/socs/agents/wiregrid_actuator/agent.py
@@ -354,8 +354,8 @@ class WiregridActuatorAgent:
                     'Could not acquire lock'
 
             onoffs = self.actuator.ls.get_onoff(io_name)
-            io_names = self.actuator.ls.get_io_name(io_name)
-            io_labels = self.actuator.ls.get_label(io_name)
+            io_names = self.actuator.ls.io_names
+            io_labels = self.actuator.ls.io_labels
             for i, io_name in enumerate(io_names):
                 io_label = io_labels[i]
                 msg += 'check_limitswitch(): {:10s} ({:20s}) : {}\n'\
@@ -388,8 +388,8 @@ class WiregridActuatorAgent:
                 return False, 'check_stopper(): Could not acquire lock'
 
             onoffs = self.actuator.st.get_onoff(io_name)
-            io_names = self.actuator.st.get_io_name(io_name)
-            io_labels = self.actuator.st.get_label(io_name)
+            io_names = self.actuator.st.io_names
+            io_labels = self.actuator.st.io_labels
             for i, io_name in enumerate(io_names):
                 io_label = io_labels[i]
                 msg += 'check_stopper(): {:10s} ({:20s}) : {}\n'\

--- a/socs/agents/wiregrid_actuator/agent.py
+++ b/socs/agents/wiregrid_actuator/agent.py
@@ -340,7 +340,6 @@ class WiregridActuatorAgent:
         if params is None:
             params = {}
         io_name = params.get('io_name', None)
-        onoffs = []
         msg = ''
         with self.lock.acquire_timeout(timeout=3, job='check_limitswitch') \
                 as acquired:
@@ -353,13 +352,20 @@ class WiregridActuatorAgent:
                     'check_limitswitch(): '\
                     'Could not acquire lock'
 
-            onoffs = self.actuator.ls.get_onoff(io_name)
-            io_names = self.actuator.ls.io_names
-            io_labels = self.actuator.ls.io_labels
-            for i, io_name in enumerate(io_names):
-                io_label = io_labels[i]
+            onoff = self.actuator.ls.get_onoff(io_name)
+
+            if io_name is None:
+                io_name = self.actuator.ls.io_names
+            elif not hasattr(onoff, '__getitem__'):
+                io_name = [io_name]
+                onoff = [onoff]
+
+            label = self.actuator.ls.get_label(io_name)
+
+            for _io_name, _label, _onoff in zip(io_name, label, onoff):
                 msg += 'check_limitswitch(): {:10s} ({:20s}) : {}\n'\
-                    .format(io_name, io_label, 'ON' if onoffs[i] else 'OFF')
+                    .format(_io_name, _label, 'ON' if _onoff else 'OFF')
+
             self.log.info(msg)
             return True, msg
 
@@ -376,7 +382,6 @@ class WiregridActuatorAgent:
         if params is None:
             params = {}
         io_name = params.get('io_name', None)
-        onoffs = []
         msg = ''
         with self.lock.acquire_timeout(timeout=3, job='check_stopper') \
                 as acquired:
@@ -387,13 +392,20 @@ class WiregridActuatorAgent:
                     .format(self.lock.job))
                 return False, 'check_stopper(): Could not acquire lock'
 
-            onoffs = self.actuator.st.get_onoff(io_name)
-            io_names = self.actuator.st.io_names
-            io_labels = self.actuator.st.io_labels
-            for i, io_name in enumerate(io_names):
-                io_label = io_labels[i]
+            onoff = self.actuator.st.get_onoff(io_name)
+
+            if io_name is None:
+                io_name = self.actuator.st.io_names
+            elif not hasattr(onoff, '__getitem__'):
+                io_name = [io_name]
+                onoff = [onoff]
+
+            label = self.actuator.st.get_label(io_name)
+
+            for _io_name, _label, _onoff in zip(io_name, label, onoff):
                 msg += 'check_stopper(): {:10s} ({:20s}) : {}\n'\
-                    .format(io_name, io_label, 'ON' if onoffs[i] else 'OFF')
+                    .format(_io_name, _label, 'ON' if _onoff else 'OFF')
+
             self.log.info(msg)
             return True, msg
 

--- a/socs/agents/wiregrid_actuator/drivers/DigitalIO.py
+++ b/socs/agents/wiregrid_actuator/drivers/DigitalIO.py
@@ -62,7 +62,7 @@ class DigitalIO:
             io_name (str or list): A string of a IO name or list of IO names.
 
         Returns:
-            list or str: A list of True/Falses or a single True/False depending
+            list or bool: A list of True/Falses or a single True/False depending
             on the value of `io_name`. If `io_name` is None, return a list of
             the ON/OFFs for all the IOs. If `io_name` is a list, return a list
             of the ON/OFFs for asked IOs.  If `io_name` is a string (one IO),
@@ -99,7 +99,7 @@ class DigitalIO:
     def get_label(self, io_name):
         if io_name is None:
             label = self.io_labels
-        elif isinstance(io_name, list):
+        elif hasattr(io_name, '__getitem__'):
             if not all([(name in self.io_names) for name in io_name]):
                 msg = \
                     'DigitalIO[{}]:get_label(): ERROR!: '\
@@ -111,7 +111,7 @@ class DigitalIO:
                     + 'DigitalIO[{}]:get_label():     '\
                       'Asked IO names    = {}'.format(self.name, io_name)
                 raise ValueError(msg)
-            label = [self.io_indices[name] for name in io_name]
+            label = [self.io_labels[self.io_indices[name]] for name in io_name]
         else:
             if not (io_name in self.io_names):
                 msg = \
@@ -121,7 +121,7 @@ class DigitalIO:
                     + 'DigitalIO[{}]:get_label():     '\
                       'Assigned IO names = {}'.format(self.name, self.io_names)
                 raise ValueError(msg)
-            label = self.io_label(io_name)
+            label = self.io_labels[self.io_indices[io_name]]
         return label
 
     def _set_onoff(self, onoff, io_name):


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Add `speedrate` argument for `insert`/`eject` functions in `wiregrid_actuator` agent and set the limitation of the parameter from 0.0 to 5.0.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
The default value of `speedrate` is 1.0 and changing `speedrate` allows us to do fast inserting or ejecting, which is useful to check the difference between the detector responses with and without the wiregrid. Setting the `speedrate` to 5.0, the time duration for each inserting or ejecting would be about 30 sec which is three times shorter than that in default setting (`speedrate`=1.0).

**CAUTION!! \
`speedrate` > 1.0 must not be selected if elevation is not 90 deg.** 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
It was tested in Kyoto using wiregrid.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
