### PR TITLE
HWP Emulation and PID agent lockless restructure

### DIFF
--- a/docs/agents/hwp_pid.rst
+++ b/docs/agents/hwp_pid.rst
@@ -25,8 +25,7 @@ An example site-config-file block::
       {'agent-class': 'HWPPIDAgent',
        'instance-id': 'hwp-pid',
        'arguments': [['--ip', '10.10.10.101'],
-                     ['--port', '2000'],
-                     ['--mode', 'acq']]},
+                     ['--port', '2000']]},
 
 Docker Compose
 ``````````````

--- a/simulators/hwp/hwp_emulator.py
+++ b/simulators/hwp/hwp_emulator.py
@@ -154,12 +154,12 @@ class HWPEmulator:
         with self.state.lock:
             # self.logger.debug(cmd)
             if cmd == "*W02400000":
-                self.state.pid.direction = "forward"
-                logger.info("Setting direction: forward")
-                return "asdfl"
-            elif cmd == "*W02401388":
                 self.state.pid.direction = "reverse"
                 logger.info("Setting direction: reverse")
+                return "asdfl"
+            elif cmd == "*W02401388":
+                self.state.pid.direction = "forward"
+                logger.info("Setting direction: forward")
                 return "asdfl"
             elif cmd.startswith("*W014"):
                 setpt = hex_str_to_dec(cmd[5:], 3)
@@ -169,7 +169,13 @@ class HWPEmulator:
             elif cmd == "*X01":  # Get frequency
                 return f"X01{self.state.cur_freq:0.3f}"
             elif cmd == "*R01":  # Get Target
-                return f"R{PID._convert_to_hex(self.state.pid.freq_setpoint, 3)}"
+                return f"R01{PID._convert_to_hex(self.state.pid.freq_setpoint, 3)}"
+            elif cmd == "*R02":  # Get Direction
+                if self.state.pid.direction == "forward":
+                    return "1"
+                else:
+                    return "0"
+
             else:
                 self.logger.info("Unknown cmd: %s", cmd)
                 return "unknown"

--- a/simulators/hwp/hwp_emulator.py
+++ b/simulators/hwp/hwp_emulator.py
@@ -141,9 +141,9 @@ class HWPEmulator:
                 return f"{self.state.pmx.voltage}\n"
 
             # Error codes
-            elif cmd == ':system:error?': # Error codes
+            elif cmd == ':system:error?':  # Error codes
                 return '0,"No error"\n'
-            elif cmd == 'stat:ques?': # Status Codes
+            elif cmd == 'stat:ques?':  # Status Codes
                 return '0'
             elif cmd == 'volt:ext:sour?':
                 return f'{self.state.pmx.source}\n'

--- a/simulators/hwp/hwp_emulator.py
+++ b/simulators/hwp/hwp_emulator.py
@@ -6,8 +6,8 @@ import threading
 import time
 from dataclasses import dataclass
 
-from socs.testing import device_emulator
 from socs.agents.hwp_pid.drivers.pid_controller import PID
+from socs.testing import device_emulator
 
 
 def hex_str_to_dec(hex_value, decimal=3):

--- a/simulators/hwp/hwp_emulator.py
+++ b/simulators/hwp/hwp_emulator.py
@@ -1,11 +1,11 @@
 """
 HWP Emulation module
 """
-from dataclasses import dataclass
 import logging
+import threading
 import time
 from copy import deepcopy
-import threading
+from dataclasses import dataclass
 
 from socs.testing import device_emulator
 

--- a/simulators/hwp/hwp_emulator.py
+++ b/simulators/hwp/hwp_emulator.py
@@ -1,0 +1,146 @@
+"""
+HWP Emulation module
+"""
+from dataclasses import dataclass
+import logging
+import time
+from copy import deepcopy
+import threading
+
+from socs.testing import device_emulator
+
+
+def hex_str_to_dec(hex_value, decimal=3):
+    """Converts a hex string to a decimal float"""
+    return float(int(hex_value, 16)) / 10**decimal
+
+
+def float_to_hex_str(value, decimal=3):
+    """Converts a decimal float to a hex string"""
+    return "0000" + str(hex(int(value * 10**decimal)))[2:]
+
+
+@dataclass
+class PMXState:
+    output: bool = False
+    current: float = 0
+    current_limit: float = 10.0
+    voltage_limit: float = 10.0
+    voltage: float = 0
+    source: str = "volt"
+
+
+@dataclass
+class PIDState:
+    direction: str = "forward"
+    freq_setpoint: float = 0.0
+
+
+@dataclass
+class HWPState:
+    cur_freq: float = 0.0
+    pmx: PMXState = PMXState()
+    pid: PIDState = PIDState()
+    lock = threading.Lock()
+
+
+def _create_logger(name, log_level=logging.DEBUG):
+    logger = logging.getLogger(name)
+    logger.setLevel(log_level)
+    formatter = logging.Formatter("%(name)s: %(message)s")
+    handler = logging.StreamHandler()
+    handler.setFormatter(formatter)
+    logger.addHandler(handler)
+    return logger
+
+
+def lerp(start, end, t):
+    return (1 - t) * start + t * end
+
+
+class HWPEmulator:
+    def __init__(self, pid_addr=("localhost", 8003), pmx_addr=("localhost", 8004)):
+        self.pid_addr = pid_addr
+        self.pmx_addr = pmx_addr
+
+        self.state = HWPState()
+
+        self.pid_device = device_emulator.DeviceEmulator([])
+        self.pid_device._get_response = self.process_pid_msg
+        self.pid_device.logger = _create_logger("PID")
+
+        self.pmx_device = device_emulator.DeviceEmulator([])
+        self.pmx_device._get_response = self.process_pmx_msg
+        self.pmx_device.logger = _create_logger("PMX")
+
+        self.logger = _create_logger("HWP")
+
+    def start(self):
+        """Start up TCP Sockets"""
+        self.pid_device.create_tcp_relay(self.pid_addr[1])
+        self.pmx_device.create_tcp_relay(self.pmx_addr[1])
+
+    def shutdown(self):
+        """Shutdown TCP Sockets"""
+        self.pid_device.shutdown()
+        self.pmx_device.shutdown()
+
+    def update(self):
+        """Update HWP state"""
+        s = self.state
+        with s.lock:
+            if s.pmx.source == "volt":
+                s.cur_freq = lerp(s.cur_freq, s.pid.freq_setpoint, 0.3)
+
+    def process_pmx_msg(self, data):
+        """Process messages for PMX emulator"""
+        cmd = data.split(" ")[0].strip()
+        self.logger.debug(cmd)
+        with self.state.lock:
+            if cmd == "meas:curr?":
+                return f"{self.state.pmx.current}\n"
+            elif cmd == "meas:volt?":
+                return f"{self.state.pmx.voltage}\n"
+            else:
+                self.logger.info("Unknown cmd: %s", cmd)
+                if "?" in cmd:
+                    return "unknown"
+
+    def process_pid_msg(self, data):
+        """Process messages for PID emulator"""
+        logger = self.pid_device.logger
+        cmd = data.split(" ")[0].strip()
+        with self.state.lock:
+            # self.logger.debug(cmd)
+            if cmd == "*W02400000":
+                self.state.pid.direction = "forward"
+                logger.info("Setting direction: forward")
+                return "asdfl"
+            elif cmd == "*W02401388":
+                self.state.pid.direction = "reverse"
+                logger.info("Setting direction: reverse")
+                return "asdfl"
+            elif cmd.startswith("*W014"):
+                setpt = hex_str_to_dec(cmd[5:], 3)
+                logger.info("SETPOINT %s Hz", setpt)
+                self.state.pid.freq_setpoint = setpt
+                return "sdflsf"
+            elif cmd == "*X01":  # Get frequency
+                return f"X01{self.state.cur_freq:0.3f}"
+            elif cmd == "*R01":  # Get Target
+                return f"R{float_to_hex_str(self.state.pid.freq_setpoint, 3)}"
+            else:
+                self.logger.info("Unknown cmd: %s", cmd)
+                return "unknown"
+
+
+try:
+    # pmx_server = PMXEmulator('localhost', 8002)
+    hwp_em = HWPEmulator()
+    hwp_em.start()
+
+    while True:
+        hwp_em.update()
+        time.sleep(1)
+finally:
+    hwp_em.shutdown()

