### PR TITLE
Update on the treatment of logfile and log directory for the wiregrid kikusui agent

### DIFF
--- a/docs/agents/wiregrid_kikusui.rst
+++ b/docs/agents/wiregrid_kikusui.rst
@@ -56,16 +56,15 @@ An example docker-compose configuration::
         - INSTANCE_ID=wgkikusui
       volumes:
         - ${OCS_CONFIG_DIR}:/config:ro
-        - "<local directory to record log file>:/data/wg-data"
+        - "<local directory to record log file>:/data/wg-data/action"
 
 - Since the agent within the container needs to communicate with hardware on the
   host network you must use ``network_mode: "host"`` in your compose file.
 - To control the wire-grid rotation accurately,
-  the agent uses the output of the ``Wiregrid Encoder Agent``.
-  Therefore, mounting the volume of the ``ocs-wgencoder-agent`` is necessary.
+  the agent uses the OCS output of the ``Wiregrid Encoder Agent``.
 - For the ``calibration_wg()`` function and debug mode (assigned by ``--debug`` option),
   a directory path to log files should be assigned in the ``volumes`` section
-  (``/data/wg-data`` is the default path in the docker).
+  (``/data/wg-data/action`` is the path in the docker).
 
 
 Description

--- a/socs/agents/wiregrid_kikusui/agent.py
+++ b/socs/agents/wiregrid_kikusui/agent.py
@@ -386,7 +386,7 @@ class WiregridKikusuiAgent:
             return True, \
                 'Get wire-grid rotation angle = {} deg'.format(angle)
 
-    def calibrate_wg(self, session, params):
+    def calibrate_wg(self, session, params=None):
         """calibrate_wg()
 
         **Task** - Run rotation-motor calibration for wire-grid.

--- a/socs/agents/wiregrid_kikusui/agent.py
+++ b/socs/agents/wiregrid_kikusui/agent.py
@@ -41,7 +41,6 @@ class WiregridKikusuiAgent:
         self.encoder_agent = encoder_agent
         self.debug = debug
 
-        self.position_path = '/data/wg-data/position.log'
         self.debug_log_path = '/data/wg-data/action/'
 
         self.open_trial = 10
@@ -387,16 +386,12 @@ class WiregridKikusuiAgent:
             return True, \
                 'Get wire-grid rotation angle = {} deg'.format(angle)
 
-    @ocs_agent.param('storepath', default='/data/wg-data/action/', type=str)
     def calibrate_wg(self, session, params):
-        """calibrate_wg(storepath='/data/wg-data/action/')
+        """calibrate_wg()
 
         **Task** - Run rotation-motor calibration for wire-grid.
 
-        Parameters:
-            storepath (str): Path for log file.
         """
-        storepath = params.get('storepath')
 
         with self.lock.acquire_timeout(timeout=5, job='calibrate_wg')\
                 as acquired:
@@ -406,7 +401,7 @@ class WiregridKikusuiAgent:
                               .format(self.lock.job))
                 return False, 'Could not acquire lock'
 
-            logfile = openlog(storepath)
+            logfile = openlog(self.debug_log_path)
 
             cycle = 1
             for i in range(11):
@@ -468,14 +463,18 @@ class WiregridKikusuiAgent:
             self.feedback_time = params.get(
                 'feedback_time', [0.181, 0.221, 0.251, 0.281, 0.301])
 
-            logfile = openlog(self.debug_log_path)
+            if self.debug:
+                logfile = openlog(self.debug_log_path)
+            else:
+                logfile = None
 
             for i in range(int(self.num_laps * 16.)):
                 self._move_next(
                     logfile, self.feedback_steps, self.feedback_time)
                 time.sleep(self.stopped_time)
 
-            logfile.close()
+            if self.debug:
+                logfile.close()
 
             return True, 'Step-wise rotation finished'
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Update about `self.position_path`, `self.debug_log_path`, and `store_path`.
The `store_path` is used in `calibrate_wg()`, which is a function only for a test to evaluate the feedback parameters (`self.feedback_time` and `self.feedback_cut`).
- Remove unnecessary variable: `self.position_path`
- Merge `store_path` in `calibrate_wg()` function and `self.debug_log_path`
- Remove an argument of `store_path` in `calibrate_wg()`
- Add `if` when using `self.debug_log_path` in `stepwise_rotation()` function.


## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
These are modifications just to simplify the script and make it more reasonable.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
No

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
