### PR TITLE
ACU: fix crash of monitor_sun when ACU not on

### DIFF
--- a/socs/agents/acu/agent.py
+++ b/socs/agents/acu/agent.py
@@ -2284,7 +2284,10 @@ class ACUAgent:
                 },
             })
 
-            sun_is_real = True  # flags time shift during debugging.
+            # Flags for unsafe position.
+            safety_known, danger_zone, warning_zone = False, False, False
+            # Flag for time shift during debugging.
+            sun_is_real = True
             if self.sun is not None:
                 info = self.sun.get_sun_pos(az, el)
                 sun_is_real = ('WARNING' not in info)
@@ -2292,13 +2295,9 @@ class ACUAgent:
                 if az is not None:
                     t = self.sun.check_trajectory([az], [el])['sun_time']
                     new_data['sun_pos']['sun_safe_time'] = t if t > 0 else 0
-
-            # Are we currently in safe position?
-            safety_known, danger_zone, warning_zone = False, False, False
-            if self.sun is not None:
-                safety_known = True
-                danger_zone = (t < self.sun_params['policy']['min_sun_time'])
-                warning_zone = (t < self.sun_params['policy']['response_time'])
+                    safety_known = True
+                    danger_zone = (t < self.sun_params['policy']['min_sun_time'])
+                    warning_zone = (t < self.sun_params['policy']['response_time'])
 
             # Has a drill been requested?
             drill_req = (self.sun_params['next_drill'] is not None


### PR DESCRIPTION
## Description

Fix logic error in monitor_sun process, where a stale (or undefined) timestamp could be used to determine danger/warning zone. This was most likely to be activated on Agent startup, if the ACU was not reachable, on first loop iteration in monitor_sun.

## Motivation and Context

Resolves #661 

## How Has This Been Tested?

Tested on satp2, where ACU is currently off.  Process did not crash and exit.

This is unlikely to cause any issue for existing installations, as the change is minor.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
