### PR TITLE
Add `speedrate` parameter for `insert()` / `eject()` functions in `wiregrid_actuator`

### DIFF
--- a/docs/agents/wiregrid_actuator.rst
+++ b/docs/agents/wiregrid_actuator.rst
@@ -77,10 +77,6 @@ The main functions are ``insert()`` and ``eject()``.
 In the both of the functions, after the inserting/ejecting, the stopper locks the actuators again.
 However, the motor power is not turned ON or OFF during the both functions.
 
-The parameter details are here:
-- speedrate: Actuator speed rate [0.0, 5.0] (default: 0.2)
-  DO NOT use speedrate > 1.0 if el != 90 deg!!
-
 **Test Functions**
  - check_limitswitch(): Check ON/OFF of the limit switches
  - check_stopper(): Check ON/OFF (lock/unlock) of the stoppers
@@ -103,7 +99,9 @@ The parameter details are here:
 
 - distance: Actuator moving distance [mm] (default: 10)
 - speedrate: Actuator speed rate [0.0, 5.0] (default: 0.2)
-  DO NOT use speedrate > 1.0 if el != 90 deg!!
+
+.. warning::
+  DO NOT use ``speedrate > 1.0`` if ``el != 90 deg``!
 
 
 Hardware Configurations

--- a/docs/agents/wiregrid_actuator.rst
+++ b/docs/agents/wiregrid_actuator.rst
@@ -77,6 +77,10 @@ The main functions are ``insert()`` and ``eject()``.
 In the both of the functions, after the inserting/ejecting, the stopper locks the actuators again.
 However, the motor power is not turned ON or OFF during the both functions.
 
+The parameter details are here:
+- speedrate: Actuator speed rate [0.0, 5.0] (default: 0.2)
+  DO NOT use speedrate > 1.0 if el != 90 deg!!
+
 **Test Functions**
  - check_limitswitch(): Check ON/OFF of the limit switches
  - check_stopper(): Check ON/OFF (lock/unlock) of the stoppers
@@ -98,7 +102,8 @@ In the test mode, you can choose the moving distance [mm] and speed rate.
 The parameter details are here:
 
 - distance: Actuator moving distance [mm] (default: 10)
-- speedrate: Actuator speed rate [0.0, 1.0] (default: 0.2)
+- speedrate: Actuator speed rate [0.0, 5.0] (default: 0.2)
+  DO NOT use speedrate > 1.0 if el != 90 deg!!
 
 
 Hardware Configurations

--- a/socs/agents/wiregrid_actuator/agent.py
+++ b/socs/agents/wiregrid_actuator/agent.py
@@ -278,6 +278,7 @@ class WiregridActuatorAgent:
 
     @ocs_agent.param('speedrate', default=1.0, type=float,
                      check=lambda x: 0.0 < x <= 5.0)
+    @ocs_agent.param('high_speed', default=False, type=bool)
     def insert(self, session, params=None):
         """insert()
 
@@ -287,9 +288,13 @@ class WiregridActuatorAgent:
         Parameters:
             speedrate (float): Actuator speed rate [0.0, 5.0] (default: 1.0)
                 DO NOT use speedrate > 1.0 if el != 90 deg!!
+            high_speed (bool): If False, speedrate is limited to 1.0
         """
         # Get parameters
         speedrate = params.get('speedrate')
+        high_speed = params.get('high_speed')
+        if not high_speed:
+            speedrate = min(speedrate, 1.0)
         self.log.info('insert(): set speed rate = {}'
                       .format(speedrate))
 
@@ -314,6 +319,7 @@ class WiregridActuatorAgent:
 
     @ocs_agent.param('speedrate', default=1.0, type=float,
                      check=lambda x: 0.0 < x <= 5.0)
+    @ocs_agent.param('high_speed', default=False, type=bool)
     def eject(self, session, params=None):
         """eject()
 
@@ -323,9 +329,13 @@ class WiregridActuatorAgent:
         Parameters:
             speedrate (float): Actuator speed rate [0.0, 5.0] (default: 1.0)
                 DO NOT use speedrate > 1.0 if el != 90 deg!!
+            high_speed (bool): If False, speedrate is limited to 1.0
         """
         # Get parameters
         speedrate = params.get('speedrate')
