### PR TITLE
TimeoutLock less HWP PMX agent

### DIFF
--- a/docs/agents/hwp_pmx.rst
+++ b/docs/agents/hwp_pmx.rst
@@ -26,7 +26,7 @@ An example site-config-file block::
        'instance-id': 'hwp-pmx',
        'arguments': [['--ip', '10.10.10.100'],
                      ['--port', '5025'],
-                     ['--sampling-frequency', 2],
+                     ['--sampling-frequency', 1],
                      ['--supervisor-id', 'hwp-supervisor']]},
 
 Docker Compose

--- a/docs/agents/hwp_pmx.rst
+++ b/docs/agents/hwp_pmx.rst
@@ -26,8 +26,8 @@ An example site-config-file block::
        'instance-id': 'hwp-pmx',
        'arguments': [['--ip', '10.10.10.100'],
                      ['--port', '5025'],
-                     ['--mode', 'acq'],
-                     ['--sampling-frequency', 1],]},
+                     ['--sampling-frequency', 2],
+                     ['--supervisor-id', 'hwp-supervisor']]},
 
 Docker Compose
 ``````````````

--- a/socs/agents/hwp_pmx/agent.py
+++ b/socs/agents/hwp_pmx/agent.py
@@ -4,7 +4,7 @@ from dataclasses import dataclass
 from queue import Queue
 
 import txaio
-from twisted.internet import defer, reactor
+from twisted.internet import defer, reactor, threads
 
 txaio.use_twisted()
 
@@ -281,7 +281,7 @@ class HWPPMXAgent:
         PMX = None
         session.set_status('running')
 
-        self._clear_queue()
+        threads.blockingCallFromThread(reactor, self._clear_queue)
 
         sleep_time = 1 / self.f_sample - 0.01
         last_daq = 0

--- a/socs/agents/hwp_pmx/agent.py
+++ b/socs/agents/hwp_pmx/agent.py
@@ -4,7 +4,7 @@ from dataclasses import dataclass
 from queue import Queue
 
 import txaio
-from twisted.internet import defer, reactor
+from twisted.internet import defer
 
 txaio.use_twisted()
 

--- a/socs/agents/hwp_pmx/agent.py
+++ b/socs/agents/hwp_pmx/agent.py
@@ -271,8 +271,9 @@ class HWPPMXAgent:
         self.action_queue.put(action)
         return True, 'Set current limit is done'
 
+    @ocs_agent.param('test_mode', default=False, type=bool)
     def main(self, session, params):
-        """acq(test_mode=False)
+        """main(test_mode=False)
 
         **Process** - Start data acquisition.
 
@@ -312,6 +313,8 @@ class HWPPMXAgent:
                 last_daq = now
 
             self._process_actions(PMX)
+            if params['test_mode']:
+                break
             time.sleep(0.1)
 
         PMX.close()

--- a/socs/agents/hwp_pmx/agent.py
+++ b/socs/agents/hwp_pmx/agent.py
@@ -324,7 +324,7 @@ class HWPPMXAgent:
     def _process_actions(self, PMX: pmx.PMX):
         while not self.action_queue.empty():
             action = self.action_queue.get()
-            if action.__class__.__name__ in ['SetOn', 'SetOff', 'SetI', 'SetV', 'UseExt', 'UseIgn']:
+            if action.__class__.__name__ in ['SetOn', 'SetOff', 'SetI', 'SetV', 'UseExt', 'IgnExt']:
                 if self.shutdown_mode:
                     self.log.warn("Shutdown mode is in effect")
                     action.deferred.errback(Exception("Action cancelled by shutdown mode"))

--- a/socs/agents/hwp_pmx/agent.py
+++ b/socs/agents/hwp_pmx/agent.py
@@ -374,7 +374,6 @@ class HWPPMXAgent:
             self.log.warn("Exception in getting data")
             return
 
