### PR TITLE
Supervisor functionality for enabling/disabling HWP driver board

### DIFF
--- a/docs/agents/hwp_supervisor_agent.rst
+++ b/docs/agents/hwp_supervisor_agent.rst
@@ -38,9 +38,32 @@ Here is an example of a config block you can add to your ocs site-config file::
             '--ups-id', 'power-ups-az',
             '--ups-minutes-remaining-thresh', 45,
             '--iboot-id', 'power-iboot-hwp-2',
-            '--iboot-outlets', [1,2]
+            '--driver-iboot-id', 'hwp-synaccess-1',
+            '--driver-iboot-outlets', 4, 5,
+            '--driver-power-agent-type', 'synaccess',
+            '--driver-power-cycle-twice',
+            '--driver-power-cycle-wait-time', 300,
         ]}
 
+For SATP1, we use an ibootbar to power the driver, and it is not necessary to
+cycle the driver power twice, so the config will look like::
+
+       {'agent-class': 'HWPSupervisor',
+        'instance-id': 'hwp-supervisor',
+        'arguments': [
+            '--ybco-lakeshore-id', 'cryo-ls240-lsa2619',
+            '--ybco-temp-field', 'Channel_7',
+            '--ybco-temp-thresh', 75,
+            '--hwp-encoder-id', 'hwp-bbb-e1',
+            '--hwp-pmx-id', 'hwp-pmx',
+            '--hwp-pid-id', 'hwp-pid',
+            '--ups-id', 'power-ups-az',
+            '--ups-minutes-remaining-thresh', 45,
+            '--iboot-id', 'power-iboot-hwp-2',
+            '--driver-iboot-id', 'power-iboot-hwp-2',
+            '--driver-iboot-outlets', 1, 2,
+            '--driver-power-agent-type', 'iboot',
+        ]}
 
 Docker Compose
 ````````````````

--- a/docs/agents/hwp_supervisor_agent.rst
+++ b/docs/agents/hwp_supervisor_agent.rst
@@ -65,6 +65,11 @@ cycle the driver power twice, so the config will look like::
             '--driver-power-agent-type', 'iboot',
         ]}
 
+.. note::
+  The ``--driver-iboot-id`` and ``--driver-iboot-outlets`` arguments are
+  currently used to specify the agent-id and outlets for all power agent types,
+  not just ``iboot``.
+
 Docker Compose
 ````````````````
 


### PR DESCRIPTION
Adds a couple of tasks to the HWP supervisor that allows for enabling and disabling the HWP driver board.

## Description
One functionality missing in the supervisor agent, as described in [this discussion](https://github.com/simonsobs/chwp-discussions/discussions/19) is the ability to enable/disable the HWP driver board at the start/end of an observation, to turn off the HWP encoder LEDs. This PR adds operations that will do this, which can be put into the scheduler.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
Not tested yet

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
