### PR TITLE
Adds pacemaker to LS372 custom PID loop

### DIFF
--- a/socs/agents/lakeshore372/agent.py
+++ b/socs/agents/lakeshore372/agent.py
@@ -897,11 +897,12 @@ class LS372_Agent:
     @ocs_agent.param('P', type=float)
     @ocs_agent.param('I', type=float)
     @ocs_agent.param('update_time', type=float)
+    @ocs_agent.param('query_rate', type=float, default=10.)
     @ocs_agent.param('sample_heater_range', type=float, default=10e-3)
     @ocs_agent.param('test_mode', type=bool, default=False)
     def custom_pid(self, session, params):
         """custom_pid(setpoint, heater, channel, P, \
-                      I, update_time, sample_heater_range=10e-3, \
+                      I, update_time, query_rate=10., sample_heater_range=10e-3, \
                       test_mode=False)
 
         **Process** - Set custom software PID parameters for servo control of fridge
@@ -914,6 +915,7 @@ class LS372_Agent:
             P (float): Proportional value in Watts/Kelvin
             I (float): Integral Value in Hz
             update_time (float): Time between PID updates in seconds
+            query_rate (float): Rate at which to query temp data in Hz.
             sample_heater_range (float): Range for sample heater in Amps.
                                          Default is 10e-3.
             test_mode (bool, optional): Run the Process loop only once.
@@ -930,6 +932,7 @@ class LS372_Agent:
                     {"Channel_02": {"T": 293.644, "R": 33.752, "timestamps": 1601924482.722671}}
                 }
         """
+        pm = Pacemaker(params['query_rate'])
 
         with self._acq_proc_lock.acquire_timeout(timeout=0, job='custom_pid') \
                 as acq_acquired, \
@@ -998,6 +1001,7 @@ class LS372_Agent:
             self.log.info(f"Starting PID on heater {heater}, ch {ch} to setpoint {setpoint} K")
 
             while self.custom_pid:
+                pm.sleep()
                 # Get a list of T and R at the maximum sample frequency
                 temps.append(self.module.get_temp(unit='kelvin', chan=ch))
                 resistances.append(self.module.get_temp(unit='ohms', chan=ch))


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Adds pacemaker to regulate temp reading rate to LS372 custom PID loop.

## Description
<!--- Describe your changes in detail -->
Adds pacemaker, to LS372 custom pid acquisition loop. 

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Nick noticed variable readout rates for temp data with the custom PID. Part of the reason is the lack of timing regulation in the PID control loop. This PR adds a OCS Pacemaker to the body of the pid loop to limit sampling to a specified rate, defaulting to 10 Hz. This will hopefully also speed up and improve PID processing by reducing the number of repeated samples.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
Not yet tested.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
