### PR TITLE
Fix some time-out / delay bugs in ACU agent

### DIFF
--- a/socs/agents/acu/agent.py
+++ b/socs/agents/acu/agent.py
@@ -1915,14 +1915,14 @@ class ACUAgent:
 
             yield self.acu_control.http.Command('DataSets.CmdTimePositionTransfer',
                                                 'Clear Stack')
-            yield dsleep(0.2)
+            yield dsleep(0.5)
 
             if azonly:
                 yield self._set_modes(az='ProgramTrack')
             else:
                 yield self._set_modes(az='ProgramTrack', el='ProgramTrack')
 
-            yield dsleep(0.5)
+            yield dsleep(0.1)
 
             # Values for mode are:
             # - 'go' -- keep uploading points (unless there are no more to upload).
@@ -2309,14 +2309,19 @@ class ACUAgent:
                 now = time.time()
                 # Different retry conditions for moveable / not moveable
                 if moveable and (now - last_panic > 60.):
+                    # When moveable, only attempt escape every 1 minute.
                     self.log.warn('monitor_sun is requesting escape_sun_now.')
-                    self.sun_params['next_drill'] = None
                     self.agent.start('escape_sun_now')
                     last_panic = now
                 elif not moveable and (now - last_panic > 600.):
+                    # When not moveable, only print complaint message every 10 minutes.
                     self.log.warn('monitor_sun cannot request escape_sun_now, '
-                                  'because platform not moveable by remote.')
+                                  'because platform not moveable by remote!')
                     last_panic = now
+
+                # Regardless, clear the drill indicator -- we don't
+                # want that to occur randomly later.
+                self.sun_params['next_drill'] = None
 
             # Update session.
             session.data.update(new_data)

--- a/socs/agents/acu/agent.py
+++ b/socs/agents/acu/agent.py
@@ -1992,7 +1992,12 @@ class ACUAgent:
                 if free_positions >= STACK_REFILL_THRESHOLD:
                     new_line_target = max(int(free_positions - STACK_TARGET), 1)
 
-                    while mode == 'go' and (len(lines) < new_line_target or lines[-1][0] != 0):
+                    # Make sure that you get one more line than you
+                    # need (len(lines) > new_line_target), so that
+                    # after "grabbing the minimum batch", below, there
+                    # is still >= 1 line left.  The lines-is-empty
+                    # check is used to decide we're done.
+                    while mode == 'go' and (len(lines) <= new_line_target or lines[-1][0] != 0):
                         try:
                             lines.extend(next(point_gen))
                         except StopIteration:

--- a/socs/agents/acu/agent.py
+++ b/socs/agents/acu/agent.py
@@ -1026,9 +1026,14 @@ class ACUAgent:
         # can be as long as 12 seconds.
         MAX_STARTUP_TIME = 13.
 
-        # Velocity to assume when computing maximum time a move should take (to bail
-        # out in unforeseen circumstances).
-        UNREASONABLE_VEL = 0.5
+        # Velocity to assume when computing maximum time a move should
+        # take (to bail out in unforeseen circumstances).  There are
+        # other checks in place to catch when the platform has not
+        # started moving or has stopped at the wrong place.  So the
+        # timeout computed from this should only activate in cases
+        # where some other commander has taken over and then kept the
+        # platform moving around.
+        UNREASONABLE_VEL = 0.1
 
         # Positive acknowledgment of AcuControl.go_to
         OK_RESPONSE = b'OK, Command executed.'


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Key features:
- ACU: go_to_axes patiently waits for the warning horn to sound
- ACU: suppress Sun escape (and logging) if platform not moveable
- ACU: allow more time for _run_scan to enter ProgramTrack mode
- ACU: increase overall timeout

## Motivation and Context

Addresses issues reported in #617, #619, #620.  There are a few mysteries remaining but I think we should close these and get clean measurements of any new problems.

Resolves #617.
Resolves #619.
Resolves #620.

## How Has This Been Tested?

Tested on SATP1.  "Not moveable" suppression of Sun avoidance escapes was simulated with a time-based hack.

I am comfortable running this on any platform as is.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
