### PR TITLE
Backwards compatibility and packet drop counters

### DIFF
--- a/docs/agents/hwp_encoder.rst
+++ b/docs/agents/hwp_encoder.rst
@@ -88,6 +88,55 @@ If chwp is completely stopped, approx_hwp_freq will not be updated.::
      'irig_time':            1659486983,
      'irig_last_updated':    1659486983.8985631}
 
+Beaglebone Packet structure
+`````````````````````````````
+.. list-table:: Encoder Packet Structure v1
+   :widths: 20 20 60
+   :header-rows: 1
+
+   * - Field
+     - Type
+     - Description
+
+   * - header
+     - unsigned long
+     - Packet header to signal encoder info. This will be ``0x2eaf`` for packet
+       versions >= 1
+
+   * - version
+     - unsigned long
+     - The version of the packet
+
+   * - num_samples
+     - unsigned long
+     - The number of samples in the packet. Each sample has three 32 bit fields, the clock counter, the clock overflow, and the edge counter.
+
+   * - quad
+     - unsigned long
+     - Quad of the first sample in the packet. This will either be 1 or 0.
+
+   * - packet_counter
+     - unsigned long
+     - Counter that is incremented each time a packet is sent from the beaglebone
+
+   * - buffer_reset_counter
+     - unsigned long
+     - Counter that is incremented each time the encoder buffer on the
+       beaglebone is reset
+
+   * - clock counts
+     - array of ``nsamp`` unsigned longs
+     - lower 32 bits of the PRU clock counter
+
+   * - clock overflow
+     - array of ``nsamp`` unsigned longs
+     - upper 32 bits of the PRU clock counter
+
+   * - Edge indexes
+     - array of ``nsamp`` unsigned longs
+     - sample counter, incremented for each edge detected in th PRU
+  
+
 Agent API
 ---------
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
This PR is built on top of @ykyohei's branch to add packet drop book-keeping to the HWP encoder agent. The purpose of this is to add encoder packet versioning to remove tight coupling requirements between socs and sobonelib. Additionally, some changes were made to the way dropped packets were counted in order to get it to work on my test setup.

This will come with a corresponding PR to sobonelib that I will link when it is made.

## Description
<!--- Describe your changes in detail -->
This PR does makes the following changes:
- change `parse_counter_info` so that it takes a packet version, so it can still parse older versions of encoder packets
- Change the object in the `counter_queue` from an unnamed tuple of values to the `EncoderPacket` dataclass. This allows us to be more flexible in what data is parsed from the incoming packet, and makes it so code does not rely on hardcoded tuple indexes.
- Adds version info, and sample count to encoder data packets. Removes hardcoded counter lengths and packet sizes.
- In addition to publishing raw counters, this tracks the number of dropped edges, encoder packets, and encoder buffer resets (from the beaglebone PRU) so we can more easily track in grafana when there are data drops, and where they are occurring. This is required because computing diffs to find dropped samples in grafana can be finicky

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
This was required for getting packet drop testing working on my local beaglebone setup. Backwards compatibility stuff is so that we don't accidentally break other HWP systems on socs update.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
This has been tested on my local beaglebone with a fixed "HWP frequency"