--- a/socs/agents/hwp_pid/agent.py
+++ b/socs/agents/hwp_pid/agent.py
@@ -5,7 +5,7 @@ import time
 import txaio
 from ocs import ocs_agent, site_config
 from ocs.ocs_twisted import TimeoutLock
-from twisted.internet import defer, threads, reactor
+from twisted.internet import defer, reactor, threads
 
 txaio.use_twisted()
 
@@ -26,6 +26,7 @@ def parse_action_result(res):
         return res
     else:
         return {'result': res}
+
 
 class Actions:
     @dataclass

--- a/socs/agents/hwp_pid/agent.py
+++ b/socs/agents/hwp_pid/agent.py
@@ -27,12 +27,14 @@ def parse_action_result(res):
     else:
         return {'result': res}
 
+
 def get_pid_state(pid: pd.PID):
     return {
         "current_freq": pid.get_freq(),
         "target_freq": pid.get_target(),
         "direction": pid.get_direction(),
     }
+
 
 class Actions:
     @dataclass
@@ -112,7 +114,6 @@ class HWPPIDAgent:
 
         agg_params = {"frame_length": 60}
         self.agent.register_feed("hwppid", record=True, agg_params=agg_params)
-
 
     def _get_data_and_publish(self, pid: pd.PID, session: ocs_agent.OpSession):
         data = {"timestamp": time.time(), "block_name": "HWPPID", "data": {}}

--- a/socs/agents/hwp_pid/agent.py
+++ b/socs/agents/hwp_pid/agent.py
@@ -223,6 +223,11 @@ class HWPPIDAgent:
         Parameters:
             freq (float): Desired HWP rotation frequency
 
+        Notes:
+            Session data is structured as follows::
+
+                >>> response.session['data']
+                {'declared_freq': 2.0}
         """
         action = Actions.DeclareFreq(**params)
         self.action_queue.put(action)
@@ -298,6 +303,14 @@ class HWPPIDAgent:
         """get_state()
 
         **Task** - Polls hardware for the current the PID state.
+
+        Notes:
+            Session data for this operation is as follows::
+
+                >>> response.session['data']
+                {'current_freq': 0,
+                 'target_freq': 0,
+                 'direction': 1}
         """
         action = Actions.GetState(**params)
         self.action_queue.put(action)

--- a/socs/agents/hwp_pid/agent.py
+++ b/socs/agents/hwp_pid/agent.py
@@ -3,9 +3,66 @@ import time
 
 from ocs import ocs_agent, site_config
 from ocs.ocs_twisted import TimeoutLock
-from twisted.internet import reactor
+from twisted.internet import reactor, defer
+import queue
+
+import txaio
+
+txaio.use_twisted()
+
 
 import socs.agents.hwp_pid.drivers.pid_controller as pd
+from dataclasses import dataclass
+
+
+class Actions:
+    @dataclass
+    class BaseAction:
+        def __post_init__(self):
+            self.deferred = defer.Deferred()
+            self.log = txaio.make_logger()
+
+    @dataclass
+    class TuneStop(BaseAction):
+        def process(self, pid: pd.PID):
+            pid.tune_stop()
+
+    @dataclass
+    class TuneFreq(BaseAction):
+        def process(self, pid: pd.PID):
+            pid.tune_freq()
+
+    @dataclass
+    class DeclareFreq(BaseAction):
+        freq: float
+
+        def process(self, pid: pd.PID):
+            pid.declare_freq(self.freq)
+            return {"declared_freq": self.freq}
+
+    @dataclass
+    class SetPID(BaseAction):
+        p: float
+        i: int
+        d: float
+
+        def process(self, pid: pd.PID):
+            pid.set_pid([self.p, self.i, self.d])
+
+    @dataclass
+    class SetDirection(BaseAction):
+        direction: str
+
+        def process(self, pid: pd.PID):
+            pid.set_direction(self.direction)
+
+    @dataclass
+    class SetScale(BaseAction):
+        slope: float
+        offset: float
+
+        def process(self, pid: pd.PID):
+            pid.set_scale(self.slope, self.offset)
 
 
 class HWPPIDAgent:
@@ -27,53 +84,89 @@ class HWPPIDAgent:
         self.ip = ip
         self.port = port
         self._verbosity = verbosity > 0
+        self.action_queue = queue.Queue()
 
-        agg_params = {'frame_length': 60}
-        self.agent.register_feed(
-            'hwppid', record=True, agg_params=agg_params)
+        agg_params = {"frame_length": 60}
+        self.agent.register_feed("hwppid", record=True, agg_params=agg_params)
 
-    @ocs_agent.param('auto_acquire', default=False, type=bool)
-    @ocs_agent.param('force', default=False, type=bool)
-    def init_connection(self, session, params):
-        """init_connection(auto_acquire=False, force=False)
+    def _get_data_and_publish(self, pid: pd.PID, session: ocs_agent.OpSession):
+        data = {"timestamp": time.time(), "block_name": "HWPPID", "data": {}}
 
-        **Task** - Initialize connection to PID
-        Controller.
+        current_freq = pid.get_freq()
+        target_freq = pid.get_target()
+        direction = pid.get_direction()
 
-        Parameters:
-            auto_acquire (bool, optional): Default is False. Starts data
-                acquisition after initialization if True.
-            force (bool, optional): Force initialization, even if already
-                initialized. Defaults to False.
+        data["data"]["current_freq"] = current_freq
+        data["data"]["target_freq"] = target_freq
+        data["data"]["direction"] = direction
 
-        """
-        if self._initialized and not params['force']:
-            self.log.info("Connection already initialized. Returning...")
-            return True, "Connection already initialized"
+        session.data.update(
+            {
+                "current_freq": current_freq,
+                "target_freq": target_freq,
+                "direction": direction,
+                "last_updated": time.time(),
+            }
+        )
+        self.agent.publish_to_feed("hwppid", data)
 
-        with self.lock.acquire_timeout(10, job='init_connection') as acquired:
-            if not acquired:
-                self.log.warn(
-                    'Could not run init_connection because {} is already running'.format(self.lock.job))
-                return False, 'Could not acquire lock'
-
+    def _process_actions(self, pid):
+        while not self.action_queue.empty():
+            action = self.action_queue.get()
             try:
-                self.pid = pd.PID(ip=self.ip, port=self.port,
-                                  verb=self._verbosity)
-                self.log.info('Connected to PID controller')
-            except BrokenPipeError:
-                self.log.error('Could not establish connection to PID controller')
-                reactor.callFromThread(reactor.stop)
-                return False, 'Unable to connect to PID controller'
+                self.log.info(f"Running action {action}")
+                res = action.process(pid)
+                action.deferred.callback(res)
+            except Exception as e:
+                self.log.error(f"Error processing action: {action}")
+                action.deferred.errback(e)
 
-        self._initialized = True
+    def _clear_queue(self):
+        while not self.action_queue.empty():
+            action = self.action_queue.get()
+            action.deferred.errback(Exception("Action cancelled"))
 
-        # Start 'acq' Process if requested
-        if params['auto_acquire']:
-            self.agent.start('acq')
+    def main(self, session, params):
+        """main()
 
-        return True, 'Connection to PID controller established'
+        **Process** - Main Process for PID agent. Periodically queries PID
+            controller for data, and executes requested actions.
 
