### PR TITLE
add timeout exception error and timeout vals

### DIFF
--- a/socs/agents/ucsc_radiometer/agent.py
+++ b/socs/agents/ucsc_radiometer/agent.py
@@ -69,12 +69,16 @@ class UCSCRadiometerAgent:
 
         while self.take_data:
             try:
-                r = requests.get(self.url)
+                r = requests.get(self.url, timeout=6)
             except ValueError:
                 pm.sleep()
                 continue
-            except requests.exceptions.ConnectionError:
-                self.log.warn("Unable to connect to radiometer server. Connection closed. Trying again..")
+            except requests.exceptions.ConnectionError as e:
+                self.log.warn(f"Connection error occured: {e}")
+                pm.sleep()
+                continue
+            except requests.exceptions.Timeout as e:
+                self.log.warn(f"Timeout exception occurred: {e}")
                 pm.sleep()
                 continue
             data = r.json()


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Through debugging this agent in the `daq-dev` environment, I came across a timeout exception that occurs in the radiometer agent. This won't solve our current problem, as that issue is related to the CLASS server connection. But this exception adds a bit more robustness to the agent. Also changed the ConnectionError log message to output the specific error rather than a summary.

## How Has This Been Tested?
Has been tested on the CLASS server in the `daq-dev` environment.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
