### PR TITLE
hwp-pmx: reset protection code in clear_alarm

### DIFF
--- a/socs/agents/hwp_pmx/agent.py
+++ b/socs/agents/hwp_pmx/agent.py
@@ -158,6 +158,7 @@ class HWPPMXAgent:
         action = Actions.ClearAlarm(**params)
         self.action_queue.put(action)
         session.data = yield action.deferred
+        self.prot = 0
         return True, 'Clear alarm'
 
     @defer.inlineCallbacks


### PR DESCRIPTION
## Description
Minor debug of hwp-pmx.
We need to reset the protection code (self.prot) in clear_alarm task.
This was implemented in the previous version of agent (following link), but I forgot to include this self.prot reset when we refactored the hwp-pmx agent to be TimoutLock less.

https://github.com/simonsobs/socs/blob/288fb5c2cac25d554bcfa161e6fb455b7eee1fd5/socs/agents/hwp_pmx/agent.py#L129

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