-
     def monitor_supervisor(self, session, params):
         """monitor_supervisor()
 

--- a/socs/agents/hwp_pmx/agent.py
+++ b/socs/agents/hwp_pmx/agent.py
@@ -25,101 +25,65 @@ class Actions:
 
     @dataclass
     class SetOn(BaseAction):
-        def process(self, module, log=None):
-            if log is None:
-                log = self.log
-
-            log.info("Setting PMX on...")
+        def process(self, module):
+            self.log.info("Setting PMX on...")
             module.turn_off()
-            return True
 
     @dataclass
     class SetOff(BaseAction):
-        def process(self, module, log=None):
-            if log is None:
-                log = self.log
-
-            log.info("Setting PMX off...")
+        def process(self, module):
+            self.log.info("Setting PMX off...")
             module.turn_off()
-            return True
 
     @dataclass
     class UseExt(BaseAction):
-        def process(self, module, log=None):
-            if log is None:
-                log = self.log
-
-            log.info("Setting PMX Kikusui to PID control...")
+        def process(self, module):
+            self.log.info("Setting PMX Kikusui to PID control...")
             module.use_external_voltage()
-            return True
 
     @dataclass
     class IgnExt(BaseAction):
-        def process(self, module, log=None):
-            if log is None:
-                log = self.log
-
-            log.info("Setting PMX Kikusui to direct control...")
+        def process(self, module):
+            self.log.info("Setting PMX Kikusui to direct control...")
             module.ign_external_voltage()
-            return True
 
     @dataclass
     class ClearAlarm(BaseAction):
-        def process(self, module, log=None):
-            if log is None:
-                log = self.log
-
-            log.info("Clear PMX alarm...")
+        def process(self, module):
+            self.log.info("Clear PMX alarm...")
             module.clear_alarm()
-            return True
 
     @dataclass
     class SetI(BaseAction):
         curr: float
 
-        def process(self, module, log=None):
-            if log is None:
-                log = self.log
-
+        def process(self, module):
             msg, val = module.set_current(self.curr)
-            log.info(msg + "...")
-            return True
+            self.log.info(msg + "...")
 
     @dataclass
     class SetV(BaseAction):
         volt: float
 
-        def process(self, module, log=None):
-            if log is None:
-                log = self.log
-
+        def process(self, module):
             msg, val = module.set_voltage(self.volt)
-            log.info(msg + "...")
-            return True
+            self.log.info(msg + "...")
 
     @dataclass
     class SetILim(BaseAction):
         curr: float
 
-        def process(self, module, log=None):
-            if log is None:
-                log = self.log
-
+        def process(self, module):
             msg, val = module.set_current_limit(self.curr)
-            log.info(msg + "...")
-            return True
+            self.log.info(msg + "...")
 
     @dataclass
     class SetVLim(BaseAction):
         volt: float
 
-        def process(self, module, log=None):
-            if log is None:
-                log = self.log
-
+        def process(self, module):
             msg, val = module.set_voltage_limit(self.volt)
-            log.info(msg + "...")
-            return True
+            self.log.info(msg + "...")
 
 
 class HWPPMXAgent:
@@ -161,6 +125,7 @@ class HWPPMXAgent:
 
         self.agent.register_feed('rotation_action', record=True)
 
+    @defer.inlineCallbacks
     def set_on(self, session, params):
         """set_on()
         **Task** - Turn on the PMX Kikusui.
@@ -170,8 +135,10 @@ class HWPPMXAgent:
 
         action = Actions.SetOn(**params)
         self.action_queue.put(action)
+        session.data = yield action.deferred
         return True, 'Set PMX Kikusui on'
 
+    @defer.inlineCallbacks
     def set_off(self, session, params):
         """set_off()
         **Task** - Turn off the PMX Kikusui.
@@ -181,16 +148,20 @@ class HWPPMXAgent:
 
         action = Actions.SetOff(**params)
         self.action_queue.put(action)
+        session.data = yield action.deferred
         return True, 'Set PMX Kikusui off'
 
+    @defer.inlineCallbacks
     def clear_alarm(self, session, params):
         """clear_alarm()
         **Task** - Clear alarm and exit protection mode.
         """
         action = Actions.ClearAlarm(**params)
         self.action_queue.put(action)
+        session.data = yield action.deferred
         return True, 'Clear alarm'
 
+    @defer.inlineCallbacks
     def use_ext(self, session, params):
         """use_ext()
         **Task** - Set the PMX Kikusui to use an external voltage control. Doing so
@@ -202,8 +173,10 @@ class HWPPMXAgent:
 
         action = Actions.UseExt(**params)
         self.action_queue.put(action)
+        session.data = yield action.deferred
         return True, 'Set PMX Kikusui to PID control'
 
