### PR TITLE
hwp-pcu: more robust get_status

### DIFF
--- a/socs/agents/hwp_pcu/agent.py
+++ b/socs/agents/hwp_pcu/agent.py
@@ -12,6 +12,7 @@ from ocs import ocs_agent, site_config
 
 import socs.agents.hwp_pcu.drivers.hwp_pcu as pcu
 
+
 class Actions:
     class BaseAction:
         def __post_init__(self):
@@ -22,11 +23,13 @@ class Actions:
     class SendCommand (BaseAction):
         command: str
 
+
 def process_action(action, PCU: pcu.PCU):
     """Process an action with PCU hardware"""
     if isinstance(action, Actions.SendCommand):
         PCU.send_command(action.command)
         action.log.info(f"Command: {action.command}")
+
 
 class HWPPCUAgent:
     """Agent to phase compensation improve the CHWP motor efficiency

--- a/socs/agents/hwp_pcu/agent.py
+++ b/socs/agents/hwp_pcu/agent.py
@@ -12,7 +12,6 @@ from ocs import ocs_agent, site_config
 
 import socs.agents.hwp_pcu.drivers.hwp_pcu as pcu
 
-
 class Actions:
     class BaseAction:
         def __post_init__(self):
@@ -23,35 +22,11 @@ class Actions:
     class SendCommand (BaseAction):
         command: str
 
-
 def process_action(action, PCU: pcu.PCU):
     """Process an action with PCU hardware"""
     if isinstance(action, Actions.SendCommand):
-        off_channel = []
-        on_channel = []
-        if action.command == 'off':
-            off_channel = [0, 1, 2, 5, 6, 7]
-            on_channel = []
-        elif action.command == 'on_1':
-            off_channel = [5, 6, 7]
-            on_channel = [0, 1, 2]
-        elif action.command == 'on_2':
-            on_channel = [0, 1, 2, 5, 6, 7]
-            off_channel = []
-        elif action.command == 'stop':
-            on_channel = [1, 2, 5]
-            off_channel = [0, 6, 7]
-
+        PCU.send_command(action.command)
         action.log.info(f"Command: {action.command}")
-        action.log.info(f"  Off channels: {off_channel}")
-        action.log.info(f"  On channels: {on_channel}")
-        for i in off_channel:
-            PCU.relay_off(i)
-        for i in on_channel:
-            PCU.relay_on(i)
-
-        return dict(off_channel=off_channel, on_channel=on_channel)
-
 
 class HWPPCUAgent:
     """Agent to phase compensation improve the CHWP motor efficiency
@@ -108,24 +83,44 @@ class HWPPCUAgent:
                 'block_name': 'hwppcu',
                 'data': {}}
         status = PCU.get_status()
+
         data['data']['status'] = status
         self.agent.publish_to_feed('hwppcu', data)
         session.data = {'status': status, 'last_updated': now}
+
+        if status in ['failed', 'undefined']:
+            PCU.clear_buffer()
+            self.log.warn(f'Status is {status}, cleared buffer')
+
+    def _clear_queue(self):
+        while not self.action_queue.empty():
+            action = self.action_queue.get()
+            action.deferred.errback(Exception("Action cancelled"))
 
     def main(self, session, params):
         """
         **Process** - Main process for PCU agent.
         """
-        PCU = pcu.PCU(port=self.port)
-        self.log.info('Connected to PCU')
-
+        PCU = None
         session.set_status('running')
-        while not self.action_queue.empty():
-            action = self.action_queue.get()
-            action.deferred.errback(Exception("Action cancelled"))
+
+        self._clear_queue()
 
         last_daq = 0
         while session.status in ['starting', 'running']:
+            if PCU is None:
+                try:
+                    PCU = pcu.PCU(port=self.port)
+                    self.log.info('Connected to PCU')
+                    PCU.clear_buffer()
+                    self.log.info('Cleared buffer')
+                except ConnectionRefusedError:
+                    self.log.error(
+                        "Could not connect to PCU. "
+                        "Retrying after 30 sec..."
+                    )
+                    time.sleep(30)
+                    continue
             now = time.time()
             if now - last_daq > 5:
                 self._get_and_publish_data(PCU, session)

--- a/socs/agents/hwp_pcu/agent.py
+++ b/socs/agents/hwp_pcu/agent.py
@@ -4,7 +4,7 @@ from dataclasses import dataclass
 from queue import Queue
 
 import txaio
-from twisted.internet import defer
+from twisted.internet import defer, reactor, threads
 
 txaio.use_twisted()
 
@@ -107,7 +107,7 @@ class HWPPCUAgent:
         PCU = None
         session.set_status('running')
 
-        self._clear_queue()
+        threads.blockingCallFromThread(reactor, self._clear_queue)
 
         last_daq = 0
         while session.status in ['starting', 'running']:

