### PR TITLE
Suprsync shouldn't try to copy ignored files

### DIFF
--- a/socs/db/suprsync.py
+++ b/socs/db/suprsync.py
@@ -348,7 +348,7 @@ class SupRsyncFilesManager:
             SupRsyncFile.removed == None,  # noqa: E711
             SupRsyncFile.archive_name == archive_name,
             SupRsyncFile.failed_copy_attempts < max_copy_attempts,
-            SupRsyncFile.ignore == False,
+            SupRsyncFile.ignore == False,  # noqa: E712
         )
 
         files = []

--- a/socs/db/suprsync.py
+++ b/socs/db/suprsync.py
@@ -348,7 +348,7 @@ class SupRsyncFilesManager:
             SupRsyncFile.removed == None,  # noqa: E711
             SupRsyncFile.archive_name == archive_name,
             SupRsyncFile.failed_copy_attempts < max_copy_attempts,
-            SupRsyncFile.ignore is False,
+            SupRsyncFile.ignore == False,
         )
 
         files = []

--- a/socs/db/suprsync.py
+++ b/socs/db/suprsync.py
@@ -347,7 +347,8 @@ class SupRsyncFilesManager:
         query = session.query(SupRsyncFile).filter(
             SupRsyncFile.removed == None,  # noqa: E711
             SupRsyncFile.archive_name == archive_name,
-            SupRsyncFile.failed_copy_attempts < max_copy_attempts
+            SupRsyncFile.failed_copy_attempts < max_copy_attempts,
+            SupRsyncFile.ignore is False,
         )
 
         files = []


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Changes suprsync get_copyable_files so that doesn't include ignored files.

## Description
Changes suprsync get_copyable_files so that doesn't include ignored files.

## Motivation and Context
We don't want to attempt to copy bad files.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
Not tested yet

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