+        high_speed = params.get('high_speed')
+        if not high_speed:
+            speedrate = min(speedrate, 1.0)
         self.log.info('eject(): set speed rate = {}'
                       .format(speedrate))
 
@@ -472,6 +482,7 @@ class WiregridActuatorAgent:
     @ocs_agent.param('distance', default=10., type=float)
     @ocs_agent.param('speedrate', default=0.2, type=float,
                      check=lambda x: 0.0 < x <= 5.0)
+    @ocs_agent.param('high_speed', default=False, type=bool)
     def insert_test(self, session, params):
         """insert_test(distance=10, speedrate=0.1)
 
@@ -482,10 +493,14 @@ class WiregridActuatorAgent:
             distance (float): Actuator moving distance [mm] (default: 10)
             speedrate (float): Actuator speed rate [0.0, 5.0] (default: 0.2)
                 DO NOT use speedrate > 1.0 if el != 90 deg!!
+            high_speed (bool): If False, speedrate is limited to 1.0
         """
         # Get parameters
         distance = params.get('distance')
         speedrate = params.get('speedrate')
+        high_speed = params.get('high_speed')
+        if not high_speed:
+            speedrate = min(speedrate, 1.0)
         self.log.info('insert_test(): set distance   = {} mm'
                       .format(distance))
         self.log.info('insert_test(): set speed rate = {}'
@@ -524,6 +539,7 @@ class WiregridActuatorAgent:
     @ocs_agent.param('distance', default=10., type=float)
     @ocs_agent.param('speedrate', default=0.2, type=float,
                      check=lambda x: 0.0 < x <= 5.0)
+    @ocs_agent.param('high_speed', default=False, type=bool)
     def eject_test(self, session, params):
         """eject_test(distance=10, speedrate=0.1)
 
@@ -534,10 +550,14 @@ class WiregridActuatorAgent:
             distance (float): Actuator moving distance [mm] (default: 10)
             speedrate (float): Actuator speed rate [0.0, 5.0] (default: 0.2)
                 DO NOT use speedrate > 1.0 if el != 90 deg!!
+            high_speed (bool): If False, speedrate is limited to 1.0
         """
         # Get parameters
         distance = params.get('distance', 10)
         speedrate = params.get('speedrate', 0.2)
+        high_speed = params.get('high_speed')
+        if not high_speed:
+            speedrate = min(speedrate, 1.0)
         self.log.info('eject_test(): set distance   = {} mm'
                       .format(distance))
         self.log.info('eject_test(): set speed rate = {}'

--- a/socs/agents/wiregrid_actuator/agent.py
+++ b/socs/agents/wiregrid_actuator/agent.py
@@ -276,13 +276,23 @@ class WiregridActuatorAgent:
     ##################
     # Return: status(True or False), message
 
+    @ocs_agent.param('speedrate', default=1.0, type=float,
+                     check=lambda x: 0.0 < x <= 5.0)
     def insert(self, session, params=None):
         """insert()
 
         **Task** - Insert the wire-grid into the forebaffle interface above the
         SAT.
 
+        Parameters:
+            speedrate (float): Actuator speed rate [0.0, 5.0] (default: 1.0)
+                DO NOT use speedrate > 1.0 if el != 90 deg!!
         """
+        # Get parameters
+        speedrate = params.get('speedrate')
+        self.log.info('insert(): set speed rate = {}'
+                      .format(speedrate))
+
         with self.lock.acquire_timeout(timeout=3, job='insert') as acquired:
             if not acquired:
                 self.log.warn(
@@ -293,22 +303,32 @@ class WiregridActuatorAgent:
             # Wait for a second before moving
             time.sleep(1)
             # Moving commands
-            ret, msg = self._insert(920, 1.0)
+            ret, msg = self._insert(920, speedrate)
             if not ret:
                 msg = 'insert(): '\
-                      'ERROR!: Failed insert() in _insert(850,1.0) | {}'\
-                      .format(msg)
+                      'ERROR!: Failed insert() in _insert(920,{}) | {}'\
+                      .format(speedrate, msg)
                 self.log.error(msg)
                 return False, msg
             return True, 'insert(): Successfully finish!'
 
+    @ocs_agent.param('speedrate', default=1.0, type=float,
+                     check=lambda x: 0.0 < x <= 5.0)
     def eject(self, session, params=None):
         """eject()
 
         **Task** - Eject the wire-grid from the forebaffle interface above the
         SAT.
 
+        Parameters:
+            speedrate (float): Actuator speed rate [0.0, 5.0] (default: 1.0)
+                DO NOT use speedrate > 1.0 if el != 90 deg!!
         """
+        # Get parameters
+        speedrate = params.get('speedrate')
+        self.log.info('eject(): set speed rate = {}'
+                      .format(speedrate))
+
         with self.lock.acquire_timeout(timeout=3, job='eject') as acquired:
             if not acquired:
                 self.log.warn(
@@ -319,10 +339,10 @@ class WiregridActuatorAgent:
             # Wait for a second before moving
             time.sleep(1)
             # Moving commands
-            ret, msg = self._eject(920, 1.0)
+            ret, msg = self._eject(920, speedrate)
             if not ret:
-                msg = 'eject(): ERROR!: Failed in _eject(850,1.0) | {}'\
-                    .format(msg)
+                msg = 'eject(): ERROR!: Failed in _eject(920,{}) | {}'\
+                    .format(speedrate, msg)
                 self.log.error(msg)
                 return False, msg
             return True, 'eject(): Successfully finish!'
@@ -451,7 +471,7 @@ class WiregridActuatorAgent:
 
     @ocs_agent.param('distance', default=10., type=float)
     @ocs_agent.param('speedrate', default=0.2, type=float,
-                     check=lambda x: 0.0 < x <= 1.0)
+                     check=lambda x: 0.0 < x <= 5.0)
     def insert_test(self, session, params):
         """insert_test(distance=10, speedrate=0.1)
 
@@ -460,7 +480,8 @@ class WiregridActuatorAgent:
 
         Parameters:
             distance (float): Actuator moving distance [mm] (default: 10)
-            speedrate (float): Actuator speed rate [0.0, 1.0] (default: 0.2)
+            speedrate (float): Actuator speed rate [0.0, 5.0] (default: 0.2)
+                DO NOT use speedrate > 1.0 if el != 90 deg!!
         """
         # Get parameters
         distance = params.get('distance')
@@ -502,7 +523,7 @@ class WiregridActuatorAgent:
 
     @ocs_agent.param('distance', default=10., type=float)
     @ocs_agent.param('speedrate', default=0.2, type=float,
-                     check=lambda x: 0.0 < x <= 1.0)
+                     check=lambda x: 0.0 < x <= 5.0)
     def eject_test(self, session, params):
         """eject_test(distance=10, speedrate=0.1)
 
@@ -510,8 +531,9 @@ class WiregridActuatorAgent:
         above the SAT with a small distance.
 
         Parameters:
-            distance:  Actuator moving distance [mm] (default: 10)
-            speedrate: Actuator speed rate [0.0, 1.0] (default: 0.2)
+            distance (float): Actuator moving distance [mm] (default: 10)
+            speedrate (float): Actuator speed rate [0.0, 5.0] (default: 0.2)
+                DO NOT use speedrate > 1.0 if el != 90 deg!!
         """
         # Get parameters
         distance = params.get('distance', 10)

--- a/socs/agents/wiregrid_actuator/agent.py
+++ b/socs/agents/wiregrid_actuator/agent.py
@@ -280,15 +280,16 @@ class WiregridActuatorAgent:
                      check=lambda x: 0.0 < x <= 5.0)
     @ocs_agent.param('high_speed', default=False, type=bool)
     def insert(self, session, params=None):
-        """insert()
+        """insert(speedrate=1.0, high_speed=False)
 
         **Task** - Insert the wire-grid into the forebaffle interface above the
         SAT.
 
         Parameters:
             speedrate (float): Actuator speed rate [0.0, 5.0] (default: 1.0)
-                DO NOT use speedrate > 1.0 if el != 90 deg!!
-            high_speed (bool): If False, speedrate is limited to 1.0
+                DO NOT use ``speedrate > 1.0`` if ``el != 90 deg``!
+            high_speed (bool): If False, speedrate is limited to 1.0. Defaults
+                to False.
         """
         # Get parameters
         speedrate = params.get('speedrate')
@@ -321,15 +322,16 @@ class WiregridActuatorAgent:
                      check=lambda x: 0.0 < x <= 5.0)
     @ocs_agent.param('high_speed', default=False, type=bool)
     def eject(self, session, params=None):
-        """eject()
+        """eject(speedrate=1.0, high_speed=False)
 
         **Task** - Eject the wire-grid from the forebaffle interface above the
         SAT.
 
         Parameters:
             speedrate (float): Actuator speed rate [0.0, 5.0] (default: 1.0)
-                DO NOT use speedrate > 1.0 if el != 90 deg!!
-            high_speed (bool): If False, speedrate is limited to 1.0
+                DO NOT use ``speedrate > 1.0`` if ``el != 90 deg``!
+            high_speed (bool): If False, speedrate is limited to 1.0. Defaults
+                to False.
         """
         # Get parameters
         speedrate = params.get('speedrate')
@@ -484,7 +486,7 @@ class WiregridActuatorAgent:
                      check=lambda x: 0.0 < x <= 5.0)
     @ocs_agent.param('high_speed', default=False, type=bool)
     def insert_test(self, session, params):