+        Notes:
+            The most recent data collected is stored in the session data in the
+            structure::
+
+                >>> response.session['data']
+                {'current_freq': 0,
+                 'target_freq': 0,
+                 'direction': 1,
+                 'last_updated': 1649085992.719602}
+        """
+        pid = pd.PID(ip=self.ip, port=self.port, verb=self._verbosity)
+        self.log.info("Connected to PID controller")
+
+        self._clear_queue()
+
+        sample_period = 5.0
+        last_sample = 0.0
+        session.set_status("running")
+        while session.status in ["starting", "running"]:
+            now = time.time()
+            if now - last_sample > sample_period:
+                self._get_data_and_publish(pid, session)
+                last_sample = now
+
+            self._process_actions(pid)
+            time.sleep(0.2)
+
+        return True, "Exited main process"
+
+    def _main_stop(self, session, params):
+        """Stop main process"""
+        session.set_status("stopping")
+        return True, "Set main status to stopping"
+
+    @defer.inlineCallbacks
     def tune_stop(self, session, params):
         """tune_stop()
 
@@ -81,16 +174,12 @@ class HWPPIDAgent:
         optimize the PID parameters for deceleration.
 
         """
-        with self.lock.acquire_timeout(3, job='tune_stop') as acquired:
-            if not acquired:
-                self.log.warn(
-                    'Could not tune stop because {} is already running'.format(self.lock.job))
-                return False, 'Could not acquire lock'
+        action = Actions.TuneStop(**params)
+        self.action_queue.put(action)
+        session.data = yield action.deferred
+        return True, f"Completed: {str(action)}"
 
-            self.pid.tune_stop()
-
-        return True, 'Reversing Direction'
-
+    @defer.inlineCallbacks
     def tune_freq(self, session, params):
         """tune_freq()
 
@@ -98,17 +187,13 @@ class HWPPIDAgent:
         and optimize the PID parameters for rotation.
 
         """
-        with self.lock.acquire_timeout(3, job='tune_freq') as acquired:
-            if not acquired:
-                self.log.warn(
-                    'Could not tune freq because {} is already running'.format(self.lock.job))
-                return False, 'Could not acquire lock'
+        action = Actions.TuneFreq(**params)
+        self.action_queue.put(action)
+        session.data = yield action.deferred
+        return True, f"Completed: {str(action)}"
 
-            self.pid.tune_freq()
-
-        return True, 'Tuning to setpoint'
-
-    @ocs_agent.param('freq', default=0., check=lambda x: 0. <= x <= 3.0)
+    @defer.inlineCallbacks
+    @ocs_agent.param("freq", default=0.0, check=lambda x: 0.0 <= x <= 3.0)
     def declare_freq(self, session, params):
         """declare_freq(freq=0)
 
@@ -119,19 +204,15 @@ class HWPPIDAgent:
             freq (float): Desired HWP rotation frequency
 
         """
-        with self.lock.acquire_timeout(3, job='declare_freq') as acquired:
-            if not acquired:
-                self.log.warn(
-                    'Could not declare freq because {} is already running'.format(self.lock.job))
-                return False, 'Could not acquire lock'
+        action = Actions.DeclareFreq(**params)
+        self.action_queue.put(action)
+        session.data = yield action.deferred
+        return True, f"Completed: {str(action)}"
 
-            self.pid.declare_freq(params['freq'])
-
-        return True, 'Setpoint at {} Hz'.format(params['freq'])
-
-    @ocs_agent.param('p', default=0.2, type=float, check=lambda x: 0. < x <= 8.)
-    @ocs_agent.param('i', default=63, type=int, check=lambda x: 0 <= x <= 200)
-    @ocs_agent.param('d', default=0., type=float, check=lambda x: 0. <= x < 10.)
+    @defer.inlineCallbacks
+    @ocs_agent.param("p", default=0.2, type=float, check=lambda x: 0.0 < x <= 8.0)
+    @ocs_agent.param("i", default=63, type=int, check=lambda x: 0 <= x <= 200)
+    @ocs_agent.param("d", default=0.0, type=float, check=lambda x: 0.0 <= x < 10.0)
     def set_pid(self, session, params):
         """set_pid(p=0.2, i=63, d=0.)
 
@@ -143,76 +224,14 @@ class HWPPIDAgent:
             p (float): Proportional PID value
             i (int): Integral PID value
             d (float): Derivative PID value
-
         """
-        with self.lock.acquire_timeout(3, job='set_pid') as acquired:
-            if not acquired:
-                self.log.warn(
-                    'Could not set pid because {} is already running'.format(self.lock.job))
-                return False, 'Could not acquire lock'
+        action = Actions.DeclareFreq(**params)
+        self.action_queue.put(action)
+        session.data = yield action.deferred
+        return True, f"Completed: {str(action)}"
 
-            self.pid.set_pid(
-                [params['p'], params['i'], params['d']])
-
-        return True, f"Set PID params to p: {params['p']}, i: {params['i']}, d: {params['d']}"
-
-    def get_freq(self, session, params):
-        """get_freq()
-
-        **Task** - Return the current HWP frequency as seen by the PID
-        controller.
-
-        """
-        with self.lock.acquire_timeout(3, job='get_freq') as acquired:
-            if not acquired:
-                self.log.warn(
-                    'Could not get freq because {} is already running'.format(self.lock.job))
-                return False, 'Could not acquire lock'
-
-            freq = self.pid.get_freq()
-            session.data = {
-                'freq': freq,
-                'timestamp': time.time(),
-            }
-
-        return True, 'Current frequency = {}'.format(freq)
-
-    def get_target(self, session, params):
-        """get_target()
-
-        **Task** - Return the target HWP frequency of the PID
-        controller.
-
-        """
-        with self.lock.acquire_timeout(3, job='get_target') as acquired:
-            if not acquired:
-                self.log.warn(
-                    'Could not get freq because {} is already running'.format(self.lock.job))
-                return False, 'Could not acquire lock'
-
-            freq = self.pid.get_target()
-
-        return True, 'Target frequency = {}'.format(freq)
-
-    def get_direction(self, session, params):
-        """get_direction()
-
-        **Task** - Return the current HWP tune direction as seen by the PID
-        controller.
-
-        """
-        with self.lock.acquire_timeout(3, job='get_direction') as acquired:
-            if not acquired:
-                self.log.warn(
-                    'Could not get freq because {} is already running'.format(self.lock.job))
-                return False, 'Could not acquire lock'
-
-            direction = self.pid.get_direction()
-            session.data = {'direction': direction}
-
-        return True, 'Current direction = {}'.format(['Forward', 'Reverse'][direction])
-
-    @ocs_agent.param('direction', type=str, default='0', choices=['0', '1'])
+    @defer.inlineCallbacks
+    @ocs_agent.param("direction", type=str, default="0", choices=["0", "1"])
     def set_direction(self, session, params):
         """set_direction(direction='0')
 
@@ -222,18 +241,16 @@ class HWPPIDAgent:
             direction (str): '0' for forward and '1' for reverse.
 
         """
-        with self.lock.acquire_timeout(3, job='set_direction') as acquired:
-            if not acquired:
-                self.log.warn(
-                    'Could not set direction because {} is already running'.format(self.lock.job))
-                return False, 'Could not acquire lock'
+        action = Actions.SetDirection(**params)
+        self.action_queue.put(action)
+        session.data = yield action.deferred
+        return True, f"Completed: {str(action)}"
 
-            self.pid.set_direction(params['direction'])
-
-        return True, 'Set direction'
-
-    @ocs_agent.param('slope', default=1., type=float, check=lambda x: -10. < x < 10.)
-    @ocs_agent.param('offset', default=0.1, type=float, check=lambda x: -10. < x < 10.)
+    @defer.inlineCallbacks
+    @ocs_agent.param("slope", default=1.0, type=float, check=lambda x: -10.0 < x < 10.0)
+    @ocs_agent.param(
+        "offset", default=0.1, type=float, check=lambda x: -10.0 < x < 10.0
+    )
     def set_scale(self, session, params):
         """set_scale(slope=1, offset=0.1)
 
