### PR TITLE
Supervisor actions

### DIFF
--- a/docs/agents/hwp_supervisor_agent.rst
+++ b/docs/agents/hwp_supervisor_agent.rst
@@ -109,7 +109,7 @@ or not. For example, to spin up to a particular frequency, you can run:
                       {'class': 'Done', 'msg': None, 'success': True}],
           'success': True}
 
-To stop an action while its running, you can use the ``abort_action`` task, 
+To stop an action while its running, you can use the ``abort_action`` task,
 which will set the state of the current action to ``Abort``, and put the
 supervisor into the Idle state.
 
@@ -127,7 +127,7 @@ supervisor into the Idle state.
     print("Result 2: ")
     print(res2.session['data']['action'])
 
-    >> 
+    >>
     Result 1:
     {'action_id': 1,
     'completed': True,
@@ -139,7 +139,7 @@ supervisor into the Idle state.
                         'target_freq': 2.0},
                       {'class': 'Abort'}],
     'success': False}
-    Result 2: 
+    Result 2:
     {'action_id': 3,
     'completed': True,
     'cur_state': {'class': 'Done', 'msg': None, 'success': True},

--- a/docs/agents/hwp_supervisor_agent.rst
+++ b/docs/agents/hwp_supervisor_agent.rst
@@ -84,15 +84,15 @@ supervisor will do nothing until the HWP frequency is within tolerance of a
 specified freq for a specified period of time, at which point it will transition
 into the Done state.
 
-A *Control Action* is a user-requested operation, where a starting state can
-transition through any number of states before completing. The action object
-contains its current state, state history, completion status, and whether it
-considers itself successful. The action is considered "complete" when it
-transitions into a "completion state", which can be ``Done``, ``Error``,
-``Abort``, or ``Idle``, at which point no more state transitions will occur.
-In between update calls, a control action may be aborted by the state-machine,
-where the action will transition into the completed "Abort" state, and no further
-action will be taken.
+A *Control Action* is a user-requested operation, in which a starting control
+state is requested, that then transitions through any number of subsequent
+states before completing. The action object contains its current state, state
+history, completion status, and whether it considers itself successful. The
+action is considered "complete" when it transitions into a "completion state",
+which can be ``Done``, ``Error``, ``Abort``, or ``Idle``, at which point no more
+state transitions will occur.  In between update calls, a control action may be
+aborted by the state-machine, where the action will transition into the
+completed "Abort" state, and no further action will be taken.
 
 OCS agent operations are generally one-to-one with control actions, where each
 operation begins a new action, and sleeps until that action is complete.

--- a/socs/agents/hwp_supervisor/agent.py
+++ b/socs/agents/hwp_supervisor/agent.py
@@ -4,7 +4,7 @@ import threading
 import time
 import traceback
 from dataclasses import asdict, dataclass, field
-from typing import Optional, List, Dict
+from typing import Dict, List, Optional
 
 import numpy as np
 import ocs
@@ -14,8 +14,9 @@ from ocs.client_http import ControlClientError
 from ocs.ocs_client import OCSClient, OCSReply
 from ocs.ocs_twisted import Pacemaker
 
-
 client_cache = {}
+
+
 def get_op_data(agent_id, op_name, log=None, test_mode=False):
     """
     Process data from an agent operation, and formats it for the ``monitor``
@@ -362,12 +363,12 @@ class ControlState:
         def __init__(self):
             super().__init__()
             self.start_time = time.time()
-        
+
         def encode(self):
             d = {'class': self.__class__.__name__}
             d.update(asdict(self))
             return d
-        
+
     @dataclass
     class Idle(Base):
         """Does nothing"""
@@ -506,7 +507,8 @@ class ControlState:
         """Abort current action"""
         pass
 
-    completed_states = ( Done, Error, Abort, Idle )
+    completed_states = (Done, Error, Abort, Idle)
+
 
 class ControlAction:
     """
@@ -526,7 +528,7 @@ class ControlAction:
         self.success = False
         self.state_history = []
         self.set_state(state)
-    
+
     def set_state(self, state: ControlState.Base):
         """
         Sets state for the current action. If this is a `completed_state`,
@@ -538,7 +540,7 @@ class ControlAction:
             self.completed = True
         if isinstance(state, ControlState.Done):
             self.success = state.success
-        
+
     def encode(self):
         """Encodes this as a dict"""
         return dict(
@@ -548,10 +550,10 @@ class ControlAction:
             cur_state=self.cur_state.encode(),
             state_history=[s.encode() for s in self.state_history],
         )
-    
+
     def sleep_until_complete(self, session=None, dt=1):
         """
-        Sleeps until the action is complete. 
+        Sleeps until the action is complete.
 
         Args
         -----
@@ -567,6 +569,7 @@ class ControlAction:
             if self.completed:
                 return
             time.sleep(dt)
+
 
 class ControlStateMachine:
     def __init__(self):
@@ -1109,17 +1112,17 @@ def make_parser(parser=None):
                              "shutdown is triggered")
 
     pgroup.add_argument(
-        '--driver-iboot-id', 
+        '--driver-iboot-id',
         help="Instance ID for IBoot-PDU agent that powers the HWP Driver board")
     pgroup.add_argument(
-        '--driver-iboot-outlets', nargs='+', type=int, 
+        '--driver-iboot-outlets', nargs='+', type=int,
         help="Outlets for driver iboot power")
 
     pgroup.add_argument(
-        '--gripper-iboot-id', 
+        '--gripper-iboot-id',
         help="Instance ID for IBoot-PDU agent that powers the gripper controller")
     pgroup.add_argument(
-        '--gripper-iboot-outlets', nargs='+', type=int, 
+        '--gripper-iboot-outlets', nargs='+', type=int,
         help="Outlets for gripper iboot power")
 
     pgroup.add_argument('--forward-dir', choices=['cw', 'ccw'], default="cw",

--- a/socs/agents/hwp_supervisor/agent.py
+++ b/socs/agents/hwp_supervisor/agent.py
@@ -963,6 +963,18 @@ class HWPSupervisor:
         **Process** - Process to manage the spin-state for HWP agents. This will
         issue commands to various HWP agents depending on the current control
         state.
+
+        Notes
+        --------
+
+        Example of ``session.data``::
+
+            >>> session['data'] 
+            {
+                'current_action': <Encoded action>,
+                'action_history': List[Encoded action]
+                'timestammp': <time.time()>
+            }
         """
         clients = self._get_hwp_clients()
 
@@ -1000,6 +1012,20 @@ class HWPSupervisor:
         freq_thresh_duration : float
             Duration (seconds) for which the HWP must be within ``freq_thresh`` of the
             ``target_freq`` to be considered successful.
+
+        Notes
+        --------
+
+        Example of ``session.data``::
+
+            >>> session['data'] 
+            {'action': 
+                {'action_id': 3,
+                'completed': True,
+                'cur_state': {'class': 'Done', 'msg': None, 'success': True},
+                'state_history': List[ConrolState],
+                'success': True}
+            }
         """
         if params['target_freq'] >= 0:
             d = '0' if self.forward_is_cw else '1'
@@ -1031,6 +1057,20 @@ class HWPSupervisor:
             Direction of the HWP. Must be one of ``cw`` or ``ccw``,
             corresponding to the clockwise and counter-clockwise directions of
             the HWP, as seen when looking at the cryostat from the sky.
+
+        Notes
+        --------
+
+        Example of ``session.data``::
+
+            >>> session['data'] 
+            {'action': 
+                {'action_id': 3,
+                'completed': True,
+                'cur_state': {'class': 'Done', 'msg': None, 'success': True},
+                'state_history': List[ConrolState],
+                'success': True}
+            }
         """
         if params['direction'] == 'cw':
             d = '0' if self.forward_is_cw else '1'
@@ -1058,6 +1098,20 @@ class HWPSupervisor:
         freq_thresh_duration : float
             Duration (seconds) for which the HWP must be within ``freq_thresh`` of the
             ``target_freq`` to be considered successful.
+
+        Notes
+        --------
+
+        Example of ``session.data``::
+
+            >>> session['data'] 
+            {'action': 
+                {'action_id': 3,
+                'completed': True,
+                'cur_state': {'class': 'Done', 'msg': None, 'success': True},
+                'state_history': List[ConrolState],
+                'success': True}
+            }
         """
         state = ControlState.Brake(
             freq_tol=params['freq_tol'],
@@ -1071,6 +1125,20 @@ class HWPSupervisor:
         """pmx_off()
 
         **Task** - Sets the control state to turn off the PMX.
+
+        Notes
+        --------
+
+        Example of ``session.data``::
+
+            >>> session['data'] 
+            {'action': 
+                {'action_id': 3,
+                'completed': True,
+                'cur_state': {'class': 'Done', 'msg': None, 'success': True},
+                'state_history': List[ConrolState],
+                'success': True}
+            }
         """
         state = ControlState.PmxOff()
         action = self.control_state_machine.request_new_action(state)
@@ -1081,6 +1149,20 @@ class HWPSupervisor:
         """abort_action()
 
         **Task** - Aborts the current action, setting the control state to Idle
+
+        Notes
+        --------
+
+        Example of ``session.data``::
+
+            >>> session['data'] 
+            {'action': 
+                {'action_id': 3,
+                'completed': True,
+                'cur_state': {'class': 'Idle'},
+                'state_history': List[ConrolState],
+                'success': False}
+            }
         """
         state = ControlState.Idle()
         action = self.control_state_machine.request_new_action(state)

--- a/socs/agents/hwp_supervisor/agent.py
+++ b/socs/agents/hwp_supervisor/agent.py
@@ -1040,7 +1040,7 @@ class HWPSupervisor:
         )
         action = self.control_state_machine.request_new_action(state)
         action.sleep_until_complete(session=session)
-        return True, f"Completed with state: {action.cur_state}"
+        return action.success, f"Completed with state: {action.cur_state}"
 
     @ocs_agent.param('voltage', type=float)
     @ocs_agent.param('direction', type=str, choices=['cw', 'ccw'], default='cw')
@@ -1082,7 +1082,7 @@ class HWPSupervisor:
         )
         action = self.control_state_machine.request_new_action(state)
         action.sleep_until_complete(session=session)
