### PR TITLE
Removes subclassing for ControlStates

### DIFF
--- a/socs/agents/hwp_supervisor/agent.py
+++ b/socs/agents/hwp_supervisor/agent.py
@@ -242,13 +242,13 @@ class HWPState:
 
     def update_pmx_state(self, op):
         """
-        Updates state values from the pmx acq operation results.
+        Updates state values from the pmx main operation results.
 
         Args
         -----
         op : dict
             Dict containing the operations (from get_op_data) from the pmx
-            ``acq`` process
+            ``main`` process
         """
         keymap = {'pmx_current': 'curr', 'pmx_voltage': 'volt',
                   'pmx_source': 'source', 'pmx_last_updated': 'last_updated'}
@@ -256,13 +256,13 @@ class HWPState:
 
     def update_pid_state(self, op):
         """
-        Updates state values from the pid acq operation results.
+        Updates state values from the pid main operation results.
 
         Args
         -----
         op : dict
             Dict containing the operations (from get_op_data) from the pid
-            ``acq`` process
+            ``main`` process
         """
         self._update_from_keymap(op, {
             'pid_current_freq': 'current_freq',
@@ -1084,7 +1084,7 @@ class HWPSupervisor:
             # 1. Gather data from relevant operations
             temp_op = get_op_data(self.ybco_lakeshore_id, 'acq', **kw)
             enc_op = get_op_data(self.hwp_encoder_id, 'acq', **kw)
-            pmx_op = get_op_data(self.hwp_pmx_id, 'acq', **kw)
+            pmx_op = get_op_data(self.hwp_pmx_id, 'main', **kw)
             pid_op = get_op_data(self.hwp_pid_id, 'main', **kw)
             ups_op = get_op_data(self.ups_id, 'acq', **kw)
 

--- a/socs/agents/hwp_supervisor/agent.py
+++ b/socs/agents/hwp_supervisor/agent.py
@@ -356,31 +356,40 @@ class HWPState:
         else:  # Only grip if the hwp_freq is smaller than 0.01
             return 'stop'
 
+class ControlStateInfo:
+    def __init__(self, state):
+        """
+        Class that holds the control state dataclass, and relevant metadata
+        such as start time and last_update time.
+
+        Args
+        ------
+        state : ControlState
+            ControlState object
+        """
+        self.state = state
+        self.last_update_time = 0
+        self.start_time = time.time()
+        self.state_type = state.__class__.__name__
+    
+    def encode(self):
+        d = {
+            'state_type': self.state_type,
+            'start_time': self.start_time,
+            'last_update_time': self.last_update_time,
+        }
+        d.update(asdict(self.state))
+        return d
+
 
 class ControlState:
     """Namespace for HWP control state definitions"""
     @dataclass
-    class Base:
-        def __init__(self):
-            super().__init__()
-            self.start_time = time.time()
-            self.last_update_time = 0
-
-        def encode(self):
-            d = {
-                'class': self.__class__.__name__,
-                'start_time': self.start_time,
-                'last_update_time': self.last_update_time,
-            }
-            d.update(asdict(self))
-            return d
-
-    @dataclass
-    class Idle(Base):
+    class Idle:
         """Does nothing"""
 
     @dataclass
-    class PIDToFreq(Base):
+    class PIDToFreq:
         """
         Configures PID and PMX agents to PID to a target frequency.
 
@@ -402,7 +411,7 @@ class ControlState:
         freq_tol_duration: float
 
     @dataclass
-    class CheckInitialRotation(Base):
+    class CheckInitialRotation:
         """
         In this state, will check if the HWP has started rotating. If it has not
         started rotating in ``check_wait_time`` seconds, it will briefly turn on the PCU
@@ -416,7 +425,7 @@ class ControlState:
         start_time: float = field(default_factory=time.time)
 
     @dataclass
-    class WaitForTargetFreq(Base):
+    class WaitForTargetFreq:
         """
         Wait until HWP reaches its target frequency before transitioning to
         the Done state.
@@ -443,7 +452,7 @@ class ControlState:
         _pcu_enabled: bool = field(init=False, default=False)
 
     @dataclass
-    class ConstVolt(Base):
+    class ConstVolt:
         """
         Configure PMX agent to output a constant voltage.
 
@@ -458,7 +467,7 @@ class ControlState:
         direction: str
 
     @dataclass
-    class Done(Base):
+    class Done:
         """
         Signals the last state has completed
 
@@ -475,7 +484,7 @@ class ControlState:
         msg: str = None
 
     @dataclass
-    class Error(Base):
+    class Error:
         """
         Signals the last state update threw an error
 
@@ -490,7 +499,7 @@ class ControlState:
         start_time: float = field(default_factory=time.time)
 
     @dataclass
-    class Brake(Base):
+    class Brake:
         """
         Configure the PID and PMX agents to actively brake the HWP
         """
@@ -499,7 +508,7 @@ class ControlState:
         brake_voltage: float
 
     @dataclass
-    class WaitForBrake(Base):
+    class WaitForBrake:
         """
         Waits until the HWP has slowed before shutting off PMX
 
@@ -510,7 +519,7 @@ class ControlState:
         prev_freq: float = None
 
     @dataclass
-    class PmxOff(Base):
+    class PmxOff:
         """
         Turns off the PMX
 
@@ -522,12 +531,12 @@ class ControlState:
         success: bool = True
 
     @dataclass
-    class Abort(Base):
+    class Abort:
         """Abort current action"""
         pass
 
     @dataclass
-    class EnableDriverBoard(Base):
+    class EnableDriverBoard:
         """
         Enables driver boards for encoder LEDs
 
@@ -558,7 +567,7 @@ class ControlState:
             self.cycle_timestamp = None
 
     @dataclass
-    class DisableDriverBoard(Base):
+    class DisableDriverBoard:
         """
         Disables driver board for encoder LEDs
 
@@ -591,7 +600,7 @@ class ControlAction:
     _cur_action_id: int = 0
     _id_lock = threading.Lock()
 
-    def __init__(self, state: ControlState.Base):
+    def __init__(self, state):
         with ControlAction._id_lock:
             self.action_id = ControlAction._cur_action_id
             ControlAction._cur_action_id += 1
@@ -602,13 +611,13 @@ class ControlAction:
         self.log = txaio.make_logger()  # pylint: disable=E1101
         self.set_state(state)
 
-    def set_state(self, state: ControlState.Base):
+    def set_state(self, state):
         """
         Sets state for the current action. If this is a `completed_state`,
         will mark as complete.
         """
-        self.state_history.append(state)
-        self.cur_state = state
+        self.cur_state_info = ControlStateInfo(state)
+        self.state_history.append(self.cur_state_info)
         self.log.info(f"Setting state: {state}")
         if isinstance(state, ControlState.completed_states):
             self.completed = True
@@ -621,7 +630,7 @@ class ControlAction:
             action_id=self.action_id,
             completed=self.completed,
             success=self.success,
-            cur_state=self.cur_state.encode(),
+            cur_state=self.cur_state_info.encode(),
             state_history=[s.encode() for s in self.state_history],
         )
 
@@ -702,8 +711,8 @@ class ControlStateMachine:
         """Run the next series of actions for the current state"""
         try:
             self.lock.acquire()
-            state = self.action.cur_state
-            state.last_update_time = time.time()
+            state = self.action.cur_state_info.state
+            self.action.cur_state_info.last_update_time = time.time()
 
             def query_pid_state():
                 data = self.run_and_validate(clients.pid.get_state)['data']
@@ -912,7 +921,7 @@ class ControlStateMachine:
         finally:
             self.lock.release()
 
-    def request_new_action(self, state: ControlState.Base):
+    def request_new_action(self, state):
         """
         Requests that a new action is started with a given state.
         If an action is already in progress, it will be aborted.
@@ -1117,6 +1126,7 @@ class HWPSupervisor:
         session.status = 'stopping'
         return True, 'Stopping monitor process'
 
+    @ocs_agent.param('test_mode', type=bool, default=False)
     def spin_control(self, session, params):
         """spin_control()
 
@@ -1146,6 +1156,8 @@ class HWPSupervisor:
                 'action_history': [a.encode() for a in self.control_state_machine.action_history],
                 'timestamp': time.time()
             }
