### PR TITLE
Remove large data structures from IV session data

### DIFF
--- a/socs/agents/pysmurf_controller/agent.py
+++ b/socs/agents/pysmurf_controller/agent.py
@@ -718,10 +718,6 @@ class PysmurfController:
             S, cfg = self._get_smurf_control(session=session)
             iva = iv.take_iv(S, cfg, **params['kwargs'])
             session.data = {
-                'bands': iva.bands.tolist(),
-                'channels': iva.channels.tolist(),
-                'bgmap': iva.bgmap.tolist(),
-                'R_n': iva.R_n.tolist(),
                 'filepath': iva.filepath,
             }
             return True, "Finished taking IV"


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
There are a couple of large data structures stored in the session.data of `take_iv`. I'm concerned this is a potential location for the [data leak seen in the controllers](https://github.com/simonsobs/daq-discussions/discussions/59), so I think it's worth testing with these removed.

## Description
<!--- Describe your changes in detail -->
Removes large objects from take_iv session.data

## Motivation and Context
Potentially addresses [data leak seen in the pysmurf controllers](https://github.com/simonsobs/daq-discussions/discussions/59)
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
Not tested yet.
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