-        return True, f"Completed with state: {action.cur_state}"
+        return action.success, f"Completed with state: {action.cur_state}"
 
     @ocs_agent.param('freq_tol', type=float, default=0.05)
     @ocs_agent.param('freq_tol_duration', type=float, default=10)
@@ -1119,7 +1119,7 @@ class HWPSupervisor:
         )
         action = self.control_state_machine.request_new_action(state)
         action.sleep_until_complete(session=session)
-        return True, f"Completed with state: {action.cur_state}"
+        return action.success, f"Completed with state: {action.cur_state}"
 
     def pmx_off(self, session, params):
         """pmx_off()
@@ -1143,7 +1143,7 @@ class HWPSupervisor:
         state = ControlState.PmxOff()
         action = self.control_state_machine.request_new_action(state)
         action.sleep_until_complete(session=session)
-        return True, f"Completed with state: {action.cur_state}"
+        return action.success, f"Completed with state: {action.cur_state}"
 
     def abort_action(self, session, params):
         """abort_action()

--- a/socs/testing/device_emulator.py
+++ b/socs/testing/device_emulator.py
@@ -28,7 +28,9 @@ def create_device_emulator(responses, relay_type, port=9001, encoding='utf-8',
         encoding (str): Encoding for the messages and responses. See
             :func:`socs.testing.device_emulator.DeviceEmulator` for more
             details.
-
+        reconnect (bool): If True, on TCP client disconnect, the emulator will
+            listen for new incoming connections instead of quitting
+        
     Returns:
         function:
             A pytest fixture that creates a Device emulator of the specified
@@ -67,6 +69,8 @@ class DeviceEmulator:
             given encoding. No encoding is used if set to None. That can be
             useful if you need to use raw data from your hardware. Defaults
             to 'utf-8'.
+        reconnect (bool): If True, on TCP client disconnect, the emulator will
+            listen for new incoming connections instead of quitting
 
     Attributes:
         responses (dict): Current set of responses the DeviceEmulator would

--- a/socs/testing/device_emulator.py
+++ b/socs/testing/device_emulator.py
@@ -254,6 +254,13 @@ class DeviceEmulator:
         while self._read:
             try:
                 msg = self._conn.recv(4096)
+                if not msg:
+                    # attempt to reconnect
+                    self.logger.info("Client disconnected, waiting for new connection")
+                    self._conn, client_address = self._sock.accept()
+                    self.logger.info(f"Client connection made from {client_address}")
+                    continue
+
             # Was seeing this on tests in the cryomech agent
             except ConnectionResetError:
                 self.logger.info('Caught connection reset on Agent clean up')

--- a/socs/testing/hwp_emulator.py
+++ b/socs/testing/hwp_emulator.py
@@ -6,7 +6,6 @@ import logging
 import threading
 import time
 from dataclasses import dataclass, field
-import argparse
 
 import pytest
 

--- a/socs/testing/hwp_emulator.py
+++ b/socs/testing/hwp_emulator.py
@@ -1,6 +1,7 @@
 """
 HWP Emulation module
 """
+import argparse
 import logging
 import threading
 import time

--- a/socs/testing/hwp_emulator.py
+++ b/socs/testing/hwp_emulator.py
@@ -5,6 +5,7 @@ import logging
 import threading
 import time
 from dataclasses import dataclass, field
+import argparse
 
 import pytest
 
@@ -105,6 +106,7 @@ class HWPEmulator:
             with s.lock:
                 if s.pmx.source == "volt":
                     s.cur_freq = lerp(s.cur_freq, s.pid.freq_setpoint, 0.3)
+            time.sleep(1)
 
     def process_pmx_msg(self, data):
         """Process messages for PMX emulator"""
@@ -214,7 +216,12 @@ def create_hwp_emulator_fixture(**kwargs):
 
 
 if __name__ == "__main__":
-    hwp_em = HWPEmulator()
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--pid-port", type=int, default=5025)
+    parser.add_argument("--pmx-port", type=int, default=5026)
+    args = parser.parse_args()
+
+    hwp_em = HWPEmulator(pid_port=args.pid_port, pmx_port=args.pmx_port)
     try:
         hwp_em.start()
         while True:

--- a/tests/agents/hwp_pid/test_pid_controller.py
+++ b/tests/agents/hwp_pid/test_pid_controller.py
@@ -2,7 +2,7 @@ from socs.agents.hwp_pid.drivers.pid_controller import PID
 from socs.testing.device_emulator import create_device_emulator
 
 pid_emu = create_device_emulator(
-    {'*W02400000': 'W02\r'}, relay_type='tcp', port=3003)
+    {'*W02400000': 'W02\r'}, relay_type='tcp', port=3003, reconnect=False)
 
 
 def test_send_message(pid_emu):


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Provides various updates to the HWP Supervisor required for site use.