+            if params['test_mode']:
+                break
             time.sleep(1)
         return True, "Finished spin control process"
 

--- a/socs/agents/hwp_supervisor/agent.py
+++ b/socs/agents/hwp_supervisor/agent.py
@@ -1213,7 +1213,7 @@ class HWPSupervisor:
         )
         action = self.control_state_machine.request_new_action(state)
         action.sleep_until_complete(session=session)
-        return action.success, f"Completed with state: {action.cur_state}"
+        return action.success, f"Completed with state: {action.cur_state_info.state}"
 
     @ocs_agent.param('voltage', type=float)
     @ocs_agent.param('direction', type=str, choices=['cw', 'ccw'], default='cw')
@@ -1255,7 +1255,7 @@ class HWPSupervisor:
         )
         action = self.control_state_machine.request_new_action(state)
         action.sleep_until_complete(session=session)
-        return action.success, f"Completed with state: {action.cur_state}"
+        return action.success, f"Completed with state: {action.cur_state_info.state}"
 
     @ocs_agent.param('freq_tol', type=float, default=0.05)
     @ocs_agent.param('freq_tol_duration', type=float, default=10)
@@ -1296,7 +1296,7 @@ class HWPSupervisor:
         )
         action = self.control_state_machine.request_new_action(state)
         action.sleep_until_complete(session=session)
