### PR TITLE
Move HWP encoder timeout packet log to debug level

### DIFF
--- a/socs/agents/hwp_encoder/agent.py
+++ b/socs/agents/hwp_encoder/agent.py
@@ -52,6 +52,7 @@ HWPEncoder_full: separated feed for full-sample HWP encoder data,
 
 import argparse
 import calendar
+import os
 import select
 import socket
 import struct
@@ -700,6 +701,9 @@ def make_parser(parser=None):
 
 # Portion of the code that runs
 def main(args=None):
+    # Start logging
+    txaio.start_logging(level=os.environ.get("LOGLEVEL", "info"))
+
     parser = make_parser()
     args = site_config.parse_args(agent_class='HWPBBBAgent',
                                   parser=parser,

--- a/socs/agents/hwp_encoder/agent.py
+++ b/socs/agents/hwp_encoder/agent.py
@@ -365,7 +365,8 @@ class EncoderParser:
                         # Clear self.data
                         self.data = ''
                     elif header == 0x1234:
-                        self.log.error('Received timeout packet.')
+                        # Expected behavior when HWP is not spinning
+                        self.log.debug('Received timeout packet.')
                         # Clear self.data
                         self.data = ''
                     else:


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
This PR changes the log level of the 'Received timeout packet.' message in the HWP Encoder agent from 'error' to 'debug'. If the HWP is not spinning, this packet is expected as normal behavior.

I also add the setup that allows changing the log level via environment variable, so it can be changed in the Docker Compose config. 

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
When the HWP is not spinning, this packet is received every 10 seconds, filling the logs with this message. This makes it difficult to see any other messages that might be more relevant for debugging.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
Not yet tested, though is a straightforward change. The log level selection is used in other agents.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
