### PR TITLE
Make hwp_pid more robust

### DIFF
--- a/socs/agents/hwp_pid/agent.py
+++ b/socs/agents/hwp_pid/agent.py
@@ -51,7 +51,7 @@ class HWPPIDAgent:
             self.log.info("Connection already initialized. Returning...")
             return True, "Connection already initialized"
 
-        with self.lock.acquire_timeout(0, job='init_connection') as acquired:
+        with self.lock.acquire_timeout(10, job='init_connection') as acquired:
             if not acquired:
                 self.log.warn(
                     'Could not run init_connection because {} is already running'.format(self.lock.job))
@@ -273,7 +273,7 @@ class HWPPIDAgent:
                  'last_updated': 1649085992.719602}
 
         """
-        with self.lock.acquire_timeout(timeout=0, job='acq') as acquired:
+        with self.lock.acquire_timeout(timeout=10, job='acq') as acquired:
             if not acquired:
                 self.log.warn('Could not start iv acq because {} is already running'
                               .format(self.lock.job))
@@ -314,7 +314,7 @@ class HWPPIDAgent:
                                 'direction': direction,
                                 'last_updated': time.time()}
 
-                time.sleep(1)
+                time.sleep(5)
 
         self.agent.feeds['hwppid'].flush_buffer()
         return True, 'Acqusition exited cleanly'


### PR DESCRIPTION
Make hwp_pid more robust

## Description
To make hwp_pid more robust, made timeout longer and sampling rate lower.
Any other suggestions of modification is very welcomed.

## Motivation and Context
We observe so many timeout in satp3 hwp_pid. Especially when house keeping data rate increases (when hwp spin fast).
![2023-12-08 171335](https://github.com/simonsobs/socs/assets/38639108/b7352048-2e54-491e-9258-4f2e9dfe2a72)

## How Has This Been Tested?
I would like to test the effect of this modifications.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