-        """insert_test(distance=10, speedrate=0.1)
+        """insert_test(distance=10, speedrate=0.2, high_speed=False)
 
         **Task** - Insert slowly the wire-grid into the forebaffle interface
         above the SAT with a small distance.
@@ -492,8 +494,9 @@ class WiregridActuatorAgent:
         Parameters:
             distance (float): Actuator moving distance [mm] (default: 10)
             speedrate (float): Actuator speed rate [0.0, 5.0] (default: 0.2)
-                DO NOT use speedrate > 1.0 if el != 90 deg!!
-            high_speed (bool): If False, speedrate is limited to 1.0
+                DO NOT use ``speedrate > 1.0`` if ``el != 90 deg``!
+            high_speed (bool): If False, speedrate is limited to 1.0. Defaults
+                to False.
         """
         # Get parameters
         distance = params.get('distance')
@@ -541,7 +544,7 @@ class WiregridActuatorAgent:
                      check=lambda x: 0.0 < x <= 5.0)
     @ocs_agent.param('high_speed', default=False, type=bool)
     def eject_test(self, session, params):
-        """eject_test(distance=10, speedrate=0.1)
+        """eject_test(distance=10, speedrate=0.2, high_speed=False)
 
         **Task** - Eject slowly the wire-grid from the forebaffle interface
         above the SAT with a small distance.
@@ -549,8 +552,9 @@ class WiregridActuatorAgent:
         Parameters:
             distance (float): Actuator moving distance [mm] (default: 10)
             speedrate (float): Actuator speed rate [0.0, 5.0] (default: 0.2)
-                DO NOT use speedrate > 1.0 if el != 90 deg!!
-            high_speed (bool): If False, speedrate is limited to 1.0
+                DO NOT use ``speedrate > 1.0`` if ``el != 90 deg``!
+            high_speed (bool): If False, speedrate is limited to 1.0. Defaults
+                to False.
         """
         # Get parameters
         distance = params.get('distance', 10)


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Add `speedrate` argument for `insert()`/`eject()` functions in `wiregrid_actuator` agent and set the limitation of the parameter from 0.0 to 5.0.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
The default value of `speedrate` is 1.0 and changing `speedrate` allows us to do fast inserting or ejecting, which is useful to check the difference between the detector responses with and without the wiregrid. Setting the `speedrate` to 5.0, the time duration for each inserting or ejecting would be about 30 sec which is three times shorter than that in default setting (`speedrate`=1.0).

**CAUTION!! \
`speedrate` > 1.0 must not be selected if elevation is not 90 deg.** 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
It was tested in Kyoto using wiregrid.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
