### PR TITLE
Adds HWPPCUAgent to plugin file

### DIFF
--- a/socs/agents/ocs_plugin_so.py
+++ b/socs/agents/ocs_plugin_so.py
@@ -20,6 +20,7 @@ for n, f in [
         ('FPGAAgent', 'holo_fpga/agent.py'),
         ('FTSAerotechAgent', 'fts_aerotech/agent.py'),
         ('HWPBBBAgent', 'hwp_encoder/agent.py'),
+        ('HWPPCUAgent', 'hwp_pcu/agent.py'),
         ('HWPPicoscopeAgent', 'hwp_picoscope/agent.py'),
         ('HWPPIDAgent', 'hwp_pid/agent.py'),
         ('HWPPMXAgent', 'hwp_pmx/agent.py'),

--- a/socs/plugin.py
+++ b/socs/plugin.py
@@ -11,6 +11,7 @@ agents = {
     'GeneratorAgent': {'module': 'socs.agents.generator.agent', 'entry_point': 'main'},
     'HWPBBBAgent': {'module': 'socs.agents.hwp_encoder.agent', 'entry_point': 'main'},
     'HWPGripperAgent': {'module': 'socs.agents.hwp_gripper.agent', 'entry_point': 'main'},
+    'HWPPCUAgent': {'module': 'socs.agents.hwp_pcu.agent', 'entry_point': 'main'},
     'HWPPicoscopeAgent': {'module': 'socs.agents.hwp_picoscope.agent', 'entry_point': 'main'},
     'HWPPIDAgent': {'module': 'socs.agents.hwp_pid.agent', 'entry_point': 'main'},
     'HWPPMXAgent': {'module': 'socs.agents.hwp_pmx.agent', 'entry_point': 'main'},


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

When trying to get PCU running, noticed that we forgot to add the PCU agent to the plugin file.
## Description
<!--- Describe your changes in detail -->
When trying to get PCU running, noticed that we forgot to add the PCU agent to the plugin file. This fixes that.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Bugfix

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
