### PR TITLE
Bug fixes to get hwp_supervisor working for satp1

### DIFF
--- a/socs/agents/hwp_supervisor/agent.py
+++ b/socs/agents/hwp_supervisor/agent.py
@@ -242,13 +242,13 @@ class HWPState:
 
     def update_pmx_state(self, op):
         """
-        Updates state values from the pmx acq operation results.
+        Updates state values from the pmx main operation results.
 
         Args
         -----
         op : dict
             Dict containing the operations (from get_op_data) from the pmx
-            ``acq`` process
+            ``main`` process
         """
         keymap = {'pmx_current': 'curr', 'pmx_voltage': 'volt',
                   'pmx_source': 'source', 'pmx_last_updated': 'last_updated'}
@@ -256,13 +256,13 @@ class HWPState:
 
     def update_pid_state(self, op):
         """
-        Updates state values from the pid acq operation results.
+        Updates state values from the pid main operation results.
 
         Args
         -----
         op : dict
             Dict containing the operations (from get_op_data) from the pid
-            ``acq`` process
+            ``main`` process
         """
         self._update_from_keymap(op, {
             'pid_current_freq': 'current_freq',
@@ -359,12 +359,10 @@ class HWPState:
 
 class ControlState:
     """Namespace for HWP control state definitions"""
-    @dataclass
+    @dataclass(kw_only=True)
     class Base:
-        def __init__(self):
-            super().__init__()
-            self.start_time = time.time()
-            self.last_update_time = 0
+        start_time: float = field(default_factory=time.time)
+        last_update_time: float = 0
 
         def encode(self):
             d = {
@@ -413,7 +411,7 @@ class ControlState:
         freq_tol_duration: float
         direction: str
         check_wait_time: float = 15.0
-        start_time: float = field(default_factory=time.time)
+        start_time: float = field(default_factory=time.time, kw_only=True)
 
     @dataclass
     class WaitForTargetFreq(Base):
@@ -487,7 +485,7 @@ class ControlState:
             Time that the state was entered
         """
         traceback: str
-        start_time: float = field(default_factory=time.time)
+        start_time: float = field(default_factory=time.time, kw_only=True)
 
     @dataclass
     class Brake(Base):
@@ -720,7 +718,7 @@ class ControlStateMachine:
                 self.run_and_validate(clients.pid.tune_freq, timeout=60)
                 self.run_and_validate(
                     clients.pcu.send_command,
-                    kwargs={'command': 'off'}, timeout=None,
+                    kwargs={'command': 'off'}, timeout=None
                 )
                 self.action.set_state(ControlState.CheckInitialRotation(
                     target_freq=state.target_freq,
@@ -1074,7 +1072,7 @@ class HWPSupervisor:
             # 1. Gather data from relevant operations
             temp_op = get_op_data(self.ybco_lakeshore_id, 'acq', **kw)
             enc_op = get_op_data(self.hwp_encoder_id, 'acq', **kw)
-            pmx_op = get_op_data(self.hwp_pmx_id, 'acq', **kw)
+            pmx_op = get_op_data(self.hwp_pmx_id, 'main', **kw)
             pid_op = get_op_data(self.hwp_pid_id, 'main', **kw)
             ups_op = get_op_data(self.ups_id, 'acq', **kw)
 

--- a/socs/agents/hwp_supervisor/agent.py
+++ b/socs/agents/hwp_supervisor/agent.py
@@ -359,10 +359,10 @@ class HWPState:
 
 class ControlState:
     """Namespace for HWP control state definitions"""
-    @dataclass(kw_only=True)
+    @dataclass
     class Base:
-        start_time: float = field(default_factory=time.time)
-        last_update_time: float = 0
+        start_time: float = field(default_factory=time.time, kw_only=True)
+        last_update_time: float = field(default=0, kw_only=True)
 
         def encode(self):
             d = {

--- a/socs/agents/hwp_supervisor/agent.py
+++ b/socs/agents/hwp_supervisor/agent.py
@@ -718,7 +718,7 @@ class ControlStateMachine:
                 self.run_and_validate(clients.pid.tune_freq, timeout=60)
                 self.run_and_validate(
                     clients.pcu.send_command,
-                    kwargs={'command': 'off'}, timeout=None
+                    kwargs={'command': 'off'}, timeout=None,
                 )
                 self.action.set_state(ControlState.CheckInitialRotation(
                     target_freq=state.target_freq,


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Modifications to the hwp_supervisor agent to get it working with the most recent docker images

## Description
<!--- Describe your changes in detail -->
Renamed the pid monitoring process to `main` from `acq`
Changed the structure of the `ControlState.Base()` class to allow for proper inheritance

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
When testing with the most recent docker images, the process `spin_control` continually crashes with the error `spin_control:1 CRASH: [Failure instance: Traceback: <class 'AttributeError'>: 'Idle' object has no attribute 'start_time'`. Upon investigation the cause was found to be because of improper inheritance of the base class `ControlState.Base()`

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
This was tested by running the agent on daq-satp1 and calling the functions: `pid_to_freq`, `brake`, `pmx_off`, `enable_driver_board`, and `disable_driver_board`

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
