### PR TITLE
moves callbacks to reactor in PCU agent

### DIFF
--- a/socs/agents/hwp_pcu/agent.py
+++ b/socs/agents/hwp_pcu/agent.py
@@ -75,10 +75,10 @@ class HWPPCUAgent:
             try:
                 self.log.info(f"Running action {action}")
                 res = process_action(action, PCU)
-                action.deferred.callback(res)
+                reactor.callFromThread(action.deferred.callback, res)
             except Exception as e:
                 self.log.error(f"Error processing action: {action}")
-                action.deferred.errback(e)
+                reactor.callFromThread(action.deferred.errback, e)
 
     def _get_and_publish_data(self, PCU: pcu.PCU, session):
         now = time.time()


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Fixes race condition from callbacks in PCU agent


## Description
<!--- Describe your changes in detail -->
During HWP testing today Kyohei and I saw some strange behavior in when calling PCU agent operations through a client, which I am pretty sure are due to how [this race condition](https://github.com/simonsobs/socs/issues/607) interacts  [with the OCS timeout logic](https://github.com/simonsobs/ocs/blob/7badb58c6094fba6f1607284df3437ce20c06e91/ocs/ocs_agent.py#L818-L837). The behavior we were seeing was that anytime we called an operation through an OCS client with a timeout that wasn't None, it would return a TIMEOUT error even when successful. 

For testing, we changed the supervisor agent to not set any timeouts when interacting with the PCU agent, but I'm pretty sure this can be fixed by fixing that race condition in the agent re-structure.

## Motivation and Context
Important for HWP supervisor

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
This has not been tested.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