-        return action.success, f"Completed with state: {action.cur_state}"
+        return action.success, f"Completed with state: {action.cur_state_info.state}"
 
     def pmx_off(self, session, params):
         """pmx_off()
@@ -1320,7 +1320,7 @@ class HWPSupervisor:
         state = ControlState.PmxOff()
         action = self.control_state_machine.request_new_action(state)
         action.sleep_until_complete(session=session)
-        return action.success, f"Completed with state: {action.cur_state}"
+        return action.success, f"Completed with state: {action.cur_state_info.state}"
 
     def abort_action(self, session, params):
         """abort_action()
@@ -1374,7 +1374,7 @@ class HWPSupervisor:
         state = ControlState.EnableDriverBoard(**kw)
         action = self.control_state_machine.request_new_action(state)
         action.sleep_until_complete(session=session)
-        return action.success, f"Completed with state: {action.cur_state}"
+        return action.success, f"Completed with state: {action.cur_state_info.state}"
 
     def disable_driver_board(self, session, params):
         """disable_driver_board()
@@ -1402,7 +1402,7 @@ class HWPSupervisor:
         state = ControlState.DisableDriverBoard(**kw)
         action = self.control_state_machine.request_new_action(state)
         action.sleep_until_complete(session=session)
-        return action.success, f"Completed with state: {action.cur_state}"
+        return action.success, f"Completed with state: {action.cur_state_info.state}"
 
 
 def make_parser(parser=None):

--- a/socs/agents/hwp_supervisor/agent.py
+++ b/socs/agents/hwp_supervisor/agent.py
@@ -356,6 +356,7 @@ class HWPState:
         else:  # Only grip if the hwp_freq is smaller than 0.01
             return 'stop'
 
+
 class ControlStateInfo:
     def __init__(self, state):
         """
@@ -371,7 +372,7 @@ class ControlStateInfo:
         self.last_update_time = 0
         self.start_time = time.time()
         self.state_type = state.__class__.__name__
-    
+
     def encode(self):
         d = {
             'state_type': self.state_type,

--- a/socs/agents/hwp_supervisor/agent.py
+++ b/socs/agents/hwp_supervisor/agent.py
@@ -1135,6 +1135,12 @@ class HWPSupervisor:
         issue commands to various HWP agents depending on the current control
         state.
 
+        Args
+        ----------
+        test_mode : bool
+            If True, spin_control loop will run a single update iteration before
+            exiting. This is useful for testing actions.
+
         Notes
         --------
 

--- a/tests/agents/test_hwp_supervisor_agent.py
+++ b/tests/agents/test_hwp_supervisor_agent.py
@@ -14,6 +14,21 @@ def create_session(op_name):
     return session
 
 
+def test_hwp_supervisor_control():
+    mock_agent = mock.MagicMock()
+    log = txaio.make_logger()
+    txaio.start_logging(level='debug')
+    mock_agent.log = log
+    log.info('Initialized mock OCSAgent')
+    parser = make_parser()
+    args = parser.parse_args(args=['--hwp-encoder-id', 'test'])
+    agent = HWPSupervisor(mock_agent, args)
+    session = create_session('spin_control')
+    params = {'test_mode': True}
+    success, result = agent.spin_control(session, params)
+    return
+
+
 def test_hwp_supervisor_agent():
     mock_agent = mock.MagicMock()
     log = txaio.make_logger()


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Bugfixes that are related to subclassing dataclasses

## Description
<!--- Describe your changes in detail -->
This fixes the same problem that @bbixler500 addresses in https://github.com/simonsobs/socs/pull/657, however does it by replacing the inheritance of the `Base` class with the addition of a `ControlStateInfo` class that manages general state metadata such as start and last update time, and the state-name.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
This fixes issues in the current code where having a dataclass subclass a non-dataclass object will overwrite the __init__ function, leaving fields undefined.

I think Bryce's method of using `kw_only=True` is a valid fix, but only works python >=3.10.

Since the mechanics of combining dataclasses and inheritance is not fully clear to me, I think its generally better to use this method even after python3.10, since the inheritance is more prone to error.
## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
I added a hwp-supervisor unit test that exposes the existing bug, and it is passes with the new code. If @bbixler500 or @ykyohei could test on one of the sat platforms that would be ideal though.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
