### PR TITLE
Fix 'encoder_data' field when storing session.data

### DIFF
--- a/socs/agents/wiregrid_encoder/agent.py
+++ b/socs/agents/wiregrid_encoder/agent.py
@@ -316,7 +316,7 @@ class WiregridEncoderAgent:
                 }
                 session.data['timestamp'] = current_time
                 session.data['fields']['irig_data'] = irig_field_dict
-                session.data['fields']['enc_data'] = enc_field_dict
+                session.data['fields']['encoder_data'] = enc_field_dict
                 # End of loop
             # End of lock acquiring
 

--- a/socs/agents/wiregrid_kikusui/agent.py
+++ b/socs/agents/wiregrid_kikusui/agent.py
@@ -169,7 +169,7 @@ class WiregridKikusuiAgent:
 
         try:
             position = (float)(
-                response.session['data']['fields']['enc_data']['reference_degree'][-1])
+                response.session['data']['fields']['encoder_data']['reference_degree'][-1])
         except Exception as e:
             self.log.warn(
                 'Failed to get encoder position | '


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
This fixes the field name used to store 'encoder_data' in `session.data`. This should now match the documented structure.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
When testing sorunlib functionality at site with satp1 I found the `session.data` didn't have the expected field that I was trying to pull 'last_updated' from.

```
{
  "fields": {
    "irig_data": {
      "last_updated": 0,
      "irig_time": 0,
      "rising_edge_count": 0,
      "edge_diff": 0,
      "irig_sec": 0,
      "irig_min": 0,
      "irig_hour": 0,
      "irig_day": 0,
      "irig_year": 0
    },
    "encoder_data": {},
    "timestamp": 0,
    "enc_data": {
      "last_updated": 1706047078.7213721,
      "quadrature": [
        0,
        0,
        0,
        0,
        0,
        0,
        0,
        0,
        0,
        0,
        0
      ],
      "pru_clock": [
        152196144698317,
        152196154698448,
        152196164698596,
        152196174698727,
        152196184698875,
        152196194699006,
        152196204699154,
        152196214699285,
        152196224699433,
        152196234699564,
        152196244699712
      ],
      "reference_degree": [
        132.9923076923077,
        132.9923076923077,
        132.9923076923077,
        132.9923076923077,
        132.9923076923077,
        132.9923076923077,
        132.9923076923077,
        132.9923076923077,
        132.9923076923077,
        132.9923076923077,
        132.9923076923077
      ],
      "error": [
        0,
        0,
        0,
        0,
        0,
        0,
        0,
        0,
        0,
        0,
        0
      ]
    }
  },
  "timestamp": 1706047087.8708746
}
```

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
Not yet tested.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