@@ -247,87 +264,10 @@ class HWPPIDAgent:
                 voltage" relationship
 
         """
-        with self.lock.acquire_timeout(3, job='set_scale') as acquired:
-            if not acquired:
-                self.log.warn(
-                    'Could not set scale because {} is already running'.format(self.lock.job))
-                return False, 'Could not acquire lock'
-
-            self.pid.set_scale(params['slope'], params['offset'])
-
-        return True, 'Set scale'
-
-    def acq(self, session, params):
-        """acq()
-
-        **Process** - Start PID data acquisition.
-
-        Notes:
-            The most recent data collected is stored in the session data in the
-            structure::
-
-                >>> response.session['data']
-                {'current_freq': 0,
-                 'target_freq': 0,
-                 'direction': 1,
-                 'last_updated': 1649085992.719602}
-
-        """
-        with self.lock.acquire_timeout(timeout=10, job='acq') as acquired:
-            if not acquired:
-                self.log.warn('Could not start iv acq because {} is already running'
-                              .format(self.lock.job))
-                return False, 'Could not acquire lock'
-
-            session.set_status('running')
-            last_release = time.time()
-            self.take_data = True
-
-            while self.take_data:
-                # Relinquish sampling lock occasionally.
-                if time.time() - last_release > 1.:
-                    last_release = time.time()
-                    if not self.lock.release_and_acquire(timeout=10):
-                        self.log.warn(f"Failed to re-acquire sampling lock, "
-                                      f"currently held by {self.lock.job}.")
-                        continue
-
-                data = {'timestamp': time.time(),
-                        'block_name': 'HWPPID', 'data': {}}
-
-                try:
-                    current_freq = self.pid.get_freq()
-                    target_freq = self.pid.get_target()
-                    direction = self.pid.get_direction()
-
-                    data['data']['current_freq'] = current_freq
-                    data['data']['target_freq'] = target_freq
-                    data['data']['direction'] = direction
-                except BaseException:
-                    time.sleep(1)
-                    continue
-
-                self.agent.publish_to_feed('hwppid', data)
-
-                session.data = {'current_freq': current_freq,
-                                'target_freq': target_freq,
-                                'direction': direction,
-                                'last_updated': time.time()}
-
-                time.sleep(5)
-
-        self.agent.feeds['hwppid'].flush_buffer()
-        return True, 'Acqusition exited cleanly'
-
-    def _stop_acq(self, session, params):
-        """
-        Stop acq process.
-        """
-        if self.take_data:
-            self.take_data = False
-            return True, 'requested to stop taking data'
-
-        return False, 'acq is not currently running'
+        action = Actions.SetScale(**params)
+        self.action_queue.put(action)
+        session.data = yield action.deferred
+        return True, f"Completed: {str(action)}"
 
 
 def make_parser(parser=None):
@@ -339,49 +279,43 @@ def make_parser(parser=None):
         parser = argparse.ArgumentParser()
 
     # Add options specific to this agent
-    pgroup = parser.add_argument_group('Agent Options')
-    pgroup.add_argument('--ip')
-    pgroup.add_argument('--port')
-    pgroup.add_argument('--verbose', '-v', action='count', default=0,
-                        help='PID Controller verbosity level.')
-    pgroup.add_argument('--mode', type=str, default='acq',
-                        choices=['init', 'acq'],
-                        help="Starting operation for the Agent.")
+    pgroup = parser.add_argument_group("Agent Options")
+    pgroup.add_argument("--ip")
+    pgroup.add_argument("--port")
+    pgroup.add_argument(
+        "--verbose",
+        "-v",
+        action="count",
+        default=0,
+        help="PID Controller verbosity level.",
+    )
+    pgroup.add_argument("--mode")
     return parser
 
 
 def main(args=None):
     parser = make_parser()
-    args = site_config.parse_args(agent_class='HWPPIDAgent',
-                                  parser=parser,
-                                  args=args)
-
-    init_params = False
-    if args.mode == 'init':
-        init_params = {'auto_acquire': False}
-    elif args.mode == 'acq':
-        init_params = {'auto_acquire': True}
+    args = site_config.parse_args(agent_class="HWPPIDAgent", parser=parser, args=args)
 
     agent, runner = ocs_agent.init_site_agent(args)
-    hwppid_agent = HWPPIDAgent(agent, ip=args.ip,
-                               port=args.port,
-                               verbosity=args.verbose)
-    agent.register_task('init_connection', hwppid_agent.init_connection,
-                        startup=init_params)
-    agent.register_process('acq', hwppid_agent.acq,
-                           hwppid_agent._stop_acq)
-    agent.register_task('tune_stop', hwppid_agent.tune_stop)
-    agent.register_task('tune_freq', hwppid_agent.tune_freq)
-    agent.register_task('declare_freq', hwppid_agent.declare_freq)
-    agent.register_task('set_pid', hwppid_agent.set_pid)
-    agent.register_task('get_freq', hwppid_agent.get_freq)
-    agent.register_task('get_target', hwppid_agent.get_target)
-    agent.register_task('get_direction', hwppid_agent.get_direction)
-    agent.register_task('set_direction', hwppid_agent.set_direction)
-    agent.register_task('set_scale', hwppid_agent.set_scale)
 
+    if args.mode is not None:
+        agent.log.warn("--mode agrument is deprecated.")
+
+    hwppid_agent = HWPPIDAgent(
+        agent, ip=args.ip, port=args.port, verbosity=args.verbose
+    )
+    agent.register_process(
+        "main", hwppid_agent.main, hwppid_agent._main_stop, startup=True
+    )
+    agent.register_task("tune_stop", hwppid_agent.tune_stop, blocking=False)
+    agent.register_task("tune_freq", hwppid_agent.tune_freq, blocking=False)
+    agent.register_task("declare_freq", hwppid_agent.declare_freq, blocking=False)
+    agent.register_task("set_pid", hwppid_agent.set_pid, blocking=False)
+    agent.register_task("set_direction", hwppid_agent.set_direction, blocking=False)
+    agent.register_task("set_scale", hwppid_agent.set_scale, blocking=False)
     runner.run(agent, auto_reconnect=True)
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     main()

--- a/socs/agents/hwp_pid/agent.py
+++ b/socs/agents/hwp_pid/agent.py
@@ -1,18 +1,18 @@
 import argparse
+import queue
 import time
 
+import txaio
 from ocs import ocs_agent, site_config
 from ocs.ocs_twisted import TimeoutLock
-from twisted.internet import reactor, defer
-import queue
-
-import txaio
+from twisted.internet import defer, reactor
 
 txaio.use_twisted()
 
 
-import socs.agents.hwp_pid.drivers.pid_controller as pd
 from dataclasses import dataclass
+
+import socs.agents.hwp_pid.drivers.pid_controller as pd
 
 
 class Actions:

--- a/socs/agents/hwp_pid/agent.py
+++ b/socs/agents/hwp_pid/agent.py
@@ -5,7 +5,7 @@ import time
 import txaio
 from ocs import ocs_agent, site_config
 from ocs.ocs_twisted import TimeoutLock
-from twisted.internet import defer, reactor
+from twisted.internet import defer
 
 txaio.use_twisted()
 

--- a/socs/common/pmx.py
+++ b/socs/common/pmx.py
@@ -79,14 +79,16 @@ class PMX:
         self.ser.write("MEAS:CURR?\n\r")
         self.wait()
         try:
-            val = float(self.ser.readline())
-            msg = "Measured current = %.3f A" % (val)
+            val = self.ser.readline()
+            curr = float(val)
+            msg = "Measured current = %.3f A" % (curr)
             # print(msg)
         except ValueError:
-            val = -999.
+            print(f"Could not convert '{val}' to float")
+            curr = -999.
             msg = 'WARNING! Could not get correct current value! | Response = "%s"' % (val)
             print(msg)
-        return msg, val
+        return msg, curr
 
     def check_voltage_current(self):
         """Check both the voltage and current."""

--- a/socs/testing/device_emulator.py
+++ b/socs/testing/device_emulator.py
@@ -165,6 +165,7 @@ class DeviceEmulator:
             else:
                 response = self.responses[msg]
         except Exception as e:
+            self.logger.info(f"Responses: {self.responses}")
             self.logger.info(f"encountered error {e}")
             self.logger.info(tb.format_exc())
             response = None

--- a/socs/testing/device_emulator.py
+++ b/socs/testing/device_emulator.py
@@ -5,6 +5,7 @@ import subprocess
 import threading
 import time
 import traceback as tb
+from copy import deepcopy
 
 import pytest
 import serial
@@ -82,7 +83,7 @@ class DeviceEmulator:
     """
 
     def __init__(self, responses, encoding='utf-8'):
