### PR TITLE
add documentation of udev rules for hwp-pcu

### DIFF
--- a/docs/agents/hwp_pcu.rst
+++ b/docs/agents/hwp_pcu.rst
@@ -18,6 +18,15 @@ motors the same.
     :func: make_parser
     :prog: python3 agent.py
 
+Dependencies
+------------
+
+The PCU device shows up on the system as /dev/ttyACMx where x is not guaranteed to be consistent. To solve this issue we should create a udev rule for the PCU device. The Lakeshore240's have solved the same issue by making udev rules in simonsobs/ls240-drivers repository. We can make the udev rule for PCU in the same way. The example is as follows::
+
+$ SUBSYSTEM == "tty", ATTRS{idVendor} == "2a19", ATTRS{idProduct} == "0c02", MODE = "0666", SYMLINK = "PCU"
+
+If your devices were plugged in already you will need to unplug and replug them for the udev rules to properly recognize the devices and set the path and permissions appropriately. Once you complete this step they will be recongized on reboots, and the udev rules will not need to be reinstalled unless you add a new device.
+
 Configuration File Examples
 ---------------------------
 

--- a/docs/agents/hwp_pcu.rst
+++ b/docs/agents/hwp_pcu.rst
@@ -21,19 +21,24 @@ motors the same.
 Dependencies
 ------------
 
-The PCU device shows up on the system as /dev/ttyACMx where x is not guaranteed
-to be consistent. To solve this issue we should create a udev rule for the PCU
-device. The Lakeshore240's have solved the same issue by making udev rules in
-simonsobs/ls240-drivers repository. We can make the udev rule for PCU in the
-same way. The example is as follows::
+The PCU device shows up on the system as ``/dev/ttyACMx`` where ``x`` is not
+guaranteed to be consistent. To solve this issue we should create a udev rule
+for the PCU device. Establish the udev rule by creating a file in
+``/etc/udev/rules.d/`` with the following contents::
 
-$ SUBSYSTEM == "tty", ATTRS{idVendor} == "2a19", ATTRS{idProduct} == "0c02", MODE = "0666", SYMLINK = "PCU"
+  SUBSYSTEM=="tty", ATTRS{idVendor}=="2a19", ATTRS{idProduct}=="0c02", MODE="0666", SYMLINK="PCU"
 
-If your devices were plugged in already you will need to unplug and replug them
-for the udev rules to properly recognize the devices and set the path and
-permissions appropriately. Once you complete this step they will be recongized
-on reboots, and the udev rules will not need to be reinstalled unless you add a
-new device.
+.. note::
+    If multiple PCU devices are connected to the same computer you will want to
+    include the serial number in the rules, which you can add with
+    ``ATTRS{serial}=="<serial number of PCU>"``.
+
+If the PCU was connected to the computer already you will need to unplug and
+replug it for the udev rule to properly recognize the device, create the
+symlink, and set the permissions appropriately. Once you complete this step the
+device will be recongized on reboot, and the udev rules will not need to be
+reinstalled unless you add a new device. The PCU should now be available at
+``/dev/PCU``.
 
 Configuration File Examples
 ---------------------------

--- a/docs/agents/hwp_pcu.rst
+++ b/docs/agents/hwp_pcu.rst
@@ -21,11 +21,19 @@ motors the same.
 Dependencies
 ------------
 
-The PCU device shows up on the system as /dev/ttyACMx where x is not guaranteed to be consistent. To solve this issue we should create a udev rule for the PCU device. The Lakeshore240's have solved the same issue by making udev rules in simonsobs/ls240-drivers repository. We can make the udev rule for PCU in the same way. The example is as follows::
+The PCU device shows up on the system as /dev/ttyACMx where x is not guaranteed
+to be consistent. To solve this issue we should create a udev rule for the PCU
+device. The Lakeshore240's have solved the same issue by making udev rules in
+simonsobs/ls240-drivers repository. We can make the udev rule for PCU in the
+same way. The example is as follows::
 
 $ SUBSYSTEM == "tty", ATTRS{idVendor} == "2a19", ATTRS{idProduct} == "0c02", MODE = "0666", SYMLINK = "PCU"
 
-If your devices were plugged in already you will need to unplug and replug them for the udev rules to properly recognize the devices and set the path and permissions appropriately. Once you complete this step they will be recongized on reboots, and the udev rules will not need to be reinstalled unless you add a new device.
+If your devices were plugged in already you will need to unplug and replug them
+for the udev rules to properly recognize the devices and set the path and
+permissions appropriately. Once you complete this step they will be recongized
+on reboots, and the udev rules will not need to be reinstalled unless you add a
+new device.
 
 Configuration File Examples
 ---------------------------


### PR DESCRIPTION
Add documentation of udev rules for hwp-pcu

## Description, Motivation and Context
Motivated by https://github.com/simonsobs/ocs-deployment-configs/issues/142. We considered adding rules in https://github.com/simonsobs/ls240-drivers, but we concluded that it will be enough to document it socs.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
