### PR TITLE
error handling for flowmeter agent

### DIFF
--- a/socs/agents/ifm_sbn246_flowmeter/agent.py
+++ b/socs/agents/ifm_sbn246_flowmeter/agent.py
@@ -110,7 +110,7 @@ class FlowmeterAgent:
             dp = int(self.daq_port)
             adr = "/iolinkmaster/port[{}]/iolinkdevice/pdin/getdata".format(dp)
             url = 'http://{}'.format(self.ip_address)
-            
+
             try:
                 r = requests.post(url, json={"code": "request", "cid": -1, "adr": adr})
             except requests.exceptions.ConnectionError as e:

--- a/socs/agents/ifm_sbn246_flowmeter/agent.py
+++ b/socs/agents/ifm_sbn246_flowmeter/agent.py
@@ -110,8 +110,14 @@ class FlowmeterAgent:
             dp = int(self.daq_port)
             adr = "/iolinkmaster/port[{}]/iolinkdevice/pdin/getdata".format(dp)
             url = 'http://{}'.format(self.ip_address)
+            
+            try:
+                r = requests.post(url, json={"code": "request", "cid": -1, "adr": adr})
+            except requests.exceptions.ConnectionError as e:
+                self.log.warn(f"Connection error occured: {e}")
+                pm.sleep()
+                continue
 
-            r = requests.post(url, json={"code": "request", "cid": -1, "adr": adr})
             value = r.json()['data']['value']
 
             flow_gpm, temp_f = extract(value)  # units [gallons/minute], [F]

--- a/socs/agents/ifm_sbn246_flowmeter/agent.py
+++ b/socs/agents/ifm_sbn246_flowmeter/agent.py
@@ -115,7 +115,6 @@ class FlowmeterAgent:
                 r = requests.post(url, json={"code": "request", "cid": -1, "adr": adr})
             except requests.exceptions.ConnectionError as e:
                 self.log.warn(f"Connection error occured: {e}")
-                pm.sleep()
                 continue
 
             value = r.json()['data']['value']


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Handling the following error for the flowmeter; noticed that pump skid 1 required frequent restarts due to this:

```
2024-03-22T10:08:04+0000 acq:0 CRASH: [Failure instance: Traceback: <class 'requests.exceptions.ConnectionError'>: ('Connection aborted.', ConnectionResetError(104, 'Connection reset by peer'))
```

## Motivation and Context
Need to implement connection error handling in agent 

## How Has This Been Tested?
Hasn't been tested at the site---currently have pump skid 1 agent with error handling running on daq-dev in case a connection error comes up soon. At the time of submitting this PR, no connection error has yet occurred. 

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
