### PR TITLE
Run nan_to_num on quantiles

### DIFF
--- a/socs/agents/pysmurf_controller/agent.py
+++ b/socs/agents/pysmurf_controller/agent.py
@@ -801,7 +801,7 @@ class PysmurfController:
                 if np.isnan(arr).all():
                     return None
                 labels = [f'{name}_q{q}' for q in quantiles]
-                qs = [float(np.nanquantile(arr, q / 100)) for q in quantiles]
+                qs = [float(np.nan_to_num(np.nanquantile(arr, q / 100))) for q in quantiles]
                 block = {
                     k: q
                     for k, q in zip(labels, qs)


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Replaces nans and +- inf in bias step quantile functions.

## Description
<!--- Describe your changes in detail -->
This should fix the issue with infs getting passed to session.data reported here: https://github.com/simonsobs/socs/issues/645


## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Resolves #645, which has been occasionally crashing the schedule.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
I've tested running the line w/ fake data to make sure there are no typos.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
