### PR TITLE
Modification the max current setting of the kikusui agent (wire grid)

### DIFF
--- a/socs/agents/wiregrid_kikusui/agent.py
+++ b/socs/agents/wiregrid_kikusui/agent.py
@@ -289,14 +289,14 @@ class WiregridKikusuiAgent:
             return True, 'Set Kikusui off'
 
     @ocs_agent.param('current', default=0., type=float,
-                     check=lambda x: 0.0 <= x <= 3.0)
+                     check=lambda x: 0.0 <= x <= 4.5)
     def set_c(self, session, params):
         """set_c(current=0)
 
         **Task** - Set current [A]
 
         Parameters:
-            current (float): set current [A] (should be [0.0, 3.0])
+            current (float): set current [A] (should be [0.0, 4.5])
         """
         current = params.get('current')
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
In this pull request, I changed the max current setting about the wire grid kikusui agent. It was changed from 3.0 A to 4.5 A.
The kikusui power supply itself supports 18 V-5 A max in its specification. And this change will increase the motor's max torque, so the wire grid can rotate under lower temperatures.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Now the wire grid used for SAT-MF2 has an issue in that it cannot rotate under low ambient temperature, even though the grease in its bearing has temperature resistance. When I checked the rotation directly, the rotator can move with a small additional torque support by hand. Then, to make the rotation robust, we want to change the max current setting to 4.5 A.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
At the site, I changed the settings of the kikusui power supply manually, and confirmed the grid can rotate at 4.5 A max. Further, the over current protection in the hardware is now set at 4.9 A. So this change makes the rotation easy for the OCS operation as well.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
