### PR TITLE
Remove instances of session.set_status('starting')

### DIFF
--- a/socs/agents/generator/agent.py
+++ b/socs/agents/generator/agent.py
@@ -329,8 +329,6 @@ class GeneratorAgent:
                               "{} is already running".format(self.lock.job))
                 return False, "Could not acquire lock."
 
-            session.set_status('starting')
-
             self._connect()
             if not self.initialized:
                 return False, 'Could not connect to generator'

--- a/socs/agents/labjack/agent.py
+++ b/socs/agents/labjack/agent.py
@@ -246,7 +246,6 @@ class LabJackAgent:
                               "{} is already running".format(self.lock.job))
                 return False, "Could not acquire lock."
 
-            session.set_status('starting')
             # Connect with the labjack
             self.handle = ljm.openS("ANY", "ANY", self.ip_address)
             info = ljm.getHandleInfo(self.handle)

--- a/socs/agents/lakeshore240/agent.py
+++ b/socs/agents/lakeshore240/agent.py
@@ -64,8 +64,6 @@ class LS240_Agent:
                               "{} is already running".format(self.lock.job))
                 return False, "Could not acquire lock."
 
-            session.set_status('starting')
-
             self.module = Module(port=self.port)
             print("Initialized Lakeshore module: {!s}".format(self.module))
             session.add_message("Lakeshore initialized with ID: %s" % self.module.inst_sn)

--- a/socs/agents/lakeshore425/agent.py
+++ b/socs/agents/lakeshore425/agent.py
@@ -68,8 +68,6 @@ class LS425Agent:
                               "{} is already running".format(self.lock.job))
                 return False, "Could not acquire lock."
 
-            session.set_status('starting')
-
             self.dev = ls.LakeShore425(self.port)
             self.log.info(self.dev.get_id())
             print("Initialized Lakeshore module: {!s}".format(self.dev))

--- a/socs/agents/pysmurf_controller/agent.py
+++ b/socs/agents/pysmurf_controller/agent.py
@@ -714,7 +714,6 @@ class PysmurfController:
             if not acquired:
                 return False, f"Operation failed: {self.lock.job} is running."
 
-            session.set_status('starting')
             S, cfg = self._get_smurf_control(session=session)
             iva = iv.take_iv(S, cfg, **params['kwargs'])
             session.data = {
@@ -778,7 +777,6 @@ class PysmurfController:
             if not acquired:
                 return False, f"Operation failed: {self.lock.job} is running."
 
-            session.set_status('starting')
             S, cfg = self._get_smurf_control(session=session)
             bsa = bias_steps.take_bias_steps(
                 S, cfg, **params['kwargs']
@@ -881,7 +879,6 @@ class PysmurfController:
             if not acquired:
                 return False, f"Operation failed: {self.lock.job} is running."
 
-            session.set_status('starting')
             S, cfg = self._get_smurf_control(session=session)
             bwa = bias_wave.take_bias_waves(
                 S, cfg, **params['kwargs']

--- a/socs/agents/smurf_file_emulator/agent.py
+++ b/socs/agents/smurf_file_emulator/agent.py
@@ -689,7 +689,6 @@ class SmurfFileEmulator:
             tag (str, optional):
                 User tag to add to the g3 stream.
         """
-        session.set_status('starting')
 
         if self.tune is None:
             raise ValueError("No tune loaded!")

--- a/socs/agents/vantagepro2/agent.py
+++ b/socs/agents/vantagepro2/agent.py
@@ -78,8 +78,6 @@ class VantagePro2Agent:
                               "{} is already running".format(self.lock.job))
                 return False, "Could not acquire lock."
 
-            session.set_status('starting')
-
             self._initialize_module()
 
         # Start data acquisition if requested


### PR DESCRIPTION
These conflict with recent ocs, where status comes in as "running" already, and "starting" is going backwards

## Motivation and Context

Test failure in #663 -- I guess test system just starting using newer OCS with the session fixes / changes in it?

## How Has This Been Tested?

Just the CI.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