-        self.responses = responses
+        self.responses = deepcopy(responses)
         self.default_response = None
         self.encoding = encoding
         self._type = None
@@ -341,6 +342,6 @@ class DeviceEmulator:
 
         """
         self.logger.info(f"responses set to {responses}")
-        self.responses = responses
+        self.responses = deepcopy(responses)
         self.logger.info(f"default response set to '{default_response}'")
         self.default_response = default_response

--- a/socs/testing/device_emulator.py
+++ b/socs/testing/device_emulator.py
@@ -92,7 +92,7 @@ class DeviceEmulator:
         self.logger = logging.getLogger(self.__class__.__name__)
         self.logger.setLevel(logging.DEBUG)
         if len(self.logger.handlers) == 0:
-            formatter = logging.Formatter("%(name)s: %(message)s")
+            formatter = logging.Formatter("%(asctime)s - %(name)s: %(message)s")
             handler = logging.StreamHandler()
             handler.setFormatter(formatter)
             self.logger.addHandler(handler)

--- a/socs/testing/device_emulator.py
+++ b/socs/testing/device_emulator.py
@@ -4,6 +4,7 @@ import socket
 import subprocess
 import threading
 import time
+import traceback as tb
 
 import pytest
 import serial
@@ -165,6 +166,7 @@ class DeviceEmulator:
                 response = self.responses[msg]
         except Exception as e:
             self.logger.info(f"encountered error {e}")
+            self.logger.info(tb.format_exc())
             response = None
 
         return response

--- a/socs/testing/device_emulator.py
+++ b/socs/testing/device_emulator.py
@@ -90,10 +90,11 @@ class DeviceEmulator:
 
         self.logger = logging.getLogger(self.__class__.__name__)
         self.logger.setLevel(logging.DEBUG)
-        formatter = logging.Formatter("%(name)s: %(message)s")
-        handler = logging.StreamHandler()
-        handler.setFormatter(formatter)
-        self.logger.addHandler(handler)
+        if len(self.logger.handlers) == 0:
+            formatter = logging.Formatter("%(name)s: %(message)s")
+            handler = logging.StreamHandler()
+            handler.setFormatter(formatter)
+            self.logger.addHandler(handler)
 
     @staticmethod
     def _setup_socat():
@@ -140,7 +141,7 @@ class DeviceEmulator:
                                     target=self._read_serial)
         bkg_read.start()
 
-    def _get_response(self, msg):
+    def get_response(self, msg):
         """Determine the response to a given message.
 
         Args:
@@ -182,7 +183,7 @@ class DeviceEmulator:
                     msg = msg.strip().decode(self.encoding)
                 self.logger.debug(f"msg='{msg}'")
 
-                response = self._get_response(msg)
+                response = self.get_response(msg)
 
                 # Avoid user providing bytes-like response
                 if isinstance(response, bytes) and self.encoding is not None:
@@ -257,7 +258,7 @@ class DeviceEmulator:
             if msg:
                 self.logger.debug(f"msg='{msg}'")
 
-                response = self._get_response(msg)
+                response = self.get_response(msg)
 
                 # Avoid user providing bytes-like response
                 if isinstance(response, bytes) and self.encoding is not None:

--- a/socs/testing/device_emulator.py
+++ b/socs/testing/device_emulator.py
@@ -1,9 +1,9 @@
+import logging
 import shutil
 import socket
 import subprocess
 import threading
 import time
-import logging
 
 import pytest
 import serial

--- a/socs/testing/device_emulator.py
+++ b/socs/testing/device_emulator.py
@@ -6,6 +6,7 @@ import threading
 import time
 import traceback as tb
 from copy import deepcopy
+from typing import Dict
 
 import pytest
 import serial
@@ -311,7 +312,15 @@ class DeviceEmulator:
         while not self._sock_bound:
             time.sleep(0.1)
 
-    def update_responses(self, responses):
+    def update_responses(self, responses: Dict):
+        """
+        Updates the current responses. See ``define_responses`` for more detail.
+
+        Args
+        ------
+        responses: dict
+            Dict of commands to use to update the current responses.
+        """
         self.responses.update(responses)
         self.logger.info(f"responses set to {self.responses}")
 

--- a/socs/testing/device_emulator.py
+++ b/socs/testing/device_emulator.py
@@ -310,6 +310,10 @@ class DeviceEmulator:
         while not self._sock_bound:
             time.sleep(0.1)
 
+    def update_responses(self, responses):
+        self.responses.update(responses)
+        self.logger.info(f"responses set to {self.responses}")
+
     def define_responses(self, responses, default_response=None):
         """Define what responses are available to reply with on the configured
         communication relay.

--- a/socs/testing/device_emulator.py
+++ b/socs/testing/device_emulator.py
@@ -3,6 +3,7 @@ import socket
 import subprocess
 import threading
 import time
+import logging
 
 import pytest
 import serial
@@ -87,6 +88,13 @@ class DeviceEmulator:
         self._read = True
         self._conn = None
 
+        self.logger = logging.getLogger(self.__class__.__name__)
+        self.logger.setLevel(logging.DEBUG)
+        formatter = logging.Formatter("%(name)s: %(message)s")
+        handler = logging.StreamHandler()
+        handler.setFormatter(formatter)
+        self.logger.addHandler(handler)
+
     @staticmethod
     def _setup_socat():
         """Setup a data relay with socat.
@@ -155,7 +163,7 @@ class DeviceEmulator:
             else:
                 response = self.responses[msg]
         except Exception as e:
-            print(f"encountered error {e}")
+            self.logger.info(f"encountered error {e}")
             response = None
 
         return response
@@ -172,7 +180,7 @@ class DeviceEmulator:
                 msg = self.ser.readline()
                 if self.encoding:
                     msg = msg.strip().decode(self.encoding)
-                print(f"msg='{msg}'")
+                self.logger.debug(f"msg='{msg}'")
 
                 response = self._get_response(msg)
 
@@ -183,7 +191,7 @@ class DeviceEmulator:
                 if response is None:
                     continue
 
-                print(f"response='{response}'")
+                self.logger.debug(f"response='{response}'")
                 if self.encoding:
                     response = (response + '\r\n').encode(self.encoding)
                 self.ser.write(response)
@@ -230,24 +238,24 @@ class DeviceEmulator:
                 self._sock.bind(('127.0.0.1', port))
                 self._sock_bound = True
             except OSError:
-                print(f"Failed to bind to port {port}, trying again...")
+                self.logger.error(f"Failed to bind to port {port}, trying again...")
                 time.sleep(1)
         self._sock.listen(1)
-        print("Device emulator waiting for tcp client connection")
+        self.logger.info("Device emulator waiting for tcp client connection")
         self._conn, client_address = self._sock.accept()
