### PR TITLE
Remove incompatible network_mode from example config

### DIFF
--- a/docs/agents/wiregrid_encoder.rst
+++ b/docs/agents/wiregrid_encoder.rst
@@ -54,17 +54,14 @@ An example docker-compose configuration::
       image: simonsobs/socs:latest
       restart: always
       hostname: ocs-docker
-      network_mode: "host"
       environment:
         - INSTANCE_ID=wgencoder
       volumes:
         - ${OCS_CONFIG_DIR}:/config:ro
         - "/data/wg-data:/data/wg-data"
       ports:
-          - "localhost:50007:50007/udp"
+          - "50007:50007/udp"
 
-- Since the agent within the container needs to communicate with hardware on the
-  host network you must use ``network_mode: "host"`` in your compose file.
 - ``/data/wg-data`` is a directory to store
   the information of the current angle of the wire-grid rotation,
   which is used in ``Wiregrid Kikusui Agent`` for feedback control of the rotation.


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->
"host" network mode is incompatible with port binding. The port binding example also shows a restriction to just accepting connections from localhost, which I don't think we want if the encoder is across the network and not running on the same machine that the wg-encoder agent is running.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
The daq-satp3 deployment configs used this combination "host" mode and port binding, which was preventing the wg-encoder agent container from coming online.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
The satp1 and satp3 configs have been updated to use just the non-`localhost` port binding, with no 'host' network mode.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
