### PR TITLE
Change check range of gripper distance

### DIFF
--- a/socs/agents/hwp_gripper/agent.py
+++ b/socs/agents/hwp_gripper/agent.py
@@ -170,7 +170,7 @@ class HWPGripperAgent:
 
     @ocs_agent.param('mode', default='push', type=str, choices=['push', 'pos'])
     @ocs_agent.param('actuator', default=1, type=int, check=lambda x: 1 <= x <= 3)
-    @ocs_agent.param('distance', default=0, type=float, check=lambda x: -10. <= x <= 10.)
+    @ocs_agent.param('distance', default=0, type=float, check=lambda x: -20. <= x <= 20.)
     def move(self, session, params=None):
         """move(mode='push', actuator=1, distance=0)
 

--- a/socs/agents/hwp_gripper/agent.py
+++ b/socs/agents/hwp_gripper/agent.py
@@ -170,7 +170,6 @@ class HWPGripperAgent:
 
     @ocs_agent.param('mode', default='push', type=str, choices=['push', 'pos'])
     @ocs_agent.param('actuator', default=1, type=int, check=lambda x: 1 <= x <= 3)
-    @ocs_agent.param('distance', default=0, type=float, check=lambda x: -20. <= x <= 20.)
     def move(self, session, params=None):
         """move(mode='push', actuator=1, distance=0)
 

--- a/socs/agents/hwp_gripper/agent.py
+++ b/socs/agents/hwp_gripper/agent.py
@@ -170,6 +170,7 @@ class HWPGripperAgent:
 
     @ocs_agent.param('mode', default='push', type=str, choices=['push', 'pos'])
     @ocs_agent.param('actuator', default=1, type=int, check=lambda x: 1 <= x <= 3)
+    @ocs_agent.param('distance', default=0, type=float)
     def move(self, session, params=None):
         """move(mode='push', actuator=1, distance=0)
 


### PR DESCRIPTION
Change check range of gripper distance from 10 mm to 20 mm.

## Description
Since the actuator distance of the SATP3 is greater than 10 mm, it is helpful to allow a distance of up to 20 mm for the operation of the SATP3 gripper.

## How Has This Been Tested?
No testing is required because this is a very minor change.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
