### PR TITLE
Adds except for caget failure

### DIFF
--- a/docs/agents/pysmurf-controller.rst
+++ b/docs/agents/pysmurf-controller.rst
@@ -33,6 +33,12 @@ These can be installed via pip:
     $ python -m pip install 'sodetlib @ git+https://github.com/simonsobs/sodetlib.git@master'
     $ python -m pip install 'sotodlib @ git+https://github.com/simonsobs/sotodlib.git@master'
 
+Additionally, ``socs`` should be installed with the ``pysmurf`` group:
+
+.. code-block:: bash
+
+    $ pip install -U socs[pysmurf]
+
 Configuration File Examples
 -----------------------------------
 

--- a/docs/user/installation.rst
+++ b/docs/user/installation.rst
@@ -30,6 +30,8 @@ The different groups, and the agents they provide dependencies for are:
      - Magpie Agent
    * - ``pfeiffer``
      - Pfeiffer TC 400 Agent
+   * - ``pysmurf``
+     - Pysmurf Controller Agent
    * - ``smurf_sim``
      - SMuRF File Emulator, SMuRF Stream Simulator
    * - ``synacc``

--- a/requirements.txt
+++ b/requirements.txt
@@ -35,6 +35,7 @@ pandas
 pfeiffer-vacuum-protocol==0.4
 
 # pysmurf controller
+pyepics
 pysmurf @ git+https://github.com/slaclab/pysmurf.git@main
 sodetlib @ git+https://github.com/simonsobs/sodetlib.git@master
 sotodlib @ git+https://github.com/simonsobs/sotodlib.git@master

--- a/setup.py
+++ b/setup.py
@@ -37,11 +37,12 @@ magpie_deps = [
 pfeiffer_deps = ['pfeiffer-vacuum-protocol==0.4']
 
 # Pysmurf Controller Agent
-# pysmurf_deps = [
-#     'pysmurf @ git+https://github.com/slaclab/pysmurf.git@main',
-#     'sodetlib @ git+https://github.com/simonsobs/sodetlib.git@master',
-#     'sotodlib @ git+https://github.com/simonsobs/sotodlib.git@master',
-# ]
+pysmurf_deps = [
+    'pyepics',
+    # 'pysmurf @ git+https://github.com/slaclab/pysmurf.git@main',
+    # 'sodetlib @ git+https://github.com/simonsobs/sodetlib.git@master',
+    # 'sotodlib @ git+https://github.com/simonsobs/sotodlib.git@master',
+]
 
 # SMuRF File Emulator, SMuRF Stream Simulator
 smurf_sim_deps = ['so3g']
@@ -60,7 +61,7 @@ timing_master_deps = ['pyepics']
 # Note: Not including the holograph deps, which are Python 3.8 only. Also not
 # including any dependencies with only direct references.
 all_deps = acu_deps + labjack_deps + magpie_deps + pfeiffer_deps + \
-    smurf_sim_deps + synacc_deps + timing_master_deps
+    pysmurf_deps + smurf_sim_deps + synacc_deps + timing_master_deps
 all_deps = list(set(all_deps))
 
 setup(
@@ -119,7 +120,7 @@ setup(
         'labjack': labjack_deps,
         'magpie': magpie_deps,
         'pfeiffer': pfeiffer_deps,
-        # 'pysmurf': pysmurf_deps,
+        'pysmurf': pysmurf_deps,
         'smurf_sim': smurf_sim_deps,
         'synacc': synacc_deps,
         'timing_master': timing_master_deps,

--- a/socs/agents/pysmurf_controller/agent.py
+++ b/socs/agents/pysmurf_controller/agent.py
@@ -7,12 +7,12 @@ from twisted.python.failure import Failure
 
 matplotlib.use('Agg')
 import argparse
-import epics
 import os
 import sys
 import time
 from typing import Optional
 
+import epics
 import numpy as np
 import sodetlib as sdl
 from ocs import ocs_agent, site_config

--- a/socs/agents/pysmurf_controller/agent.py
+++ b/socs/agents/pysmurf_controller/agent.py
@@ -7,6 +7,7 @@ from twisted.python.failure import Failure
 
 matplotlib.use('Agg')
 import argparse
+import epics
 import os
 import sys
 import time
@@ -316,7 +317,7 @@ class PysmurfController:
                     stream_id=cfg.stream_id,
                 )
                 session.data.update(d)
-            except RuntimeError:
+            except (RuntimeError, epics.ca.ChannelAccessGetFailure):
                 self.log.warn("Could not connect to epics server! Waiting and "
                               "then trying again")
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Adds exception for epics channel access get failure in pysmurf-controller check-state. I believe this should make the check-state function more robust by preventing the behavior seen in #575 .

## Description
<!--- Describe your changes in detail -->
Excepts caget failures in check_state

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
#575 

<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
Not tested yet

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
