### PR TITLE
ACU: permit scans on LAT even when Sun Avoidance is not to be enabled

### DIFF
--- a/socs/agents/acu/agent.py
+++ b/socs/agents/acu/agent.py
@@ -40,11 +40,18 @@ DEFAULT_SCAN_PARAMS = {
 }
 
 
-#: Default Sun avoidance params by platform type (enabled, policy)
+#: Default Sun avoidance params by platform type (enabled, policy). If
+#: either of escape *or* monitoring is enabled, then the full policy
+#: must be specified.
 SUN_CONFIGS = {
     'ccat': {
         'enabled': False,
-        'policy': {},
+        'policy': {
+            'exclusion_radius': 20,
+            'el_horizon': 10,
+            'min_sun_time': 1800,
+            'response_time': 7200,
+        },
     },
     'satp': {
         'enabled': True,

--- a/socs/agents/acu/agent.py
+++ b/socs/agents/acu/agent.py
@@ -2208,6 +2208,8 @@ class ACUAgent:
 
             yield dsleep(1)
 
+        return True, 'monitor_sun exited cleanly.'
+
     @ocs_agent.param('reset', type=bool, default=None)
     @ocs_agent.param('enable', type=bool, default=None)
     @ocs_agent.param('temporary_disable', type=float, default=None)


### PR DESCRIPTION
## Description

Adds basic Sun-safety "policy" for the LAT, even though avoidance won't be enabled for now.  Without this the monitor_sun process just crashes.

Also makes sure that `_check_scan_sunsafe` short-circuits to True when avoidance is disabled (and to False if the map is not valid).  This means that a sun-safety policy is not needed, if avoidance is disabled.  The monitor_sun process will not be runnable, but that's ok.

## Motivation and Context

LAT could not scan; this was a bug.

## How Has This Been Tested?

Tested on LAT in a few different configs.  This should not affect how SATPs run.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
