### PR TITLE
Remove mibBuilder from MBG-SYNCBOX-N2X-MIB.py

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -16,6 +16,7 @@ exclude =
     socs/mibs/MBG-SNMP-ROOT-MIB.py,
     socs/mibs/IBOOTPDU-MIB.py,
     socs/mibs/UPS-MIB.py,
+    socs/mibs/MBG-SYNCBOX-N2X-MIB.py,
     versioneer.py,
     docs/conf.py,
 per-file-ignores =

--- a/socs/mibs/MBG-SYNCBOX-N2X-MIB.py
+++ b/socs/mibs/MBG-SYNCBOX-N2X-MIB.py
@@ -5,9 +5,6 @@
 # On host HAWKING platform Linux version 5.15.90.1-microsoft-standard-WSL2 by user davidvng
 # Using Python version 3.8.8 (default, Apr 13 2021, 19:58:26)
 #
-from pysnmp.smi import builder
-
-mibBuilder = builder.MibBuilder()
 
 Integer, ObjectIdentifier, OctetString = mibBuilder.importSymbols("ASN1", "Integer", "ObjectIdentifier", "OctetString")
 NamedValues, = mibBuilder.importSymbols("ASN1-ENUMERATION", "NamedValues")


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Removes `mibBuilder` from `MBG-SYNCBOX-N2X-MIB.py` which had overwritten the `mibBuilder` instantiated in `snmp.py`, thus removing the `MIB_SOURCE` path added in `snmp.py`.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
The Syncbox Agent was failing due to SNMP not being able to find the new MIB. This import at the top of the MIB file was automatically generated from using `mibdump.py` to convert the ASN1 file to a .py MIB.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
Tested on Syncbox agent running on `daq-dev`

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