-        print(f"Client connection made from {client_address}")
+        self.logger.info(f"Client connection made from {client_address}")
 
         while self._read:
             try:
                 msg = self._conn.recv(4096)
             # Was seeing this on tests in the cryomech agent
             except ConnectionResetError:
-                print('Caught connection reset on Agent clean up')
+                self.logger.info('Caught connection reset on Agent clean up')
                 break
             if self.encoding:
                 msg = msg.strip().decode(self.encoding)
             if msg:
-                print(f"msg='{msg}'")
+                self.logger.debug(f"msg='{msg}'")
 
                 response = self._get_response(msg)
 
@@ -258,7 +266,7 @@ class DeviceEmulator:
                 if response is None:
                     continue
 
-                print(f"response='{response}'")
+                self.logger.debug(f"response='{response}'")
                 if self.encoding:
                     response = response.encode(self.encoding)
                 self._conn.sendall(response)
@@ -324,7 +332,7 @@ class DeviceEmulator:
             ``encoding=None``.
 
         """
-        print(f"responses set to {responses}")
+        self.logger.info(f"responses set to {responses}")
         self.responses = responses
-        print(f"default response set to '{default_response}'")
+        self.logger.info(f"default response set to '{default_response}'")
         self.default_response = default_response

--- a/socs/testing/hwp_emulator.py
+++ b/socs/testing/hwp_emulator.py
@@ -5,6 +5,7 @@ import logging
 import threading
 import time
 from dataclasses import dataclass
+
 import pytest
 
 from socs.agents.hwp_pid.drivers.pid_controller import PID

--- a/socs/testing/hwp_emulator.py
+++ b/socs/testing/hwp_emulator.py
@@ -4,7 +4,7 @@ HWP Emulation module
 import logging
 import threading
 import time
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 
 import pytest
 
@@ -39,8 +39,8 @@ class PIDState:
 class HWPState:
     """State of the HWP Emulator"""
     cur_freq: float = 0.0
-    pmx: PMXState = PMXState()
-    pid: PIDState = PIDState()
+    pmx: PMXState = field(default_factory=PMXState)
+    pid: PIDState = field(default_factory=PIDState)
     lock = threading.Lock()
 
 

--- a/tests/integration/test_hwp_pid_agent_integration.py
+++ b/tests/integration/test_hwp_pid_agent_integration.py
@@ -2,6 +2,7 @@ import logging
 
 import ocs
 import pytest
+import time
 from integration.util import docker_compose_file  # noqa: F401
 from integration.util import create_crossbar_fixture
 from ocs.base import OpCode
@@ -16,6 +17,13 @@ run_agent_idle = create_agent_runner_fixture(
     '../socs/agents/hwp_pid/agent.py', 'hwp_pid_agent', args=['--mode', 'init', '--log-dir', './logs/'])
 client = create_client_fixture('hwp-pid')
 hwp_emu = create_hwp_emulator_fixture(pid_port=2000, log_level=logging.DEBUG)
+
+def wait_for_main(client):
+    while True:
+        data = client.main.status().session['data']
+        if 'last_updated' in data:
+            return
+        time.sleep(0.2)
 
 
 @pytest.mark.integtest
@@ -34,6 +42,7 @@ def test_hwp_rotation_get_state(wait_for_crossbar, hwp_emu, run_agent, client):
 
 @pytest.mark.integtest
 def test_hwp_rotation_set_direction(wait_for_crossbar, hwp_emu, run_agent, client):
+    wait_for_main(client)
     resp = client.set_direction(direction='0')
     assert resp.status == ocs.OK
     assert resp.session['op_code'] == OpCode.SUCCEEDED.value
@@ -49,6 +58,7 @@ def test_hwp_rotation_set_direction(wait_for_crossbar, hwp_emu, run_agent, clien
 
 @pytest.mark.integtest
 def test_hwp_rotation_set_pid(wait_for_crossbar, hwp_emu, run_agent, client):
+    wait_for_main(client)
     resp = client.set_pid(p=0.2, i=63, d=0)
     print(resp)
     assert resp.status == ocs.OK
@@ -58,6 +68,7 @@ def test_hwp_rotation_set_pid(wait_for_crossbar, hwp_emu, run_agent, client):
 
 @pytest.mark.integtest
 def test_hwp_rotation_tune_stop(wait_for_crossbar, hwp_emu, run_agent, client):
+    wait_for_main(client)
     resp = client.tune_stop()
     print(resp)
     assert resp.status == ocs.OK
@@ -67,6 +78,7 @@ def test_hwp_rotation_tune_stop(wait_for_crossbar, hwp_emu, run_agent, client):
 
 @pytest.mark.integtest
 def test_hwp_rotation_set_scale(wait_for_crossbar, hwp_emu, run_agent, client):
+    wait_for_main(client)
     resp = client.set_scale()
     print(resp)
     assert resp.status == ocs.OK
@@ -76,6 +88,7 @@ def test_hwp_rotation_set_scale(wait_for_crossbar, hwp_emu, run_agent, client):
 
 @pytest.mark.integtest
 def test_hwp_rotation_declare_freq(wait_for_crossbar, hwp_emu, run_agent, client):
+    wait_for_main(client)
     resp = client.declare_freq(freq=0)
     print(resp)
     assert resp.status == ocs.OK
@@ -85,6 +98,7 @@ def test_hwp_rotation_declare_freq(wait_for_crossbar, hwp_emu, run_agent, client
 
 @pytest.mark.integtest
 def test_hwp_rotation_tune_freq(wait_for_crossbar, hwp_emu, run_agent, client):
+    wait_for_main(client)
     resp = client.tune_freq()
     print(resp)
     assert resp.status == ocs.OK

--- a/tests/integration/test_hwp_pid_agent_integration.py
+++ b/tests/integration/test_hwp_pid_agent_integration.py
@@ -1,11 +1,13 @@
+import logging
+
 import ocs
 import pytest
 from integration.util import docker_compose_file  # noqa: F401
 from integration.util import create_crossbar_fixture
 from ocs.base import OpCode
 from ocs.testing import create_agent_runner_fixture, create_client_fixture
+
 from socs.testing.hwp_emulator import create_hwp_emulator_fixture
-import logging
 
 wait_for_crossbar = create_crossbar_fixture()
 run_agent = create_agent_runner_fixture(
@@ -14,7 +16,6 @@ run_agent_idle = create_agent_runner_fixture(
     '../socs/agents/hwp_pid/agent.py', 'hwp_pid_agent', args=['--mode', 'init', '--log-dir', './logs/'])
 client = create_client_fixture('hwp-pid')
 hwp_emu = create_hwp_emulator_fixture(pid_port=2000, log_level=logging.DEBUG)
-
 
 
 @pytest.mark.integtest

--- a/tests/integration/test_hwp_pid_agent_integration.py
+++ b/tests/integration/test_hwp_pid_agent_integration.py
@@ -1,8 +1,8 @@
 import logging
+import time
 
 import ocs
 import pytest
-import time
 from integration.util import docker_compose_file  # noqa: F401
 from integration.util import create_crossbar_fixture
 from ocs.base import OpCode
@@ -17,6 +17,7 @@ run_agent_idle = create_agent_runner_fixture(
     '../socs/agents/hwp_pid/agent.py', 'hwp_pid_agent', args=['--mode', 'init', '--log-dir', './logs/'])
 client = create_client_fixture('hwp-pid')
 hwp_emu = create_hwp_emulator_fixture(pid_port=2000, log_level=logging.DEBUG)
+
 
 def wait_for_main(client):
     while True:

--- a/tests/integration/test_hwp_pid_agent_integration.py
+++ b/tests/integration/test_hwp_pid_agent_integration.py
@@ -4,8 +4,8 @@ from integration.util import docker_compose_file  # noqa: F401
 from integration.util import create_crossbar_fixture
 from ocs.base import OpCode
 from ocs.testing import create_agent_runner_fixture, create_client_fixture
-
-from socs.testing.device_emulator import create_device_emulator
+from socs.testing.hwp_emulator import create_hwp_emulator_fixture
+import logging
 
 wait_for_crossbar = create_crossbar_fixture()
 run_agent = create_agent_runner_fixture(
@@ -13,8 +13,8 @@ run_agent = create_agent_runner_fixture(
 run_agent_idle = create_agent_runner_fixture(
     '../socs/agents/hwp_pid/agent.py', 'hwp_pid_agent', args=['--mode', 'init', '--log-dir', './logs/'])
 client = create_client_fixture('hwp-pid')
-pid_emu = create_device_emulator(
-    {'*W02400000': 'W02\r'}, relay_type='tcp', port=2000)
+hwp_emu = create_hwp_emulator_fixture(pid_port=2000, log_level=logging.DEBUG)
+
 
 
 @pytest.mark.integtest
@@ -24,67 +24,30 @@ def test_testing(wait_for_crossbar):
 
 
 @pytest.mark.integtest
-def test_hwp_rotation_failed_connection_pid(wait_for_crossbar, run_agent_idle, client):
-    resp = client.init_connection.start()
-    print(resp)
-    # We can't really check anything here, the agent's going to exit during the
-    # init_conneciton task because it cannot connect to the PID controller.
+def test_hwp_rotation_get_state(wait_for_crossbar, hwp_emu, run_agent, client):
+    resp = client.get_state()
+    state = resp.session['data']
+    print(state)
+    assert len(state.keys()) > 0
 
 
 @pytest.mark.integtest
-def test_hwp_rotation_get_direction(wait_for_crossbar, pid_emu, run_agent, client):
-    responses = {'*R02': 'R02400000\r'}
-    pid_emu.define_responses(responses)
-
-    client.init_connection.wait()  # wait for connection to be made
-    resp = client.get_direction()
-    print(resp)
-    assert resp.status == ocs.OK
-    print(resp.session)
-    assert resp.session['op_code'] == OpCode.SUCCEEDED.value
-
-    # Test when in reverse
-    responses = {'*W02401388': 'W02\r',
-                 '*R02': 'R02401388\r'}
-    pid_emu.define_responses(responses)
-
-    client.set_direction(direction='1')
-    resp = client.get_direction()
-    print(resp)
-    assert resp.status == ocs.OK
-    print(resp.session)
-    assert resp.session['op_code'] == OpCode.SUCCEEDED.value
-
-
-@pytest.mark.integtest
-def test_hwp_rotation_set_direction(wait_for_crossbar, pid_emu, run_agent, client):
-    responses = {'*W02400000': 'W02\r',
-                 '*W02401388': 'W02\r'}
-    pid_emu.define_responses(responses)
-
-    client.init_connection.wait()  # wait for connection to be made
+def test_hwp_rotation_set_direction(wait_for_crossbar, hwp_emu, run_agent, client):
     resp = client.set_direction(direction='0')
-    print(resp)
     assert resp.status == ocs.OK
-    print(resp.session)
     assert resp.session['op_code'] == OpCode.SUCCEEDED.value
+    data = client.get_state().session['data']
+    assert data['direction'] == '0'
 
     resp = client.set_direction(direction='1')
-    print(resp)
     assert resp.status == ocs.OK
-    print(resp.session)
     assert resp.session['op_code'] == OpCode.SUCCEEDED.value
+    data = client.get_state().session['data']
+    assert data['direction'] == '1'
 
 
 @pytest.mark.integtest
-def test_hwp_rotation_set_pid(wait_for_crossbar, pid_emu, run_agent, client):
-    responses = {'*W1700C8': 'W17\r',
-                 '*W18003F': 'W18\r',
-                 '*W190000': 'W19\r',
-                 '*Z02': 'Z02\r'}
-    pid_emu.define_responses(responses)
-
-    client.init_connection.wait()  # wait for connection to be made
+def test_hwp_rotation_set_pid(wait_for_crossbar, hwp_emu, run_agent, client):
     resp = client.set_pid(p=0.2, i=63, d=0)
     print(resp)
     assert resp.status == ocs.OK
@@ -93,17 +56,7 @@ def test_hwp_rotation_set_pid(wait_for_crossbar, pid_emu, run_agent, client):
 
 
 @pytest.mark.integtest
-def test_hwp_rotation_tune_stop(wait_for_crossbar, pid_emu, run_agent, client):
-    responses = {'*W0C83': 'W0C\r',
-                 '*W01400000': 'W01\r',
-                 '*R01': 'R01400000\r',
-                 '*Z02': 'Z02\r',
-                 '*W1700C8': 'W17\r',
-                 '*W180000': 'W18\r',
-                 '*W190000': 'W19\r'}
-    pid_emu.define_responses(responses)
-
-    client.init_connection.wait()  # wait for connection to be made
+def test_hwp_rotation_tune_stop(wait_for_crossbar, hwp_emu, run_agent, client):
     resp = client.tune_stop()
     print(resp)
     assert resp.status == ocs.OK
@@ -112,26 +65,7 @@ def test_hwp_rotation_tune_stop(wait_for_crossbar, pid_emu, run_agent, client):
 
 
 @pytest.mark.integtest
-def test_hwp_rotation_get_freq(wait_for_crossbar, pid_emu, run_agent, client):
-    responses = {'*X01': 'X010.000\r'}
-    pid_emu.define_responses(responses)
-
-    client.init_connection.wait()  # wait for connection to be made
-    resp = client.get_freq()
-    print(resp)
-    assert resp.status == ocs.OK
-    print(resp.session)
-    assert resp.session['op_code'] == OpCode.SUCCEEDED.value
-
-
-@pytest.mark.integtest
-def test_hwp_rotation_set_scale(wait_for_crossbar, pid_emu, run_agent, client):
-    responses = {'*W14102710': 'W14\r',
-                 '*W03302710': 'W03\r',
-                 '*Z02': 'Z02\r'}
-    pid_emu.define_responses(responses)
-
-    client.init_connection.wait()  # wait for connection to be made
+def test_hwp_rotation_set_scale(wait_for_crossbar, hwp_emu, run_agent, client):
     resp = client.set_scale()
     print(resp)
     assert resp.status == ocs.OK
@@ -140,8 +74,7 @@ def test_hwp_rotation_set_scale(wait_for_crossbar, pid_emu, run_agent, client):
 
 
 @pytest.mark.integtest
-def test_hwp_rotation_declare_freq(wait_for_crossbar, pid_emu, run_agent, client):
-    client.init_connection.wait()  # wait for connection to be made
+def test_hwp_rotation_declare_freq(wait_for_crossbar, hwp_emu, run_agent, client):
     resp = client.declare_freq(freq=0)
     print(resp)
     assert resp.status == ocs.OK
@@ -150,17 +83,7 @@ def test_hwp_rotation_declare_freq(wait_for_crossbar, pid_emu, run_agent, client
 
 
 @pytest.mark.integtest
-def test_hwp_rotation_tune_freq(wait_for_crossbar, pid_emu, run_agent, client):
-    responses = {'*W0C81': 'W0C\r',
-                 '*W01400000': 'W01\r',
-                 '*R01': 'R01400000\r',
-                 '*Z02': 'Z02\r',
-                 '*W1700C8': 'W17\r',
-                 '*W18003F': 'W18\r',
-                 '*W190000': 'W19\r'}
-    pid_emu.define_responses(responses)
-
-    client.init_connection.wait()  # wait for connection to be made
+def test_hwp_rotation_tune_freq(wait_for_crossbar, hwp_emu, run_agent, client):
     resp = client.tune_freq()
     print(resp)
     assert resp.status == ocs.OK

--- a/tests/integration/test_hwp_pmx_agent_integration.py
+++ b/tests/integration/test_hwp_pmx_agent_integration.py
@@ -45,9 +45,15 @@ def test_hwp_rotation_main(wait_for_crossbar, kikusui_emu, run_agent, client):
 
 @pytest.mark.integtest
 def test_hwp_rotation_set_off(wait_for_crossbar, kikusui_emu, run_agent, client):
-    responses = default_responses.copy()
+    # responses = default_responses.copy()
+    responses = {}
     responses.update({
-        'output 0': '', 'output?': '0'
+        'output 0': '', 'output?': '0',
+        'meas:volt?': '2',
+        'meas:curr?': '1',
+        ':system:error?': '+0,"No error"\n',
+        'stat:ques?': '0',
+        'volt:ext:sour?': 'source_name'
     })
     kikusui_emu.define_responses(responses)
     resp = client.set_off()

--- a/tests/integration/test_hwp_pmx_agent_integration.py
+++ b/tests/integration/test_hwp_pmx_agent_integration.py
@@ -43,7 +43,6 @@ def test_hwp_rotation_set_off(wait_for_crossbar, kikusui_emu, run_agent, client)
     kikusui_emu.update_responses({
         'output 0': '', 'output?': '0',
     })
-    kikusui_emu.define_responses(responses)
     resp = client.set_off()
     print(resp)
     print(resp.session)
@@ -65,10 +64,9 @@ def test_hwp_rotation_set_on(wait_for_crossbar, kikusui_emu, run_agent, client):
 
 @pytest.mark.integtest
 def test_hwp_rotation_set_i(wait_for_crossbar, kikusui_emu, run_agent, client):
-    responses = default_responses.copy()
-    responses.update({'curr 1.000000': '',
-                      'curr?': '1.000000'})
-    kikusui_emu.define_responses(responses)
+    kikusui_emu.update_responses(
+        {'curr 1.000000': '', 'curr?': '1.000000'}
+    )
     resp = client.set_i(curr=1)
     print(resp)
     print(resp.session)
@@ -78,10 +76,8 @@ def test_hwp_rotation_set_i(wait_for_crossbar, kikusui_emu, run_agent, client):
 
 @pytest.mark.integtest
 def test_hwp_rotation_set_i_lim(wait_for_crossbar, kikusui_emu, run_agent, client):
-    responses = default_responses.copy()
-    responses.update({'curr:prot 2.000000': '',
-                      'curr:prot?': '2.000000'})
-    kikusui_emu.define_responses(responses)
+    kikusui_emu.update_responses(
+        {'curr:prot 2.000000': '', 'curr:prot?': '2.000000'})
     resp = client.set_i_lim(curr=2)
     print(resp)
     print(resp.session)
@@ -91,10 +87,8 @@ def test_hwp_rotation_set_i_lim(wait_for_crossbar, kikusui_emu, run_agent, clien
 
 @pytest.mark.integtest
 def test_hwp_rotation_set_v(wait_for_crossbar, kikusui_emu, run_agent, client):
-    responses = default_responses.copy()
-    responses.update({'volt 1.000000': '',
-                      'volt?': '1.000000'})
-    kikusui_emu.define_responses(responses)
+    kikusui_emu.update_responses(
+        {'volt 1.000000': '', 'volt?': '1.000000'})
     resp = client.set_v(volt=1)
     print(resp)
     print(resp.session)
@@ -104,12 +98,10 @@ def test_hwp_rotation_set_v(wait_for_crossbar, kikusui_emu, run_agent, client):
 
 @pytest.mark.integtest
 def test_hwp_rotation_set_v_lim(wait_for_crossbar, kikusui_emu, run_agent, client):
-    responses = default_responses.copy()
-    responses.update({
+    kikusui_emu.update_responses({
         'volt:prot 10.0': '',
         'volt:prot?': '10.000000'
     })
-    kikusui_emu.define_responses(responses)
     resp = client.set_v_lim(volt=10)
     print(resp)
     print(resp.session)
@@ -119,10 +111,10 @@ def test_hwp_rotation_set_v_lim(wait_for_crossbar, kikusui_emu, run_agent, clien
 
 @pytest.mark.integtest
 def test_hwp_rotation_use_ext(wait_for_crossbar, kikusui_emu, run_agent, client):
-    responses = default_responses.copy()
-    responses.update({'volt:ext:sour VOLT': '',
-                      'volt:ext:sour?': 'source_name'})
-    kikusui_emu.define_responses(responses)
+    kikusui_emu.update_responses({
+        'volt:ext:sour VOLT': '',
+        'volt:ext:sour?': 'source_name',
+    })
     resp = client.use_ext()
     print(resp)
     print(resp.session)
@@ -132,11 +124,10 @@ def test_hwp_rotation_use_ext(wait_for_crossbar, kikusui_emu, run_agent, client)
 
 @pytest.mark.integtest
 def test_hwp_rotation_ign_ext(wait_for_crossbar, kikusui_emu, run_agent, client):
-    responses = default_responses.copy()
-    responses.update({'volt:ext:sour NONE': '',
-                      'volt:ext:sour?': 'False'})
-    kikusui_emu.define_responses(responses)
-
+    kikusui_emu.update_responses({
+        'volt:ext:sour NONE': '',
+        'volt:ext:sour?': 'False',
+    })
     resp = client.ign_ext()
     print(resp)
     print(resp.session)

--- a/tests/integration/test_hwp_pmx_agent_integration.py
+++ b/tests/integration/test_hwp_pmx_agent_integration.py
@@ -41,19 +41,6 @@ def test_hwp_rotation_main(wait_for_crossbar, kikusui_emu, run_agent, client):
     assert resp.session['success']
 
 
-@pytest.mark.integtest
-def test_hwp_rotation_set_on(wait_for_crossbar, kikusui_emu, run_agent, client):
-    responses = default_responses.copy()
-    responses.update({
-        'output 1': '',
-        'output?': '1'
-    })
-    kikusui_emu.define_responses(responses)
-    resp = client.set_on()
-    print(resp)
-    print(resp.session)
-    assert resp.status == ocs.OK
-    assert resp.session['success']
 
 
 @pytest.mark.integtest
@@ -64,6 +51,21 @@ def test_hwp_rotation_set_off(wait_for_crossbar, kikusui_emu, run_agent, client)
     })
     kikusui_emu.define_responses(responses)
     resp = client.set_off()
+    print(resp)
+    print(resp.session)
+    assert resp.status == ocs.OK
+    assert resp.session['success']
+
+
+@pytest.mark.integtest
+def test_hwp_rotation_set_on(wait_for_crossbar, kikusui_emu, run_agent, client):
+    responses = default_responses.copy()
+    responses.update({
+        'output 1': '',
+        'output?': '1'
+    })
+    kikusui_emu.define_responses(responses)
+    resp = client.set_on()
     print(resp)
     print(resp.session)
     assert resp.status == ocs.OK


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
This PR begins to implement an emulation framework for the HWP, to be used for testing HWP agent operation. Also restructures the HWP_PID to use the lockless format.

## Description
<!--- Describe your changes in detail -->

During the dev call, and while testing out HWP supervisor status at the site, there are a number of things that we still need to update in many of the HWP agents before we can reliably use them to observe. Due to the limited access to HWP hardware, a relatively realistic HWP emulator will be extremely helpful for developing changes, and testing them before testing on real hardware. This PR begins to implement this emulation, and I have tested it running against PID and PMX agents on my local development setup.

The data being returned from the emulator isn't perfect (especially since the PID interface requires some more reverse engineering), but it is good enough such that agent tasks are able to run successfully.

In testing, I was finding many instances in which the PID agent could not successfully run operations due to the locking structure, so I refactored that agent to have the same structure as the new timeout-lockless agents, and tested with the emulator.

This PR contains the following changes:
- Start of the HWP emulation framework
- PID lockless restructure
- some logging modifications to the DeviceEmulator class to make it more usable by general emulators like this

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
Tested by running with the HWP PMX and PID agents locally.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
