### PR TITLE
ACU motion fixes and "named-positions" feature

### DIFF
--- a/socs/agents/acu/agent.py
+++ b/socs/agents/acu/agent.py
@@ -1394,7 +1394,7 @@ class ACUAgent:
     @ocs_agent.param('end_stop', default=True, type=bool)
     @inlineCallbacks
     def go_to_named(self, session, params):
-        """go_to_named(position, end_stop=True)
+        """go_to_named(target, end_stop=True)
 
         **Task** - Move the telescope to a named position,
         e.g. "home", that has been configured through command line args.

--- a/socs/agents/acu/agent.py
+++ b/socs/agents/acu/agent.py
@@ -1280,14 +1280,14 @@ class ACUAgent:
     @ocs_agent.param('end_stop', default=False, type=bool)
     @inlineCallbacks
     def go_to(self, session, params):
-        """go_to(az=None, el=None, end_stop=False)
+        """go_to(az, el, end_stop=False)
 
         **Task** - Move the telescope to a particular point (azimuth,
         elevation) in Preset mode. When motion has ended and the telescope
         reaches the preset point, it returns to Stop mode and ends.
 
         Parameters:
-            az (float): destination angle for the azimuthal axis
+            az (float): destination angle for the azimuth axis
             el (float): destination angle for the elevation axis
             end_stop (bool): put the telescope in Stop mode at the end of
                 the motion
@@ -1344,7 +1344,7 @@ class ACUAgent:
     @ocs_agent.param('end_stop', default=False, type=bool)
     @inlineCallbacks
     def set_boresight(self, session, params):
-        """set_boresight(target=None, end_stop=False)
+        """set_boresight(target, end_stop=False)
 
         **Task** - Move the telescope to a particular third-axis angle.
 
@@ -1478,6 +1478,7 @@ class ACUAgent:
         yield
         return True, 'Done'
 
+    @ocs_agent.param('_')
     @inlineCallbacks
     def clear_faults(self, session, params):
         """clear_faults()
@@ -1554,7 +1555,7 @@ class ACUAgent:
     @ocs_agent.param('azonly', type=bool, default=True)
     @inlineCallbacks
     def fromfile_scan(self, session, params=None):
-        """fromfile_scan(filename=None, adjust_times=True, azonly=True)
+        """fromfile_scan(filename, adjust_times=True, azonly=True)
 
         **Task** - Upload and execute a scan pattern from numpy file.
 
@@ -2266,13 +2267,15 @@ class ACUAgent:
     @ocs_agent.param('avoidance_radius', type=float, default=None)
     @ocs_agent.param('shift_sun_hours', type=float, default=None)
     def update_sun(self, session, params):
-        """update_sun(reset, enable, temporary_disable, escape, \
-                      avoidance_radius, shift_sun_hours)
+        """update_sun(reset=None, enable=None, temporary_disable=None,
+                      escape=None, avoidance_radius=None,
+                      shift_sun_hours=None)
 
         **Task** - Update Sun monitoring and avoidance parameters.
 
-        Args:
+        All arguments are optional.
 
+        Args:
           reset (bool): If True, reset all sun_params to the platform
             defaults.  (The "defaults" includes any overrides
             specified on Agent command line.)

--- a/socs/agents/acu/agent.py
+++ b/socs/agents/acu/agent.py
@@ -413,6 +413,12 @@ class ACUAgent:
             "StatusResponseRate": 19.237531827325963,
             "PlatformType": "satp",
             "IgnoredAxes": [],
+            "NamedPositions": {
+              "home": [
+                180,
+                40
+              ]
+            },
             "DefaultScanParams": {
               "az_speed": 2.0,
               "az_accel": 1.0,

--- a/socs/agents/acu/avoidance.py
+++ b/socs/agents/acu/avoidance.py
@@ -447,7 +447,7 @@ class SunTracker:
         # Include the direct path, but put in "worst case" details
         # based on all "confined" paths computed above.
         direct = dict(base)
-        direct['moves'] = MoveSequence(az0, el0, az1, el1)
+        direct['moves'] = MoveSequence(az0, el0, az1, el1, simplify=True)
         traj_info = self.check_trajectory(*direct['moves'].get_traj(), t=t)
         direct.update(traj_info)
         conf = [m for m in all_moves if m['travel_el_confined']]
@@ -679,6 +679,9 @@ class MoveSequence:
         No step in az or el will be greater than res.
 
         """
+        if len(self.nodes) == 1:
+            return np.array([self.nodes[0][0]]), np.array([self.nodes[0][1]])
+
         xx, yy = [], []
         for (x0, y0), (x1, y1) in self.get_legs():
             n = max(2, math.ceil(abs(x1 - x0) / res), math.ceil(abs(y1 - y0) / res))

--- a/socs/agents/acu/drivers.py
+++ b/socs/agents/acu/drivers.py
@@ -296,6 +296,12 @@ def generate_constant_velocity_scan(az_endpoint1, az_endpoint2, az_speed,
     if az_endpoint1 == az_endpoint2:
         raise ValueError('Generator requires two different az endpoints!')
 
+    # Force the el_speed to 0.  It matters because an el_speed in
+    # ProgramTrack data that exceeds the ACU limits will cause the
+    # point to be rejected, even if there's no motion in el planned
+    # (which, at the time of this writing, there is not).
+    el_speed = 0.
+
     # Note that starting scan direction gets modified, below,
     # depending on az_start.
     increasing = az_endpoint2 > az_endpoint1

--- a/tests/agents/test_acu_agent.py
+++ b/tests/agents/test_acu_agent.py
@@ -21,6 +21,24 @@ def test_avoidance():
     assert sun.check_trajectory([90], [20])['sun_time'] > 0
     assert sun.check_trajectory([270], [60])['sun_time'] > 0
 
+    # Find safe paths
+    paths = sun.analyze_paths(180, 30, 270, 40)
+    path, analysis = sun.select_move(paths)
+    assert path is not None
+    assert len(path['moves'].nodes) > 1
+
+    # Find safe short paths
+    paths = sun.analyze_paths(270.01, 40.01, 270, 40)
+    path, analysis = sun.select_move(paths)
+    assert path is not None
+    assert len(path['moves'].nodes) == 2
+
+    # Find safe paths to here (no moves)
+    paths = sun.analyze_paths(270, 40, 270, 40)
+    path, analysis = sun.select_move(paths)
+    assert path is not None
+    assert len(path['moves'].nodes) == 1
+
     # No safe moves to Sun position.
     paths = sun.analyze_paths(180, 20, az0, el0)
     path, analysis = sun.select_move(paths)


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

- When the "go_to" task runs, and Sun avoidance is enabled, and the platform is already at the target position, there is a risk that the sun safety check will crash, because of the trivial trajectory.  This is now fixed.
- The ACU's ProgramTrack mode will reject points that specify el speeds that exceed the platform limit, even if there is no actual motion in elevation.  This caused confusion during testing, so now el_speed is set to 0 in the ProgramTrack data no matter what the user says.
- A new task, "go_to_named" will cause the platform to go_to a target az, el position that has been configured through the command line.  This is mostly to support ocs-web widgets ("go to Home" button) but has other applications, where a script could be written that is general but for which the "home" position is different per-platform. 

## Motivation and Context

Deals with #601 and ground work for [ocs-web:52](https://github.com/simonsobs/ocs-web/issues/52).

Resolves #601.
Resolves #565.

## How Has This Been Tested?

Tested all on SATP3.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