+    @defer.inlineCallbacks
     def ign_ext(self, session, params):
         """ign_ext()
         **Task** - Set the PMX Kiksui to ignore external voltage control. Doing so
@@ -215,8 +188,10 @@ class HWPPMXAgent:
 
         action = Actions.IgnExt(**params)
         self.action_queue.put(action)
+        session.data = yield action.deferred
         return True, 'Set PMX Kikusui to direct control'
 
+    @defer.inlineCallbacks
     @ocs_agent.param('curr', default=0, type=float, check=lambda x: 0 <= x <= 3)
     def set_i(self, session, params):
         """set_i(curr=0)
@@ -230,8 +205,10 @@ class HWPPMXAgent:
 
         action = Actions.SetI(**params)
         self.action_queue.put(action)
+        session.data = yield action.deferred
         return True, 'Set current is done'
 
+    @defer.inlineCallbacks
     @ocs_agent.param('volt', default=0, type=float, check=lambda x: 0 <= x <= 35)
     def set_v(self, session, params):
         """set_v(volt=0)
@@ -245,8 +222,10 @@ class HWPPMXAgent:
 
         action = Actions.SetV(**params)
         self.action_queue.put(action)
+        session.data = yield action.deferred
         return True, 'Set voltage is done'
 
+    @defer.inlineCallbacks
     @ocs_agent.param('curr', default=1., type=float, check=lambda x: 0. <= x <= 3.)
     def set_i_lim(self, session, params):
         """set_i_lim(curr=1)
@@ -257,8 +236,10 @@ class HWPPMXAgent:
         """
         action = Actions.SetILim(**params)
         self.action_queue.put(action)
+        session.data = yield action.deferred
         return True, 'Set voltage limit is done'
 
+    @defer.inlineCallbacks
     @ocs_agent.param('volt', default=32., type=float, check=lambda x: 0. <= x <= 35.)
     def set_v_lim(self, session, params):
         """set_v_lim(volt=32)
