### PR TITLE
HWP ACU checks for spin-up

### DIFF
--- a/docs/agents/hwp_supervisor_agent.rst
+++ b/docs/agents/hwp_supervisor_agent.rst
@@ -129,6 +129,17 @@ current action will be aborted at the next opportunity and replaced with the new
 requested action.  The ``abort_action`` task can be used to abort the current
 action without beginning a new one.
 
+ACU Safety Checks
+```````````````````
+
+If the ACU instance-id is provided in the site-config, the supervisor will check
+the ACU state before spin-up or gripping procedures to ensure the telescope is
+in a safe state to perform the specified operation.
+
+Before spinning up the HWP, the agent will check that
+- The current elevation and commanded elevation are in the range ``(acu-min-el, acu-max-el)``.
+- The ACU state info has been updated within ``acu-max-time-since-update`` seconds.
+
 Examples
 ```````````
 Below is an example client script that runs the PID to freq operation, and waits

--- a/socs/agents/hwp_supervisor/agent.py
+++ b/socs/agents/hwp_supervisor/agent.py
@@ -784,7 +784,7 @@ class ControlStateMachine:
 
         return session
 
-    def update(self, clients, hwp_state):
+    def update(self, clients, hwp_state: HWPState):
         """Run the next series of actions for the current state"""
         try:
             self.lock.acquire()
@@ -806,6 +806,9 @@ class ControlStateMachine:
                         raise RuntimeError(f"ACU state has not been updated in {tdiff} sec")
                     if not (acu.min_el <= acu.el_current_position <= acu.max_el):
                         raise RuntimeError(f"ACU elevation is {acu.el_current_pos} deg, "
+                                           f"outside of allowed range ({acu.min_el}, {acu.max_el})")
+                    if not (acu.min_el <= acu.el_commanded_position <= acu.max_el):
+                        raise RuntimeError(f"ACU commanded elevation is {acu.el_commanded_position} deg, "
                                            f"outside of allowed range ({acu.min_el}, {acu.max_el})")
 
             if isinstance(state, ControlState.PIDToFreq):

--- a/socs/agents/hwp_supervisor/agent.py
+++ b/socs/agents/hwp_supervisor/agent.py
@@ -238,13 +238,13 @@ class HWPState:
             self.gripper_iboot = IBootState(args.gripper_iboot_id, args.gripper_iboot_outlets)
             log.info("Gripper Ibootbar id set: {id}", id=args.gripper_iboot_id)
         else:
-            log.warning("Gripper Ibootbar id not set")
+            log.warn("Gripper Ibootbar id not set")
 
         if args.driver_iboot_id is not None:
             self.driver_iboot = IBootState(args.driver_iboot_id, args.driver_iboot_outlets)
             log.info("Driver Ibootbar id set: {id}", id=args.driver_iboot_id)
         else:
-            log.warning("Driver Ibootbar id not set")
+            log.warn("Driver Ibootbar id not set")
 
         if args.acu_instance_id is not None:
             self.acu = ACUState(

--- a/socs/agents/hwp_supervisor/agent.py
+++ b/socs/agents/hwp_supervisor/agent.py
@@ -187,7 +187,10 @@ class ACUState:
         self.el_current_position = d['Elevation current position']
         self.el_commanded_position = d['Elevation commanded position']
         self.el_current_velocity = d['Elevation current velocity']
-        self.last_updated = time.time()
+        t = d.get('timestamp_agent')
+        if t is None:
+            t = time.time()
+        self.last_updated = t
 
 
 @dataclass

--- a/socs/agents/hwp_supervisor/agent.py
+++ b/socs/agents/hwp_supervisor/agent.py
@@ -1520,7 +1520,7 @@ def make_parser(parser=None):
     pgroup.add_argument(
         '--acu-max-time-since-update',
         help="Max amount of time since last ACU update before restricting spin-up",
-        default=60.0,
+        default=30.0,
     )
 
     pgroup.add_argument('--forward-dir', choices=['cw', 'ccw'], default="cw",

--- a/socs/agents/hwp_supervisor/agent.py
+++ b/socs/agents/hwp_supervisor/agent.py
@@ -1557,17 +1557,16 @@ def make_parser(parser=None):
              "postiion and velocity before HWP commands."
     )
     pgroup.add_argument(
-        '--acu-min-el', help="Min elevation before restricting HWP spin up",
-        default=48.0
+        '--acu-min-el', type=float, default=48.0,
+        help="Min elevation that HWP spin up is allowed",
     )
     pgroup.add_argument(
-        '--acu-max-el', help="Min elevation before restricting HWP spin up",
-        default=90.0
+        '--acu-max-el', type=float, default=90.0,
+        help="Max elevation that HWP spin up is allowed",
     )
     pgroup.add_argument(
-        '--acu-max-time-since-update',
-        help="Max amount of time since last ACU update before restricting spin-up",
-        default=30.0,
+        '--acu-max-time-since-update', type=float, default=30.0,
+        help="Max amount of time since last ACU update before allowing HWP spin up",
     )
 
     pgroup.add_argument('--forward-dir', choices=['cw', 'ccw'], default="cw",

--- a/socs/agents/hwp_supervisor/agent.py
+++ b/socs/agents/hwp_supervisor/agent.py
@@ -1200,6 +1200,8 @@ class HWPSupervisor:
                 self.hwp_state.driver_iboot.update()
             if self.hwp_state.gripper_iboot is not None:
                 self.hwp_state.gripper_iboot.update()
+            if self.hwp_state.acu is not None:
+                self.hwp_state.acu.update()
 
             session.data['hwp_state'] = asdict(self.hwp_state)
 

--- a/socs/agents/hwp_supervisor/agent.py
+++ b/socs/agents/hwp_supervisor/agent.py
@@ -189,6 +189,7 @@ class ACUState:
         self.el_current_velocity = d['Elevation current velocity']
         self.last_updated = time.time()
 
+
 @dataclass
 class HWPState:
     temp: Optional[float] = None


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
This PR adds a check of the ACU elevation before allowing for spinup of the HWP.

## Description
<!--- Describe your changes in detail -->
Adds ACU state information to the `HWPState` class. This state info is used by the control-state `update` function to check the ACU elevation and last update time before enabling spin-up.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Motivation is described in Kyohei's discussion here: https://github.com/simonsobs/daq-discussions/discussions/96.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
This has not yet been tested! @ykyohei can we test this on one of the SATs? To test at a safe elevation, we can raise the `acu_min_el` param.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
