### PR TITLE
Moves pysmurf-controller functions that load lots of data to subprocess

### DIFF
--- a/socs/agents/pysmurf_controller/agent.py
+++ b/socs/agents/pysmurf_controller/agent.py
@@ -21,9 +21,9 @@ from ocs.ocs_twisted import TimeoutLock
 from sodetlib.det_config import DetConfig
 from sodetlib.operations import (bias_dets, bias_steps, bias_wave, iv,
                                  uxm_relock, uxm_setup)
+
 from socs.agents.pysmurf_controller.smurf_subprocess_util import (
-    RunCfg, RunResult, run_func_in_subprocess, NBIASLINES
-)
+    NBIASLINES, RunCfg, RunResult, run_func_in_subprocess)
 
 
 class PysmurfScriptProtocol(protocol.ProcessProtocol):
@@ -86,6 +86,7 @@ def set_session_data(session, result: RunResult):
         session.data = result.return_val
     else:
         session.data = {'data': result.return_val}
+
 
 class PysmurfController:
     """
@@ -341,12 +342,12 @@ class PysmurfController:
     def _stop_check_state(self, session, params):
         """Stopper for check state process"""
         session.set_status('stopping')
-    
+
     def run_test_func(self, session, params):
         """
         Task to run subprocess test function
         """
-        cfg =RunCfg(
+        cfg = RunCfg(
             func_name='test',
         )
         result = run_func_in_subprocess(cfg)
@@ -359,7 +360,6 @@ class PysmurfController:
             session.data['data'] = result.return_val
 
         return result.success, 'finished'
-        
 
     @ocs_agent.param("duration", default=None, type=float)
     @ocs_agent.param('kwargs', default=None)
@@ -511,7 +511,7 @@ class PysmurfController:
         with self.lock.acquire_timeout(0, job='uxm_setup') as acquired:
             if not acquired:
                 return False, f"Operation failed: {self.lock.job} is running."
-            
+
             cfg = RunCfg(
                 func_name='run_uxm_setup',
                 kwargs={'bands': params['bands'], 'kwargs': params['kwargs']}
@@ -633,7 +633,7 @@ class PysmurfController:
         with self.lock.acquire_timeout(0, job='take_noise') as acquired:
             if not acquired:
                 return False, f"Operation failed: {self.lock.job} is running."
-            
+
             cfg = RunCfg(
                 func_name='take_noise',
                 args=[params['duration']],
@@ -741,7 +741,7 @@ class PysmurfController:
             if not acquired:
                 return False, f"Operation failed: {self.lock.job} is running."
             cfg = RunCfg(
-                func_name='take_iv', 
+                func_name='take_iv',
                 kwargs={'iv_kwargs': params['kwargs']}
             )
             result = run_func_in_subprocess(cfg)
@@ -799,7 +799,7 @@ class PysmurfController:
         with self.lock.acquire_timeout(0, job='bias_steps') as acquired:
             if not acquired:
                 return False, f"Operation failed: {self.lock.job} is running."
-            
+
             cfg = RunCfg(
                 func_name='take_bias_steps',
                 kwargs={
@@ -808,7 +808,7 @@ class PysmurfController:
             )
             result = run_func_in_subprocess(cfg)
             set_session_data(session, result)
-            if result.success: #Publish quantile results
+            if result.success:  # Publish quantile results
                 for name, d in result.return_val['quantiles'].items():
                     block = {
                         k: q for k, q in zip(d['labels'], d['values'])
@@ -881,7 +881,7 @@ class PysmurfController:
             )
             result = run_func_in_subprocess(cfg)
             set_session_data(session, result)
-            if result.success: # Publish quantile results
+            if result.success:  # Publish quantile results
                 for name, d in result.return_val['quantiles'].items():
                     block = {
                         k: q for k, q in zip(d['labels'], d['values'])
@@ -895,7 +895,6 @@ class PysmurfController:
                     self.agent.publish_to_feed('bias_wave_quantiles', d)
 
             return result.success, "Finished taking bias steps"
-
 
     @ocs_agent.param('bgs', default=None)
     @ocs_agent.param('kwargs', default=None)

--- a/socs/agents/pysmurf_controller/agent.py
+++ b/socs/agents/pysmurf_controller/agent.py
@@ -23,7 +23,7 @@ from sodetlib.operations import (bias_dets, bias_steps, bias_wave, iv,
                                  uxm_relock, uxm_setup)
 
 from socs.agents.pysmurf_controller.smurf_subprocess_util import (
-    NBIASLINES, RunCfg, RunResult, run_func_in_subprocess)
+    NBIASLINES, RunCfg, RunResult, run_func_in_subprocess_from_thread)
 
 
 class PysmurfScriptProtocol(protocol.ProcessProtocol):
@@ -350,7 +350,7 @@ class PysmurfController:
         cfg = RunCfg(
             func_name='test',
         )
-        result = run_func_in_subprocess(cfg)
+        result = run_func_in_subprocess_from_thread(cfg)
         if not result.success:
             self.log.error("Subprocess errored out:\n{tb}", tb=result.traceback)
 
@@ -516,7 +516,7 @@ class PysmurfController:
                 func_name='run_uxm_setup',
                 kwargs={'bands': params['bands'], 'kwargs': params['kwargs']}
             )
-            result = run_func_in_subprocess(cfg)
+            result = run_func_in_subprocess_from_thread(cfg)
             set_session_data(session, result)
             if result.traceback is not None:
                 self.log.error("Error occurred:\n{tb}", tb=result.traceback)
@@ -581,7 +581,7 @@ class PysmurfController:
                 func_name='run_uxm_relock',
                 kwargs={'bands': params['bands'], 'kwargs': params['kwargs']}
             )
-            result = run_func_in_subprocess(cfg)
+            result = run_func_in_subprocess_from_thread(cfg)
             set_session_data(session, result)
             if result.traceback is not None:
                 self.log.error("Error occurred:\n{tb}", tb=result.traceback)
@@ -639,7 +639,7 @@ class PysmurfController:
                 args=[params['duration']],
                 kwargs={'kwargs': params['kwargs']}
             )
-            result = run_func_in_subprocess(cfg)
+            result = run_func_in_subprocess_from_thread(cfg)
             set_session_data(session, result)
             return result.success, "Finished taking noise"
 
@@ -694,7 +694,7 @@ class PysmurfController:
                 func_name='take_bgmap',
                 kwargs={'kwargs': kwargs}
             )
-            result = run_func_in_subprocess(cfg)
+            result = run_func_in_subprocess_from_thread(cfg)
             set_session_data(session, result)
             return result.success, "Finished taking bgmap"
 
@@ -744,7 +744,7 @@ class PysmurfController:
                 func_name='take_iv',
                 kwargs={'iv_kwargs': params['kwargs']}
             )
-            result = run_func_in_subprocess(cfg)
+            result = run_func_in_subprocess_from_thread(cfg)
             set_session_data(session, result)
             return result.success, "Finished taking IV"
 
@@ -806,7 +806,7 @@ class PysmurfController:
                     'kwargs': params['kwargs'], 'rfrac_range': params['rfrac_range'],
                 }
             )
-            result = run_func_in_subprocess(cfg)
+            result = run_func_in_subprocess_from_thread(cfg)
             set_session_data(session, result)
             if result.success:  # Publish quantile results
                 for name, d in result.return_val['quantiles'].items():
@@ -879,7 +879,7 @@ class PysmurfController:
                     'kwargs': params['kwargs'], 'rfrac_range': params['rfrac_range'],
                 }
             )
-            result = run_func_in_subprocess(cfg)
+            result = run_func_in_subprocess_from_thread(cfg)
             set_session_data(session, result)
             if result.success:  # Publish quantile results
                 for name, d in result.return_val['quantiles'].items():

--- a/socs/agents/pysmurf_controller/agent.py
+++ b/socs/agents/pysmurf_controller/agent.py
@@ -343,8 +343,10 @@ class PysmurfController:
         session.set_status('stopping')
 
     def run_test_func(self, session, params):
-        """
-        Task to run subprocess test function
+        """run_test_func()
+
+        **Task** - Task to test the subprocessing functionality without any
+        smurf hardware.
         """
         cfg = RunCfg(
             func_name='test',
@@ -453,7 +455,7 @@ class PysmurfController:
     @ocs_agent.param('kwargs', default=None)
     @ocs_agent.param('run_in_main_procsess', default=False)
     def uxm_setup(self, session, params):
-        """uxm_setup(bands=None, kwargs=None)
+        """uxm_setup(bands=None, kwargs=None, run_in_main_process=False)
 
         **Task** - Runs first-time setup procedure for a UXM. This will run the
         following operations:
@@ -479,7 +481,8 @@ class PysmurfController:
             Dict containing additional keyword args to pass to the uxm_setup
             function.
         run_in_main_process : bool
-            If true, run smurf-function in main process
+            If true, run smurf-function in main process. Mainly for the purpose
+            of testing without the reactor running.
 
         Notes
         -------
@@ -529,7 +532,7 @@ class PysmurfController:
     @ocs_agent.param('kwargs', default=None)
     @ocs_agent.param('run_in_main_process', default=False, type=bool)
     def uxm_relock(self, session, params):
-        """uxm_relock(bands=None, kwargs=None)
+        """uxm_relock(bands=None, kwargs=None, run_in_main_process=False)
 
         **Task** - Relocks detectors to existing tune if setup has already been
         run. Runs the following operations:
@@ -553,7 +556,8 @@ class PysmurfController:
             Dict containing additional keyword args to pass to the uxm_relock
             function.
         run_in_main_process : bool
-            If true, run smurf-function in main process
+            If true, run smurf-function in main process. Mainly for the purpose
+            of testing without the reactor running.
 
         Notes
         -------
@@ -600,7 +604,7 @@ class PysmurfController:
     @ocs_agent.param('tag', default=None)
     @ocs_agent.param('run_in_main_process', default=False, type=bool)
     def take_noise(self, session, params):
-        """take_noise(duration=30., kwargs=None, tag=None)
+        """take_noise(duration=30., kwargs=None, tag=None, run_in_main_process=False)
 
         **Task** - Takes a short timestream and calculates noise statistics.
         Median white noise level for each band will be stored in the session
@@ -619,7 +623,8 @@ class PysmurfController:
             Tag (or comma-separated list of tags) to attach to the G3 stream.
             This has precedence over the `tag` key in the kwargs dict.
         run_in_main_process : bool
-            If true, run smurf-function in main process
+            If true, run smurf-function in main process. Mainly for the purpose
+            of testing without the reactor running.
 
         Notes
         -------
@@ -658,7 +663,7 @@ class PysmurfController:
     @ocs_agent.param('tag', default=None)
     @ocs_agent.param('run_in_main_process', default=False, type=bool)
     def take_bgmap(self, session, params):
-        """take_bgmap(kwargs=None, tag=None)
+        """take_bgmap(kwargs=None, tag=None, run_in_main_process=False)
 
         **Task** - Takes a bias-group map. This will calculate the number of
         channels assigned to each bias group and put that into the session data
@@ -675,7 +680,8 @@ class PysmurfController:
             String containing a tag or comma-separated list of tags to attach
             to the g3 stream.
         run_in_main_process : bool
-            If true, run smurf-function in main process
+            If true, run smurf-function in main process. Mainly for the purpose
+            of testing without the reactor running.
 
         Notes
         ------
@@ -717,7 +723,7 @@ class PysmurfController:
     @ocs_agent.param('tag', default=None)
     @ocs_agent.param('run_in_main_process', default=False, type=bool)
     def take_iv(self, session, params):
-        """take_iv(kwargs=None, tag=None)
+        """take_iv(kwargs=None, tag=None, run_in_main_process=False)
 
         **Task** - Takes an IV. This will add the normal resistance array and
         channel info to the session data object along with the analyzed IV
@@ -734,7 +740,8 @@ class PysmurfController:
             String containing a tag or comma-separated list of tags to attach
             to the g3 stream.
         run_in_main_process : bool
-            If true, run smurf-function in main process
+            If true, run smurf-function in main process. Mainly for the purpose
+            of testing without the reactor running.
 
         Notes
         ------
@@ -772,7 +779,7 @@ class PysmurfController:
     @ocs_agent.param('tag', default=None)
     @ocs_agent.param('run_in_main_process', default=False, type=bool)
     def take_bias_steps(self, session, params):
-        """take_bias_steps(kwargs=None, rfrac_range=(0.2, 0.9), tag=None)
+        """take_bias_steps(kwargs=None, rfrac_range=(0.2, 0.9), tag=None, run_in_main_process=False)
 
         **Task** - Takes bias_steps and saves the output filepath to the
         session data object. See the `sodetlib bias step docs page
@@ -790,7 +797,8 @@ class PysmurfController:
             String containing a tag or comma-separated list of tags to attach
             to the g3 stream.
         run_in_main_process : bool
-            If true, run smurf-function in main process
+            If true, run smurf-function in main process. Mainly for the purpose
+            of testing without the reactor running.
 
         Notes
         ------
@@ -833,16 +841,14 @@ class PysmurfController:
             set_session_data(session, result)
             if result.success:  # Publish quantile results
                 for name, d in result.return_val['quantiles'].items():
-                    block = {
-                        k: q for k, q in zip(d['labels'], d['values'])
-                    }
+                    block = dict(zip(d['labels'], d['values']))
                     block[f'{name}_count'] = d['count']
-                    d = {
+                    pub_data = {
                         'timestamp': time.time(),
                         'block_name': f'{name}_quantile',
                         'data': block
                     }
-                    self.agent.publish_to_feed('bias_step_quantiles', d)
+                    self.agent.publish_to_feed('bias_step_quantiles', pub_data)
 
             return result.success, "Finished taking bias steps"
 
@@ -851,7 +857,7 @@ class PysmurfController:
     @ocs_agent.param('tag', default=None)
     @ocs_agent.param('run_in_main_process', default=False, type=bool)
     def take_bias_waves(self, session, params):
-        """take_bias_waves(kwargs=None, rfrac_range=(0.2, 0.9), tag=None)
+        """take_bias_waves(kwargs=None, rfrac_range=(0.2, 0.9), tag=None, run_in_main_process=False)
 
         **Task** - Takes bias_wave and saves the output filepath to the
         session data object.
@@ -867,7 +873,8 @@ class PysmurfController:
             String containing a tag or comma-separated list of tags to attach
             to the g3 stream.
         run_in_main_process : bool
-            If true, run smurf-function in main process
+            If true, run smurf-function in main process. Mainly for the purpose
+            of testing without the reactor running.
 
         Notes
         ------
@@ -910,16 +917,14 @@ class PysmurfController:
             set_session_data(session, result)
             if result.success:  # Publish quantile results
                 for name, d in result.return_val['quantiles'].items():
-                    block = {
-                        k: q for k, q in zip(d['labels'], d['values'])
-                    }
+                    block = dict(zip(d['labels'], d['values']))
                     block[f'{name}_count'] = d['count']
-                    d = {
+                    pub_data = {
                         'timestamp': time.time(),
                         'block_name': f'{name}_quantile',
                         'data': block
                     }
-                    self.agent.publish_to_feed('bias_wave_quantiles', d)
+                    self.agent.publish_to_feed('bias_wave_quantiles', pub_data)
 
             return result.success, "Finished taking bias steps"
 

--- a/socs/agents/pysmurf_controller/agent.py
+++ b/socs/agents/pysmurf_controller/agent.py
@@ -19,11 +19,10 @@ from ocs import ocs_agent, site_config
 from ocs.ocs_agent import log_formatter
 from ocs.ocs_twisted import TimeoutLock
 from sodetlib.det_config import DetConfig
-from sodetlib.operations import (bias_dets, bias_steps, bias_wave, iv,
-                                 uxm_relock, uxm_setup)
+from sodetlib.operations import bias_dets
 
 from socs.agents.pysmurf_controller.smurf_subprocess_util import (
-    NBIASLINES, RunCfg, RunResult, run_func_in_subprocess_from_thread)
+     RunCfg, RunResult, run_func_in_subprocess_from_thread)
 
 
 class PysmurfScriptProtocol(protocol.ProcessProtocol):

--- a/socs/agents/pysmurf_controller/agent.py
+++ b/socs/agents/pysmurf_controller/agent.py
@@ -22,7 +22,7 @@ from sodetlib.det_config import DetConfig
 from sodetlib.operations import bias_dets
 
 from socs.agents.pysmurf_controller.smurf_subprocess_util import (
-     RunCfg, RunResult, run_func_in_subprocess_from_thread)
+    RunCfg, RunResult, run_func_in_subprocess_from_thread)
 
 
 class PysmurfScriptProtocol(protocol.ProcessProtocol):

--- a/socs/agents/pysmurf_controller/agent.py
+++ b/socs/agents/pysmurf_controller/agent.py
@@ -1,10 +1,11 @@
+from dataclasses import asdict
+
 import matplotlib
 from autobahn.twisted.util import sleep as dsleep
 from twisted.internet import protocol, reactor, threads
 from twisted.internet.defer import Deferred, inlineCallbacks
 from twisted.logger import FileLogObserver, Logger
 from twisted.python.failure import Failure
-from dataclasses import asdict
 
 matplotlib.use('Agg')
 import argparse

--- a/socs/agents/pysmurf_controller/smurf_subprocess_util.py
+++ b/socs/agents/pysmurf_controller/smurf_subprocess_util.py
@@ -9,7 +9,8 @@ import numpy as np
 import sodetlib as sdl
 from ocs.ocs_twisted import in_reactor_context
 from sodetlib.det_config import DetConfig
-from sodetlib.operations import bias_steps, bias_wave, iv, uxm_setup, uxm_relock
+from sodetlib.operations import (bias_steps, bias_wave, iv, uxm_relock,
+                                 uxm_setup)
 from twisted.internet import defer, protocol, reactor, threads
 
 NBIASLINES = 12

--- a/socs/agents/pysmurf_controller/smurf_subprocess_util.py
+++ b/socs/agents/pysmurf_controller/smurf_subprocess_util.py
@@ -1,0 +1,288 @@
+import sys
+import json
+from dataclasses import dataclass, field, asdict
+from typing import List, Dict, Optional
+from twisted.internet import protocol, reactor, threads, defer
+import traceback
+import os
+import sodetlib as sdl
+from sodetlib.det_config import DetConfig
+from sodetlib.operations import iv, uxm_setup, bias_steps, bias_wave
+import numpy as np
+from ocs.ocs_twisted import in_reactor_context
+
+
+NBIASLINES = 12
+
+
+def get_smurf_control():
+    """
+    Get the SMuRF control object and sodetlib configuration object for the
+    current slot
+    """
+    slot = os.environ['SLOT']
+    cfg = DetConfig()
+    cfg.load_config_files(slot=slot)
+    S = cfg.get_smurf_control()
+    S.load_tune(cfg.dev.exp['tunefile'])
+    return S, cfg
+
+
+def take_noise(duration, kwargs=None):
+    """Runs take_noise in sodetlib"""
+    if kwargs is None:
+        kwargs = {}
+    S, cfg = get_smurf_control()
+    sdl.noise.take_noise(S, cfg, duration, **kwargs)
+
+
+def take_bgmap(kwargs=None):
+    if kwargs is None:
+        kwargs = {}
+    S, cfg = get_smurf_control()
+    bsa = bias_steps.take_bgmap(S, cfg, **kwargs)
+
+    nchans_per_bg = [0 for _ in range(NBIASLINES + 1)]
+    for bg in range(NBIASLINES):
+        nchans_per_bg[bg] = int(np.sum(bsa.bgmap == bg))
+    nchans_per_bg[-1] = int(np.sum(bsa.bgmap == -1))
+    return {
+        'nchans_per_bg': nchans_per_bg,
+        'filepath': bsa.filepath,
+    }
+
+
+def take_iv(iv_kwargs=None):
+    """Runs and analyzes an IV curve"""
+    S, cfg = get_smurf_control()
+    if iv_kwargs is None:
+        iv_kwargs = {}
+    iva = iv.take_iv(S, cfg, **iv_kwargs)
+    return {'filepath': iva.filepath}
+
+
+def run_uxm_setup(bands=None, kwargs=None):
+    """Runs through the UXM setup procedure"""
+    if kwargs is None:
+        kwargs = {} 
+    S, cfg = get_smurf_control()
+    uxm_setup.uxm_setup(S, cfg, bands=bands, **kwargs)
+    return None
+
+
+def run_uxm_relock(bands=None, kwargs=None):
+    """Runs through the UXM relock procedure"""
+    if kwargs is None:
+        kwargs = {} 
+    S, cfg = get_smurf_control()
+    uxm_setup.uxm_relock(S, cfg, bands=bands, **kwargs)
+    return None
+
+
+def _process_quantiles(quantiles: list, arrays: Dict):
+    """
+    Args
+    ----
+    quantiles: list of quantiles to compute (in percent)
+    arrays: Dict of arrays to compute quantiles for
+    """
+    res = {}
+    for name, arr in arrays.items():
+        if np.isnan(arr).all():
+            continue
+        labels = [f'{name}_q{q}' for q in quantiles]
+        qs = [float(np.nan_to_num(np.nanquantile(arr, q / 100))) for q in quantiles]
+        count = int(np.sum(~np.isnan(arr)))
+        res[name] = {
+            'values': qs,
+            'labels': labels,
+            'count': count,
+        }
+    return res
+
+
+def take_bias_steps(kwargs=None, rfrac_range=(0.2, 0.9)):
+    """Takes bias steps and computes quantiles for various parameters"""
+    if kwargs is None:
+        kwargs = {}
+
+    S, cfg = get_smurf_control()
+    bsa = bias_steps.take_bias_steps(S, cfg, **kwargs)
+
+    biased = np.logical_and.reduce([
+        rfrac_range[0] < bsa.Rfrac,
+        rfrac_range[1] > bsa.Rfrac
+    ])
+    data = {
+        'filepath': bsa.filepath,
+        'biased_total': int(np.sum(biased)),
+        'biased_per_bg': [
+            int(np.sum(biased[bsa.bgmap == bg])) for bg in range(12)
+        ],
+    }
+    arrays = {
+        'Rfrac': bsa.Rfrac, 'responsivity': bsa.Si, 'Rtes': bsa.R0,
+    }
+    quantiles = np.array([15, 25, 50, 75, 85])
+    data['quantiles'] = _process_quantiles(quantiles, arrays)
+    return data
+
+
+def take_bias_waves(kwargs=None, rfrac_range=(0.2, 0.9)):
+    if kwargs is None:
+        kwargs = {}
+    S, cfg = get_smurf_control()
+    bwa = bias_wave.take_bias_waves(
+        S, cfg, **kwargs
+    )
+    biased = np.logical_and.reduce([
+        rfrac_range[0] < bwa.Rfrac,
+        rfrac_range[1] > bwa.Rfrac
+    ])
+    data = {
+        'filepath': bwa.filepath,
+        'biased_total': int(np.sum(biased)),
+        'biased_per_bg': [
+            int(np.sum(biased[bwa.bgmap == bg])) for bg in range(12)
+        ],
+    }
+    arrays = {
+        'Rfrac': bwa.Rfrac, 'responsivity': bwa.Si, 'Rtes': bwa.R0,
+    }
+    quantiles = np.array([15, 25, 50, 75, 85])
+    data['quantiles'] = _process_quantiles(quantiles, arrays)
+    return data
+
+
+def test():
+    """Function for testing subprocess operation"""
+    print("HEREE")
+    return {'test': 10}
+
+
+runnable_funcs = [
+    take_noise, take_iv, run_uxm_setup, run_uxm_relock, take_bias_steps,
+    take_bias_waves, test
+]
+func_map = {f.__name__: f for f in runnable_funcs}
+
+
+@dataclass
+class RunCfg:
+    func_name: str
+    "name of function to run"
+
+    args: List = field(default_factory=list)
+    "Args to pass to function"
+
+    kwargs: Dict = field(default_factory=dict)
+    "Kwargs to pass to function"
+
+    slot: Optional[int] = None
+    "Slot to setup smurf control for. If None, uses the slot from the environment variable 'SLOT'"
+
+    def __post_init__(self):
+        if self.func_name not in func_map:
+            raise ValueError(f"Invalid function name: {self.func_name}")
+
+
+@dataclass
+class RunResult:
+    success: bool
+    "True if function returned succesfully"
+
+    return_val: any = None
+    "Return value from function"
+
+    traceback: Optional[str] = None
+    "Traceback if function raised an exception"
+
+
+class FuncProtocol(protocol.ProcessProtocol):
+    """
+    Process protocol for running one of the above functions in a subprocess.
+    After the subprocess is started, the RunCfg object is encoded and sent to
+    the subprocess through stdin. Once the function is finished, the result is
+    encoded and passed back through FD 3.
+    """
+    def __init__(self, cfg: RunCfg):
+        self.cfg = cfg
+        self.result = None
+    
+    def connectionMade(self):
+        data = json.dumps(asdict(self.cfg)).encode()
+        self.transport.write(data)
+        self.transport.closeStdin()
+
+    def childDataReceived(self, childFD, data):
+        if childFD in [1, 2]: # stdout or stderr:
+            print(data.decode())
+
+        if childFD == 3:
+            self.result = json.loads(data.decode())
+    
+    def processExited(self, status):
+        if self.result is None:
+            raise RuntimeError("No result received from child process")
+        
+        self.deferred.callback(self.result)
+
+
+@defer.inlineCallbacks
+def _run_func_in_subprocess_reactor(cfg: RunCfg) -> RunResult:
+    """Helper function for run_func_in_subprocess, that can assume reactor context"""
+    prot = FuncProtocol(cfg)
+    prot.deferred = defer.Deferred()
+    childFDs = {0: 'w', 1: 'r', 2: 'r', 3: 'r'} # Regular FDs plus 3 for sending results back
+    env = os.environ.copy()
+    if cfg.slot is not None:
+        env['SLOT'] = str(cfg.slot)
+    reactor.spawnProcess(
+        prot, sys.executable, [sys.executable, '-u', __file__], childFDs=childFDs,
+        env=env
+    )
+    result = yield prot.deferred
+    return RunResult(**result)
+
+def run_func_in_subprocess(cfg: RunCfg) -> RunResult:
+    """
+    This function takes a RunCfg object, and runs the specified function in a
+    subprocess. The result is returned as a RunResult object. This function
+    must be run in the reactor thread.
+
+    Args
+    -----
+    cfg: RunCfg
+        Configuration object to specify the function to run, and the arguments.
+    """
+    if not in_reactor_context():
+        return threads.blockingCallFromThread(
+            reactor, _run_func_in_subprocess_reactor, cfg)
+    else:
+        return _run_func_in_subprocess_reactor(cfg)
+
+
+
+def subprocess_main():
+    """
+    Starting point for subprocesses. Reads configuration info from stdin,
+    runs the specified function, and returns the encoded result object through
+    FD 3.
+    """
+    data = sys.stdin.read()
+    cfg = RunCfg(**json.loads(data))
+    print(f'Starting subprocess function call:\n {cfg}')
+    try:
+        return_val = func_map[cfg.func_name](*cfg.args, **cfg.kwargs)
+        result = RunResult(success=True, return_val=return_val)
+        return_data = json.dumps(asdict(result)).encode()
+    except Exception:
+        result = RunResult(
+            success=False,
+            traceback=traceback.format_exc()
+        )
+        return_data = json.dumps(asdict(result)).encode()
+    os.write(3, return_data)
+
+if __name__ == '__main__':
+    subprocess_main()

--- a/socs/agents/pysmurf_controller/smurf_subprocess_util.py
+++ b/socs/agents/pysmurf_controller/smurf_subprocess_util.py
@@ -305,7 +305,7 @@ def run_smurf_func(cfg: RunCfg) -> RunResult:
                 traceback=traceback.format_exc()
             )
         return result
- 
+
     return threads.blockingCallFromThread(
         reactor, _run_func_in_subprocess_reactor, cfg)
 

--- a/socs/agents/pysmurf_controller/smurf_subprocess_util.py
+++ b/socs/agents/pysmurf_controller/smurf_subprocess_util.py
@@ -7,7 +7,6 @@ from typing import Dict, List, Optional
 
 import numpy as np
 import sodetlib as sdl
-from ocs.ocs_twisted import in_reactor_context
 from sodetlib.det_config import DetConfig
 from sodetlib.operations import (bias_steps, bias_wave, iv, uxm_relock,
                                  uxm_setup)

--- a/socs/agents/pysmurf_controller/smurf_subprocess_util.py
+++ b/socs/agents/pysmurf_controller/smurf_subprocess_util.py
@@ -189,7 +189,7 @@ def take_bias_waves(kwargs=None, rfrac_range=(0.2, 0.9)):
 
 def test():
     """Function for testing subprocess operation"""
-    print("HEREE")
+    print("Inside test func")
     return {'test': 10}
 
 
@@ -266,8 +266,8 @@ class FuncProtocol(protocol.ProcessProtocol):
 
 
 @defer.inlineCallbacks
-def _run_func_in_subprocess_reactor(cfg: RunCfg) -> RunResult:
-    """Helper function for run_func_in_subprocess, that can assume reactor context"""
+def _run_smurf_func_reactor(cfg: RunCfg) -> RunResult:
+    """Helper function for run_smurf_func, that can assume reactor context"""
     prot = FuncProtocol(cfg)
     prot.deferred = defer.Deferred()
     childFDs = {0: 'w', 1: 'r', 2: 'r', 3: 'r'}  # Regular FDs plus 3 for sending results back
@@ -307,7 +307,7 @@ def run_smurf_func(cfg: RunCfg) -> RunResult:
         return result
 
     return threads.blockingCallFromThread(
-        reactor, _run_func_in_subprocess_reactor, cfg)
+        reactor, _run_smurf_func_reactor, cfg)
 
 
 def subprocess_main():

--- a/tests/agents/test_pysmurf_controller_agent.py
+++ b/tests/agents/test_pysmurf_controller_agent.py
@@ -1,3 +1,4 @@
+import os
 from unittest import mock
 
 import numpy as np
@@ -7,7 +8,6 @@ from ocs.ocs_agent import OpSession
 
 from socs.agents.pysmurf_controller.agent import PysmurfController, make_parser
 
-import os
 os.environ['SLOT'] = '2'
 
 txaio.use_twisted()

--- a/tests/agents/test_pysmurf_controller_agent.py
+++ b/tests/agents/test_pysmurf_controller_agent.py
@@ -7,6 +7,9 @@ from ocs.ocs_agent import OpSession
 
 from socs.agents.pysmurf_controller.agent import PysmurfController, make_parser
 
+import os
+os.environ['SLOT'] = '2'
+
 txaio.use_twisted()
 
 # Number of channels in mock pysmurf system
@@ -14,7 +17,7 @@ NCHANS = 1000
 
 
 # Mocks and fixures
-def mock_pysmurf(self, session=None, load_tune=False, **kwargs):
+def mock_pysmurf(*args, **kwargs):
     """mock_pysmurf()
 
     **Mock** - Mock a pysmurf instance. Used to patch _get_smurf_control() in the PysmurfController.
@@ -222,6 +225,7 @@ def mock_uxm_setup(S, cfg, bands, **kwargs):
 
 
 @mock.patch('socs.agents.pysmurf_controller.agent.PysmurfController._get_smurf_control', mock_pysmurf)
+@mock.patch('socs.agents.pysmurf_controller.smurf_subprocess_util.get_smurf_control', mock_pysmurf)
 @mock.patch('sodetlib.operations.uxm_setup.uxm_setup', mock_uxm_setup)
 def test_uxm_setup(agent):
     """test_uxm_setup()
@@ -229,7 +233,10 @@ def test_uxm_setup(agent):
     **Test** - Tests uxm_setup task.
     """
     session = create_session('uxm_setup')
-    res = agent.uxm_setup(session, {'bands': [0], 'kwargs': None})
+    params = {
+        'bands': [0], 'kwargs': None, 'run_in_main_process': True
+    }
+    res = agent.uxm_setup(session, params)
     assert res[0] is True
 
 
@@ -258,6 +265,7 @@ def mock_uxm_relock(S, cfg, bands, **kwargs):
 
 
 @mock.patch('socs.agents.pysmurf_controller.agent.PysmurfController._get_smurf_control', mock_pysmurf)
+@mock.patch('socs.agents.pysmurf_controller.smurf_subprocess_util.get_smurf_control', mock_pysmurf)
 @mock.patch('sodetlib.operations.uxm_relock.uxm_relock', mock_uxm_relock)
 def test_uxm_relock(agent):
     """test_uxm_relock()
@@ -265,7 +273,7 @@ def test_uxm_relock(agent):
     **Test** - Tests uxm_relock task.
     """
     session = create_session('uxm_relock')
-    res = agent.uxm_relock(session, {'bands': [0], 'kwargs': None})
+    res = agent.uxm_relock(session, {'bands': [0], 'kwargs': None, 'run_in_main_process': True})
     assert res[0] is True
 
 
@@ -276,6 +284,7 @@ def mock_take_bgmap(S, cfg, **kwargs):
 
 
 @mock.patch('socs.agents.pysmurf_controller.agent.PysmurfController._get_smurf_control', mock_pysmurf)
+@mock.patch('socs.agents.pysmurf_controller.smurf_subprocess_util.get_smurf_control', mock_pysmurf)
 @mock.patch('sodetlib.operations.bias_steps.take_bgmap', mock_take_bgmap)
 def test_take_bgmap(agent):
     """test_take_bgmap()
@@ -283,7 +292,12 @@ def test_take_bgmap(agent):
     **Test** - Tests take_bgmap task.
     """
     session = create_session('take_bgmap')
-    res = agent.take_bgmap(session, {'kwargs': {'high_current_mode': False}, 'tag': None})
+    params = {
+        'kwargs': {'high_current_mode': False}, 'tag': None,
+        'run_in_main_process': True,
+    }
+    res = agent.take_bgmap(session, params)
+    print(session.data)
     assert res[0] is True
     assert session.data['nchans_per_bg'] == [NCHANS, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0]
     assert session.data['filepath'] == 'bias_step_analysis.npy'
@@ -300,6 +314,7 @@ def mock_take_iv(S, cfg, **kwargs):
 
 
 @mock.patch('socs.agents.pysmurf_controller.agent.PysmurfController._get_smurf_control', mock_pysmurf)
+@mock.patch('socs.agents.pysmurf_controller.smurf_subprocess_util.get_smurf_control', mock_pysmurf)
 @mock.patch('sodetlib.operations.iv.take_iv', mock_take_iv)
 def test_take_iv(agent):
     """test_take_iv()
@@ -307,12 +322,12 @@ def test_take_iv(agent):
     **Test** - Tests take_iv task.
     """
     session = create_session('take_iv')
-    res = agent.take_iv(session, {'kwargs': {'run_analysis': False}, 'tag': None})
+    params = {
+        'run_analysis': False, 'kwargs': {'run_analysis': False}, 'tag': None,
+        'run_in_main_process': True
+    }
+    res = agent.take_iv(session, params)
     assert res[0] is True
-    assert session.data['bands'] == np.zeros(NCHANS).tolist()
-    assert session.data['channels'] == np.arange(NCHANS).tolist()
-    assert session.data['bgmap'] == np.zeros(NCHANS).tolist()
-    assert session.data['R_n'] == np.full(NCHANS, 7e-3).tolist()
     assert session.data['filepath'] == 'test_file.npy'
 
 
@@ -323,6 +338,7 @@ def mock_take_bias_steps(S, cfg, **kwargs):
 
 
 @mock.patch('socs.agents.pysmurf_controller.agent.PysmurfController._get_smurf_control', mock_pysmurf)
+@mock.patch('socs.agents.pysmurf_controller.smurf_subprocess_util.get_smurf_control', mock_pysmurf)
 @mock.patch('sodetlib.operations.bias_steps.take_bias_steps', mock_take_bias_steps)
 def test_take_bias_steps(agent):
     """test_take_bias_steps()
@@ -330,13 +346,18 @@ def test_take_bias_steps(agent):
     **Test** - Tests take_bias_steps task.
     """
     session = create_session('take_bias_steps')
-    res = agent.take_bias_steps(session, {'kwargs': None, 'rfrac_range': (0.3, 0.9), 'tag': None})
+    params = {
+        'kwargs': None, 'rfrac_range': (0.3, 0.9), 'tag': None,
+        'run_in_main_process': True
+    }
+    res = agent.take_bias_steps(session, params)
     assert res[0] is True
     assert session.data['filepath'] == 'bias_step_analysis.npy'
 
 
 @mock.patch('socs.agents.pysmurf_controller.agent.PysmurfController._get_smurf_control', mock_pysmurf)
 @mock.patch('sodetlib.noise.take_noise', mock_take_noise)
+@mock.patch('socs.agents.pysmurf_controller.smurf_subprocess_util.get_smurf_control', mock_pysmurf)
 @mock.patch('time.sleep', mock.MagicMock())
 def test_take_noise(agent):
     """test_take_noise()
@@ -344,7 +365,11 @@ def test_take_noise(agent):
     **Test** - Tests take_noise task.
     """
     session = create_session('take_noise')
-    res = agent.take_noise(session, {'duration': 30, 'kwargs': None, 'tag': None})
+    params = {
+        'duration': 30, 'kwargs': None, 'tag': None,
+        'run_in_main_process': True
+    }
+    res = agent.take_noise(session, params)
     assert res[0] is True
 
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
This PR changes pysmurf-controller operations that load TODs such that instead of running in the main process, they call out to a subprocess.

## Description
<!--- Describe your changes in detail -->
This introduces the `smurf_subprocess_util` module, and a protocol for running functions inside a twisted subprocess in such a way that a general RunCfg can be passed to it, and a general RunResult can be returned. Any operation that involves TOD data loading is modified so that the loading and analysis occurs in a subprocess rather than in the main one.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
This should hopefully solve the memory leak, which I believe is coming from instances where TOD data is not being released to the system after it leaves scope. Moving TOD loading and analysis into subprocesses instead of the main one should enforce that this memory is returned to the OS when the subprocess exits. [This discussion](https://github.com/simonsobs/daq-discussions/discussions/81#discussioncomment-9286023) has some links that motivate this solution.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
I have tested the subprocess protocol locally through the use of the `test` process (and the new `run_test_func` operation).
I will need to test all other operations with hardware on SATp1 or SATp3.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
