### PR TITLE
prints errors caught in the pysmurf-controller subprocesses

### DIFF
--- a/socs/agents/pysmurf_controller/smurf_subprocess_util.py
+++ b/socs/agents/pysmurf_controller/smurf_subprocess_util.py
@@ -324,9 +324,11 @@ def subprocess_main():
         result = RunResult(success=True, return_val=return_val)
         return_data = encode_dataclass(result)
     except Exception:
+        exc = traceback.format_exc()
+        print(f"Exception raised in subprocess:\n{exc}")
         result = RunResult(
             success=False,
-            traceback=traceback.format_exc()
+            traceback=exc,
         )
         return_data = encode_dataclass(result)
     os.write(3, return_data)

--- a/socs/agents/pysmurf_controller/smurf_subprocess_util.py
+++ b/socs/agents/pysmurf_controller/smurf_subprocess_util.py
@@ -300,9 +300,11 @@ def run_smurf_func(cfg: RunCfg) -> RunResult:
                 return_val=func_map[cfg.func_name](*cfg.args, **cfg.kwargs)
             )
         except Exception:
+            exc = traceback.format_exc()
+            print(f"Exception raised in smurf_func:\n{exc}")
             result = RunResult(
                 success=False,
-                traceback=traceback.format_exc()
+                traceback=exc,
             )
         return result
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Logs errors in pysmurf-controller subprocess.

## Description
<!--- Describe your changes in detail -->
We are seeing that since the subprocessing change, failures in pysmurf-controller operations are not logging exceptions that are thrown (though the tracebacks are being stored in session.data). This PR adds a log of the traceback when an exception is caught in the subprocess.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
See here for an  example: https://github.com/simonsobs/daq-discussions/discussions/95


## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
Not tested yet

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