@@ -269,6 +250,7 @@ class HWPPMXAgent:
         """
         action = Actions.SetVLim(**params)
         self.action_queue.put(action)
+        session.data = yield action.deferred
         return True, 'Set current limit is done'
 
     @ocs_agent.param('test_mode', default=False, type=bool)
@@ -494,17 +476,17 @@ def main(args=None):
     agent.register_process(
         'monitor_supervisor', PMX.monitor_supervisor, PMX._stop_monitor_supervisor,
         startup=True)
-    agent.register_task('set_on', PMX.set_on)
-    agent.register_task('set_off', PMX.set_off)
-    agent.register_task('clear_alarm', PMX.clear_alarm)
-    agent.register_task('set_i', PMX.set_i)
-    agent.register_task('set_v', PMX.set_v)
-    agent.register_task('set_i_lim', PMX.set_i_lim)
-    agent.register_task('set_v_lim', PMX.set_v_lim)
-    agent.register_task('use_ext', PMX.use_ext)
-    agent.register_task('ign_ext', PMX.ign_ext)
-    agent.register_task('initiate_shutdown', PMX.initiate_shutdown)
-    agent.register_task('cancel_shutdown', PMX.cancel_shutdown)
+    agent.register_task('set_on', PMX.set_on, blocking=False)
+    agent.register_task('set_off', PMX.set_off, blocking=False)
+    agent.register_task('clear_alarm', PMX.clear_alarm, blocking=False)
+    agent.register_task('set_i', PMX.set_i, blocking=False)
+    agent.register_task('set_v', PMX.set_v, blocking=False)
+    agent.register_task('set_i_lim', PMX.set_i_lim, blocking=False)
+    agent.register_task('set_v_lim', PMX.set_v_lim, blocking=False)
+    agent.register_task('use_ext', PMX.use_ext, blocking=False)
+    agent.register_task('ign_ext', PMX.ign_ext, blocking=False)
+    agent.register_task('initiate_shutdown', PMX.initiate_shutdown, blocking=False)
+    agent.register_task('cancel_shutdown', PMX.cancel_shutdown, blocking=False)
     runner.run(agent, auto_reconnect=True)
 
 

--- a/socs/agents/hwp_pmx/agent.py
+++ b/socs/agents/hwp_pmx/agent.py
@@ -4,13 +4,14 @@ from dataclasses import dataclass
 from queue import Queue
 
 import txaio
-from twisted.internet import defer
+from twisted.internet import defer, reactor
 
 txaio.use_twisted()
 
 from ocs import ocs_agent, site_config
 
 import socs.agents.hwp_pmx.drivers.PMX_ethernet as pmx
+from socs.agents.hwp_supervisor.agent import get_op_data
 
 class Actions:
     class BaseAction:
@@ -19,7 +20,7 @@ class Actions:
             self.log = txaio.make_logger()
 
     def process(self, *args, **kwargs):
-            raise NotImplementedError
+        raise NotImplementedError
 
     @dataclass
     class SetOn(BaseAction):
@@ -80,7 +81,7 @@ class Actions:
                 log = self.log
 
             msg, val = module.set_current(self.curr)
-            log.info(msg+"...")
+            log.info(msg + "...")
             return True
 
     @dataclass
@@ -92,7 +93,7 @@ class Actions:
                 log = self.log
 
             msg, val = module.set_voltage(self.volt)
-            log.info(msg+"...")
+            log.info(msg + "...")
             return True
 
     @dataclass
@@ -104,7 +105,7 @@ class Actions:
                 log = self.log
 
             msg, val = module.set_current_limit(self.curr)
-            log.info(msg+"...")
+            log.info(msg + "...")
             return True
 
     @dataclass
@@ -116,7 +117,7 @@ class Actions:
                 log = self.log
 
             msg, val = module.set_voltage_limit(self.volt)
-            log.info(msg+"...")
+            log.info(msg + "...")
             return True
 
 class HWPPMXAgent:
@@ -460,7 +461,7 @@ def make_parser(parser=None):
                         help="ip address for kikusui PMX")
     pgroup.add_argument('--port', type=int,
                         help="port for kikusui PMX")
-    pgroup.add_argument('--sampling-frequency', type=float, default = 2,
+    pgroup.add_argument('--sampling-frequency', type=float, default=2.,
                         help="Sampling frequency for data acquisition")
     pgroup.add_argument('--supervisor-id', type=str,
                         help="Instance ID for HWP Supervisor agent")

--- a/socs/agents/hwp_pmx/agent.py
+++ b/socs/agents/hwp_pmx/agent.py
@@ -4,7 +4,7 @@ from dataclasses import dataclass
 from queue import Queue
 
 import txaio
-from twisted.internet import defer
+from twisted.internet import defer, reactor
 
 txaio.use_twisted()
 
@@ -326,10 +326,10 @@ class HWPPMXAgent:
             try:
                 self.log.info(f"Running action {action}")
                 res = action.process(PMX)
-                action.deferred.callback(res)
+                reactor.callFromThread(action.deferred.callback, res)
             except Exception as e:
                 self.log.error(f"Error processing action: {action}")
-                action.deferred.errback(e)
+                reactor.callFromThread(action.deferred.errback, e)
 
     def _clear_queue(self):
         while not self.action_queue.empty():

--- a/socs/agents/hwp_pmx/drivers/PMX_ethernet.py
+++ b/socs/agents/hwp_pmx/drivers/PMX_ethernet.py
@@ -50,7 +50,7 @@ class PMX:
                 self.conn.sendall(msg)
                 time.sleep(0.5)
                 if read:
-                    data = self.conn.recv(self.buffer_size).decode('utf-8')
+                    data = self.conn.recv(self.buffer_size).strip().decode('utf-8')
                     return data
                 return
             except (socket.timeout, OSError):

--- a/tests/default.yaml
+++ b/tests/default.yaml
@@ -48,7 +48,6 @@ hosts:
        'instance-id': 'hwp-pmx',
        'arguments': [['--ip', '127.0.0.1'],
                      ['--port', '5025'],
-                     ['--mode', 'init'],
                     ]
       },
       {'agent-class': 'CryomechCPAAgent',

--- a/tests/integration/test_hwp_pmx_agent_integration.py
+++ b/tests/integration/test_hwp_pmx_agent_integration.py
@@ -2,7 +2,6 @@ import ocs
 import pytest
 from integration.util import docker_compose_file  # noqa: F401
 from integration.util import create_crossbar_fixture
-from ocs.base import OpCode
 from ocs.testing import create_agent_runner_fixture, create_client_fixture
 
 from socs.testing.device_emulator import create_device_emulator
@@ -15,6 +14,13 @@ run_agent_idle = create_agent_runner_fixture(
 client = create_client_fixture('hwp-pmx')
 kikusui_emu = create_device_emulator({}, relay_type='tcp', port=5025)
 
+default_responses = {
+    'meas:volt?': '2',
+    'meas:curr?': '1',
+    ':system:error?': '+0,"No error"\n',
+    'stat:ques?': '0',
+    'volt:ext:sour?': 'source_name'
+}
 
 @pytest.mark.integtest
 def test_testing(wait_for_crossbar):
@@ -22,140 +28,124 @@ def test_testing(wait_for_crossbar):
     assert True
 
 
-# This ends up hanging for some reason that I can't figure out at the moment.
-# @pytest.mark.integtest
-# def test_hwp_pmx_failed_connection_kikusui(wait_for_crossbar, run_agent_idle, client):
-#     resp = client.init_connection.start()
-#     print(resp)
-#     # We can't really check anything here, the agent's going to exit during the
-#     # init_conneciton task because it cannot connect to the Kikusui.
+@pytest.mark.integtest
+def test_hwp_rotation_main(wait_for_crossbar, kikusui_emu, run_agent, client):
+    responses = default_responses.copy()
+    responses['meas:curr?'] = '1'
+    kikusui_emu.define_responses(responses)
+    client.main.stop()
+    resp = client.main.wait()
+    assert resp.session['data']['curr'] == 1.0
+    assert resp.status == ocs.OK
+    assert resp.session['success']
+
 
 
 @pytest.mark.integtest
 def test_hwp_rotation_set_on(wait_for_crossbar, kikusui_emu, run_agent, client):
-    responses = {'output 1': '',
-                 'output?': '1'}
+    responses = default_responses.copy()
+    responses.update({
+        'output 1': '',
+        'output?': '1'
+    })
     kikusui_emu.define_responses(responses)
-
-    client.init_connection.wait()  # wait for connection to be made
     resp = client.set_on()
     print(resp)
-    assert resp.status == ocs.OK
     print(resp.session)
-    assert resp.session['op_code'] == OpCode.SUCCEEDED.value
+    assert resp.status == ocs.OK
+    assert resp.session['success']
 
 
 @pytest.mark.integtest
 def test_hwp_rotation_set_off(wait_for_crossbar, kikusui_emu, run_agent, client):
-    responses = {'output 0': '',
-                 'output?': '0'}
+    responses = default_responses.copy()
+    responses.update({
+        'output 0': '', 'output?': '0'
+    })
     kikusui_emu.define_responses(responses)
-
-    client.init_connection.wait()  # wait for connection to be made
     resp = client.set_off()
     print(resp)
-    assert resp.status == ocs.OK
     print(resp.session)
-    assert resp.session['op_code'] == OpCode.SUCCEEDED.value
+    assert resp.status == ocs.OK
+    assert resp.session['success']
 
 
 @pytest.mark.integtest
 def test_hwp_rotation_set_i(wait_for_crossbar, kikusui_emu, run_agent, client):
-    responses = {'curr 1.000000': '',
-                 'curr?': '1.000000'}
+    responses = default_responses.copy()
+    responses.update({'curr 1.000000': '',
+                 'curr?': '1.000000'})
     kikusui_emu.define_responses(responses)
-
-    client.init_connection.wait()  # wait for connection to be made
     resp = client.set_i(curr=1)
     print(resp)
-    assert resp.status == ocs.OK
     print(resp.session)
-    assert resp.session['op_code'] == OpCode.SUCCEEDED.value
+    assert resp.status == ocs.OK
+    assert resp.session['success']
 
 
 @pytest.mark.integtest
 def test_hwp_rotation_set_i_lim(wait_for_crossbar, kikusui_emu, run_agent, client):
-    responses = {'curr:prot 2.000000': '',
-                 'curr:prot?': '2.000000'}
+    responses = default_responses.copy()
+    responses.update({'curr:prot 2.000000': '',
+                 'curr:prot?': '2.000000'})
     kikusui_emu.define_responses(responses)
-
-    client.init_connection.wait()  # wait for connection to be made
     resp = client.set_i_lim(curr=2)
     print(resp)
-    assert resp.status == ocs.OK
     print(resp.session)
-    assert resp.session['op_code'] == OpCode.SUCCEEDED.value
+    assert resp.status == ocs.OK
+    assert resp.session['success']
 
 
 @pytest.mark.integtest
 def test_hwp_rotation_set_v(wait_for_crossbar, kikusui_emu, run_agent, client):
-    responses = {'volt 1.000000': '',
-                 'volt?': '1.000000'}
+    responses = default_responses.copy()
+    responses.update({'volt 1.000000': '',
+                 'volt?': '1.000000'})
     kikusui_emu.define_responses(responses)
-
-    client.init_connection.wait()  # wait for connection to be made
     resp = client.set_v(volt=1)
     print(resp)
-    assert resp.status == ocs.OK
     print(resp.session)
-    assert resp.session['op_code'] == OpCode.SUCCEEDED.value
+    assert resp.status == ocs.OK
+    assert resp.session['success']
 
 
 @pytest.mark.integtest
 def test_hwp_rotation_set_v_lim(wait_for_crossbar, kikusui_emu, run_agent, client):
-    responses = {'volt:prot 10.000000': '',
-                 'volt:prot?': '10.000000'}
+    responses = default_responses.copy()
+    responses.update({
+        'volt:prot 10.0': '',
+        'volt:prot?': '10.000000'
+    })
     kikusui_emu.define_responses(responses)
-
-    client.init_connection.wait()  # wait for connection to be made
     resp = client.set_v_lim(volt=10)
     print(resp)
-    assert resp.status == ocs.OK
     print(resp.session)
-    assert resp.session['op_code'] == OpCode.SUCCEEDED.value
+    assert resp.status == ocs.OK
+    assert resp.session['success']
 
 
 @pytest.mark.integtest
 def test_hwp_rotation_use_ext(wait_for_crossbar, kikusui_emu, run_agent, client):
-    responses = {'volt:ext:sour VOLT': '',
-                 'volt:ext:sour?': 'source_name'}
+    responses = default_responses.copy()
+    responses.update({'volt:ext:sour VOLT': '',
+                 'volt:ext:sour?': 'source_name'})
     kikusui_emu.define_responses(responses)
-
-    client.init_connection.wait()  # wait for connection to be made
     resp = client.use_ext()
     print(resp)
-    assert resp.status == ocs.OK
     print(resp.session)
-    assert resp.session['op_code'] == OpCode.SUCCEEDED.value
+    assert resp.status == ocs.OK
+    assert resp.session['success']
 
 
 @pytest.mark.integtest
 def test_hwp_rotation_ign_ext(wait_for_crossbar, kikusui_emu, run_agent, client):
-    responses = {'volt:ext:sour NONE': '',
-                 'volt:ext:sour?': 'False'}
+    responses = default_responses.copy()
+    responses.update({'volt:ext:sour NONE': '',
+                 'volt:ext:sour?': 'False'})
     kikusui_emu.define_responses(responses)
 
-    client.init_connection.wait()  # wait for connection to be made
     resp = client.ign_ext()
     print(resp)
-    assert resp.status == ocs.OK
     print(resp.session)
-    assert resp.session['op_code'] == OpCode.SUCCEEDED.value
-
-
-@pytest.mark.integtest
-def test_hwp_rotation_acq(wait_for_crossbar, kikusui_emu, run_agent, client):
-    responses = {'meas:volt?': '2',
-                 'meas:curr?': '1',
-                 ':system:error?': '+0,"No error"\n',
-                 'stat:ques?': '0',
-                 'volt:ext:sour?': 'source_name'}
-    kikusui_emu.define_responses(responses)
-
-    client.init_connection.wait()  # wait for connection to be made
-    resp = client.main.start(test_mode=True)
     assert resp.status == ocs.OK
-
-    resp = client.main.wait(timeout=20)
-    assert resp.status == ocs.OK
-    assert resp.session['op_code'] == OpCode.SUCCEEDED.value
+    assert resp.session['success']

--- a/tests/integration/test_hwp_pmx_agent_integration.py
+++ b/tests/integration/test_hwp_pmx_agent_integration.py
@@ -22,6 +22,7 @@ default_responses = {
     'volt:ext:sour?': 'source_name'
 }
 
+
 @pytest.mark.integtest
 def test_testing(wait_for_crossbar):
     """Just a quick test to make sure we can bring up crossbar."""
@@ -38,7 +39,6 @@ def test_hwp_rotation_main(wait_for_crossbar, kikusui_emu, run_agent, client):
     assert resp.session['data']['curr'] == 1.0
     assert resp.status == ocs.OK
     assert resp.session['success']
-
 
 
 @pytest.mark.integtest
@@ -74,7 +74,7 @@ def test_hwp_rotation_set_off(wait_for_crossbar, kikusui_emu, run_agent, client)
 def test_hwp_rotation_set_i(wait_for_crossbar, kikusui_emu, run_agent, client):
     responses = default_responses.copy()
     responses.update({'curr 1.000000': '',
-                 'curr?': '1.000000'})
+                      'curr?': '1.000000'})
     kikusui_emu.define_responses(responses)
     resp = client.set_i(curr=1)
     print(resp)
@@ -87,7 +87,7 @@ def test_hwp_rotation_set_i(wait_for_crossbar, kikusui_emu, run_agent, client):
 def test_hwp_rotation_set_i_lim(wait_for_crossbar, kikusui_emu, run_agent, client):
     responses = default_responses.copy()
     responses.update({'curr:prot 2.000000': '',
-                 'curr:prot?': '2.000000'})
+                      'curr:prot?': '2.000000'})
     kikusui_emu.define_responses(responses)
     resp = client.set_i_lim(curr=2)
     print(resp)
@@ -100,7 +100,7 @@ def test_hwp_rotation_set_i_lim(wait_for_crossbar, kikusui_emu, run_agent, clien
 def test_hwp_rotation_set_v(wait_for_crossbar, kikusui_emu, run_agent, client):
     responses = default_responses.copy()
     responses.update({'volt 1.000000': '',
-                 'volt?': '1.000000'})
+                      'volt?': '1.000000'})
     kikusui_emu.define_responses(responses)
     resp = client.set_v(volt=1)
     print(resp)
@@ -128,7 +128,7 @@ def test_hwp_rotation_set_v_lim(wait_for_crossbar, kikusui_emu, run_agent, clien
 def test_hwp_rotation_use_ext(wait_for_crossbar, kikusui_emu, run_agent, client):
     responses = default_responses.copy()
     responses.update({'volt:ext:sour VOLT': '',
-                 'volt:ext:sour?': 'source_name'})
+                      'volt:ext:sour?': 'source_name'})
     kikusui_emu.define_responses(responses)
     resp = client.use_ext()
     print(resp)
@@ -141,7 +141,7 @@ def test_hwp_rotation_use_ext(wait_for_crossbar, kikusui_emu, run_agent, client)
 def test_hwp_rotation_ign_ext(wait_for_crossbar, kikusui_emu, run_agent, client):
     responses = default_responses.copy()
     responses.update({'volt:ext:sour NONE': '',
-                 'volt:ext:sour?': 'False'})
+                      'volt:ext:sour?': 'False'})
     kikusui_emu.define_responses(responses)
 
     resp = client.ign_ext()

--- a/tests/integration/test_hwp_pmx_agent_integration.py
+++ b/tests/integration/test_hwp_pmx_agent_integration.py
@@ -153,9 +153,9 @@ def test_hwp_rotation_acq(wait_for_crossbar, kikusui_emu, run_agent, client):
     kikusui_emu.define_responses(responses)
 
     client.init_connection.wait()  # wait for connection to be made
-    resp = client.acq.start(test_mode=True)
+    resp = client.main.start(test_mode=True)
     assert resp.status == ocs.OK
 
-    resp = client.acq.wait(timeout=20)
+    resp = client.main.wait(timeout=20)
     assert resp.status == ocs.OK
     assert resp.session['op_code'] == OpCode.SUCCEEDED.value


### PR DESCRIPTION
## Description
TimeoutLockless HWP PMX agent

## Motivation and Context
In the operation of PMX at the site, we have many timeout lock errors. To avoid this error and make PMX control more robust, we modify the PMX agent in the same way as HWP PCU agent #600
I plan to do the same modification for the HWP PID agent as well.
The way I define actions may not be good. Suggestions for better coding are welcome.

## How Has This Been Tested?
Tested in PMX in UTokyo setup

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
