### PR TITLE
Restart UPS Agent every 60 minutes

### DIFF
--- a/docs/agents/ups.rst
+++ b/docs/agents/ups.rst
@@ -31,10 +31,13 @@ using all of the available arguments::
        'arguments': [['--address', '10.10.10.50'],
                      ['--port', 161],
                      ['--mode', 'acq'],
-                     ['--snmp-version', 1]]},
+                     ['--snmp-version', 1],
+                     ['--restart-time', 60]]},
 
 .. note::
     The ``--address`` argument should be the address of the UPS on the network.
+    The ``--restart-time`` argument should be set to number of minutes before
+    exiting the agent. Setting to 0 (default) will not exit the agent.
 
 Docker Compose
 ``````````````
@@ -53,12 +56,11 @@ example docker-compose service configuration is shown here::
       - SITE_HUB=ws://127.0.0.1:8001/ws
       - SITE_HTTP=http://127.0.0.1:8001/call
       - LOGLEVEL=info
-    restart: unless-stopped
 
 
 The ``LOGLEVEL`` environment variable can be used to set the log level for
 debugging. The default level is "info".
-Since the agent exits in 60 minutes, we must set ``restart: unless-stopped``
+If not using HostManager, we must set ``restart: unless-stopped``
 to automatically restart the docker container.
 
 Description

--- a/docs/agents/ups.rst
+++ b/docs/agents/ups.rst
@@ -53,10 +53,13 @@ example docker-compose service configuration is shown here::
       - SITE_HUB=ws://127.0.0.1:8001/ws
       - SITE_HTTP=http://127.0.0.1:8001/call
       - LOGLEVEL=info
+    restart: unless-stopped
 
 
 The ``LOGLEVEL`` environment variable can be used to set the log level for
 debugging. The default level is "info".
+Since the agent exits in 60 minutes, we must set ``restart: unless-stopped``
+to automatically restart the docker container.
 
 Description
 -----------

--- a/socs/agents/ups/agent.py
+++ b/socs/agents/ups/agent.py
@@ -440,7 +440,7 @@ class UPSAgent:
         # Exit agent to release memory
         # Add "restart: unless-stopped" to docker-compose to automatically restart container
         if ((not params['test_mode']) and (timeout != 0) and (self.is_streaming)):
-            self.log.info(f"{timeout} minutes have elasped. Exiting agent.")
+            self.log.info(f"{self.restart} minutes have elasped. Exiting agent.")
             os.kill(os.getppid(), signal.SIGTERM)
 
         return True, "Finished Recording"

--- a/socs/agents/ups/agent.py
+++ b/socs/agents/ups/agent.py
@@ -438,8 +438,9 @@ class UPSAgent:
 
         # Exit agent to release memory
         # Add "restart: unless-stopped" to docker-compose to automatically restart container
-        self.log.info('60 minutes have elasped. Exiting agent.')
-        os.kill(os.getppid(), signal.SIGHUP)
+        if not params['test_mode']:
+            self.log.info('60 minutes have elasped. Exiting agent.')
+            os.kill(os.getppid(), signal.SIGHUP)
 
         return True, "Finished Recording"
 

--- a/socs/agents/ups/agent.py
+++ b/socs/agents/ups/agent.py
@@ -312,7 +312,7 @@ class UPSAgent:
         self.is_streaming = True
         timeout = time.time() + 60 * self.restart  # exit loop after self.restart minutes
         while self.is_streaming:
-            if ((timeout != 0) and (time.time() > timeout)):
+            if ((self.restart != 0) and (time.time() > timeout)):
                 break
             yield dsleep(1)
             if not self.connected:

--- a/socs/agents/ups/agent.py
+++ b/socs/agents/ups/agent.py
@@ -1,7 +1,7 @@
 import argparse
 import os
-import time
 import signal
+import time
 
 import txaio
 from autobahn.twisted.util import sleep as dsleep
@@ -309,7 +309,7 @@ class UPSAgent:
 
         session.set_status('running')
         self.is_streaming = True
-        timeout = time.time() + 60*60 # exit loop in 60 minutes
+        timeout = time.time() + 60 * 60  # exit loop in 60 minutes
         while self.is_streaming:
             if time.time() > timeout:
                 break


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Break the acq process loop and exit the agent after 60 minutes. Must add `restart: unless-stopped` to docker-compose file to automatically restart the docker container everytime this occurs.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Temporary fix for UPS agent which is the biggest contributor to high memory usage among site agents. This releases that memory by exiting the agent completely, which is what we've been doing manually. A fix to pysnmp, by switching to using asyncio, will come later.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
Tested in lab

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