## Description
<!--- Describe your changes in detail -->
This PR adds some changes that are necessary for the Supervisor to be run through sorunlib and the scheduler. Mainly, we needed a better way to track if a user-commanded operation has finished, and to determine if it was successful.

Currently, the supervisor is done by a fairly simple state machine, where agent tasks would put the machine in a particular state, and states could put the machine into a new state depending on the update function.

This PR modifies this a bit, by grouping states together into "Actions", based around user requests. Now, when a user runs an operation like `pid_to_freq`, instead of just setting the PidToFreq state, this will request a new Action that begins in the PidToFreq state. This action can be monitored until it enters a "completed" state (i.e. `Done`, `Error`, or `Abort`) at which point the action will no longer be modified. Actions provide a bit more extra book-keeping, including a unique id, the current state, the state-history of the action, and whether the action is completed and successful.

Tasks now will create an action, and monitor it until the action is completed, at which point the task will finish.

An action can be aborted by running the `abort_action` task, which will put the current action into the "Abort" state at the next opportunity, and will put the state machine into an idle state. 

Note: This requires changes from the hwp-emulation branch, so I set that as the base. I can change that after hwp-emulator is merged in.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Necessary behavior changes in order to add to next-line

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
Certain operations such as `pid_to_freq`, and `pmx_off` have been tested with the HWP emulator. We hope to be able to be able to test more on a real platform.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [X] My change requires a change to the documentation.
- [X] I have updated the documentation accordingly.
