### PR TITLE
Revert UV index scaling in vantage agent

### DIFF
--- a/socs/agents/vantagepro2/drivers.py
+++ b/socs/agents/vantagepro2/drivers.py
@@ -340,11 +340,10 @@ class VantagePro2:
         wind_speed = byte_data[10]
         loop_data['wind_chill_temp'] = F_to_C(wind_chill(temp, wind_speed))
 
-        # Correct UV Index by a factor of 10 and fix overflow
+        # Fix overflow
         uvi = loop_data['UV']
         if uvi < 0:
             uvi += 2**8
-        uvi /= 10
         loop_data['UV'] = uvi
 
         # CRC check, data must be sent byte by byte


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
This scaling changes the type from an int to a float, which once published to an InfluxDB is immutable without completely removing or rewriting the measurement.

The scaling can be handled on the display end in Grafana for until a solution is found.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
I'm trying to deploy an updated version of the agent to the site. The update includes changes from #539 and #550.

This'll allow resolution of all but one of the issues in #531.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
This has run on site with the vantage hardware.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