--- a/socs/agents/hwp_pcu/drivers/hwp_pcu.py
+++ b/socs/agents/hwp_pcu/drivers/hwp_pcu.py
@@ -1,4 +1,5 @@
 import time
+
 import serial
 
 patterns = {
@@ -68,7 +69,7 @@ class PCU:
 
     def send_command(self, command):
         pattern = patterns[command]
-        for i, p in zip([0,1,2,5,6,7], pattern):
+        for i, p in zip([0, 1, 2, 5, 6, 7], pattern):
             if p:
                 self.relay_on(i)
             else:

--- a/socs/agents/hwp_pcu/drivers/hwp_pcu.py
+++ b/socs/agents/hwp_pcu/drivers/hwp_pcu.py
@@ -59,6 +59,7 @@ class PCU:
         self.port.write(cmd.encode('utf-8'))
         self.sleep()
         response = self.read()
+        response = self.read()
         if response == "on":
             return 1
         elif response == "off":

--- a/socs/agents/hwp_pcu/drivers/hwp_pcu.py
+++ b/socs/agents/hwp_pcu/drivers/hwp_pcu.py
@@ -59,7 +59,6 @@ class PCU:
         self.port.write(cmd.encode('utf-8'))
         self.sleep()
         response = self.read()
-        response = self.read()
         if response == "on":
             return 1
         elif response == "off":

--- a/socs/agents/hwp_pcu/drivers/hwp_pcu.py
+++ b/socs/agents/hwp_pcu/drivers/hwp_pcu.py
@@ -1,6 +1,12 @@
 import time
-
 import serial
+
+patterns = {
+    'off': [0, 0, 0, 0, 0, 0],
+    'on_1': [1, 1, 1, 0, 0, 0],
+    'on_2': [1, 1, 1, 1, 1, 1],
+    'stop': [0, 1, 1, 1, 0, 0],
+}
 
 
 class PCU:
@@ -17,35 +23,58 @@ class PCU:
         self.port = serial.Serial(
             port,
             baudrate=19200,
-            timeout=10,
+            timeout=1,
+            bytesize=serial.EIGHTBITS,
+            stopbits=serial.STOPBITS_ONE,
         )
 
     def close(self):
         self.port.close()
 
+    def sleep(self):
+        time.sleep(0.1)
+
+    def read(self):
+        return self.port.read_until(b'\n\r').strip().decode()
+
+    def clear_buffer(self):
+        while True:
+            res = self.read()
+            if len(res) == 0:
+                break
+
     def relay_on(self, channel):
         cmd = "relay on " + str(channel) + "\n\r"
         self.port.write(cmd.encode('utf-8'))
-        time.sleep(.1)
+        self.sleep()
 
     def relay_off(self, channel):
         cmd = "relay off " + str(channel) + "\n\r"
         self.port.write(cmd.encode('utf-8'))
-        time.sleep(.1)
+        self.sleep()
 
     def relay_read(self, channel):
         cmd = "relay read " + str(channel) + "\n\r"
         self.port.write(cmd.encode('utf-8'))
-        time.sleep(.1)
-        response = self.port.read(25)
-        time.sleep(.1)
-        response = response.decode('utf-8')
-        if response.find("on") > 0:
-            return True
-        elif response.find("off") > 0:
-            return False
+        self.sleep()
+        response = self.read()
+        response = self.read()
+        if response == "on":
+            return 1
+        elif response == "off":
+            return 0
         else:
             return -1
+
+    def send_command(self, command):
+        pattern = patterns[command]
+        for i, p in zip([0,1,2,5,6,7], pattern):
+            if p:
+                self.relay_on(i)
+            else:
+                self.relay_off(i)
+            self.sleep()
+            self.read()
 
     def get_status(self):
         """get_status()
@@ -61,15 +90,9 @@ class PCU:
 
         for i in channel:
             channel_switch.append(self.relay_read(i))
-        if channel_switch == [False, False, False, False, False, False]:
-            return 'off'
-        elif channel_switch == [True, True, True, False, False, False]:
-            return 'on_1'
-        elif channel_switch == [True, True, True, True, True, True]:
-            return 'on_2'
-        elif channel_switch == [False, True, True, True, False, False]:
-            return 'stop'
-        elif -1 in channel_switch:
+        if -1 in channel_switch:
             return 'failed'
-        else:
-            return 'undefined'
+        for command, pattern in patterns.items():
+            if channel_switch == pattern:
+                return command
+        return 'undefined'


### PR DESCRIPTION
Make status check of hwp-pcu more robust

## Description
We had issue in the robustness of get_status in precious PR https://github.com/simonsobs/socs/pull/600 
Improved the robustness of the get_status by improving the read method and adding the clear_buffer.

## How Has This Been Tested?
Tested by phase compensation unit in UTokyo.
I would appreciate it if @17-sugiyama could double check.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
