### PR TITLE
hwp-supervisor: make  IBootState compatible with synaccess.

### DIFF
--- a/socs/agents/hwp_supervisor/agent.py
+++ b/socs/agents/hwp_supervisor/agent.py
@@ -139,7 +139,7 @@ class IBootState:
                 for outlet, label in self.outlet_labels.items()
             }
         elif self.driver_power_agent_type == 'synaccess':
-            self.outlet_labels = {o: str(o-1) for o in self.outlets}
+            self.outlet_labels = {o: str(o - 1) for o in self.outlets}
             self.outlet_state = {
                 outlet: op['data']['fields'][label]['status']
                 for outlet, label in self.outlet_labels.items()
@@ -193,10 +193,10 @@ class HWPState:
         )
         if args.gripper_iboot_id is not None:
             self.gripper_iboot = IBootState(args.gripper_iboot_id, args.gripper_iboot_outlets,
-                args.driver_power_agent_type)
+                                            args.driver_power_agent_type)
         if args.driver_iboot_id is not None:
             self.driver_iboot = IBootState(args.driver_iboot_id, args.driver_iboot_outlets,
-                args.driver_power_agent_type)
+                                           args.driver_power_agent_type)
         return self
 
     def _update_from_keymap(self, op, keymap):

--- a/socs/agents/hwp_supervisor/agent.py
+++ b/socs/agents/hwp_supervisor/agent.py
@@ -118,12 +118,12 @@ class HWPClients:
 class IBootState:
     instance_id: str
     outlets: List[int]
+    driver_power_agent_type: Literal['iboot, synaccess']
     outlet_state: Dict[int, Optional[int]] = None
     op_data: Optional[Dict] = None
 
     def __post_init__(self):
         self.outlet_state = {o: None for o in self.outlets}
-        self.outlet_labels = {o: f'outletStatus_{o}' for o in self.outlets}
 
     def update(self):
         op = get_op_data(self.instance_id, 'acq', test_mode=False)
@@ -132,10 +132,23 @@ class IBootState:
             self.outlet_state = {o: None for o in self.outlets}
             return
 
-        self.outlet_state = {
-            outlet: op['data'][label]['status']
-            for outlet, label in self.outlet_labels.items()
-        }
+        if self.driver_power_agent_type == 'iboot':
+            self.outlet_labels = {o: f'outletStatus_{o}' for o in self.outlets}
+            self.outlet_state = {
+                outlet: op['data'][label]['status']
+                for outlet, label in self.outlet_labels.items()
+            }
+        elif self.driver_power_agent_type == 'synaccess':
+            self.outlet_labels = {o: str(o-1) for o in self.outlets}
+            self.outlet_state = {
+                outlet: op['data']['fields'][label]['status']
+                for outlet, label in self.outlet_labels.items()
+            }
+        else:
+            raise ValueError(
+                f"Invalid driver_power_agent_type: {self.driver_power_agent_type}. "
+                "Must be in ['iboot', 'synaccess']"
+            )
 
 
 @dataclass
@@ -179,9 +192,11 @@ class HWPState:
             ups_minutes_remaining_thresh=args.ups_minutes_remaining_thresh,
         )
         if args.gripper_iboot_id is not None:
-            self.gripper_iboot = IBootState(args.gripper_iboot_id, args.gripper_iboot_outlets)
+            self.gripper_iboot = IBootState(args.gripper_iboot_id, args.gripper_iboot_outlets,
+                args.driver_power_agent_type)
         if args.driver_iboot_id is not None:
-            self.driver_iboot = IBootState(args.driver_iboot_id, args.driver_iboot_outlets)
+            self.driver_iboot = IBootState(args.driver_iboot_id, args.driver_iboot_outlets,
+                args.driver_power_agent_type)
         return self
 
     def _update_from_keymap(self, op, keymap):
@@ -205,6 +220,7 @@ class HWPState:
         """
         self._update_from_keymap(op, {
             'enc_freq': 'approx_hwp_freq',
+            'encoder_last_updated': 'encoder_last_updated',
             'last_quad': 'last_quad',
             'last_quad_time': 'last_quad_time',
         })

--- a/socs/agents/hwp_supervisor/agent.py
+++ b/socs/agents/hwp_supervisor/agent.py
@@ -118,7 +118,7 @@ class HWPClients:
 class IBootState:
     instance_id: str
     outlets: List[int]
-    driver_power_agent_type: Literal['iboot, synaccess']
+    agent_type: Literal['iboot, synaccess']
     outlet_state: Dict[int, Optional[int]] = None
     op_data: Optional[Dict] = None
 
@@ -132,13 +132,13 @@ class IBootState:
             self.outlet_state = {o: None for o in self.outlets}
             return
 
-        if self.driver_power_agent_type == 'iboot':
+        if self.agent_type == 'iboot':
             self.outlet_labels = {o: f'outletStatus_{o}' for o in self.outlets}
             self.outlet_state = {
                 outlet: op['data'][label]['status']
                 for outlet, label in self.outlet_labels.items()
             }
-        elif self.driver_power_agent_type == 'synaccess':
+        elif self.agent_type == 'synaccess':
             self.outlet_labels = {o: str(o - 1) for o in self.outlets}
             self.outlet_state = {
                 outlet: op['data']['fields'][label]['status']
@@ -146,7 +146,7 @@ class IBootState:
             }
         else:
             raise ValueError(
-                f"Invalid driver_power_agent_type: {self.driver_power_agent_type}. "
+                f"Invalid agent_type: {self.agent_type}. "
                 "Must be in ['iboot', 'synaccess']"
             )
 
@@ -193,7 +193,7 @@ class HWPState:
         )
         if args.gripper_iboot_id is not None:
             self.gripper_iboot = IBootState(args.gripper_iboot_id, args.gripper_iboot_outlets,
-                                            args.driver_power_agent_type)
+                                            args.gripper_power_agent_type)
         if args.driver_iboot_id is not None:
             self.driver_iboot = IBootState(args.driver_iboot_id, args.driver_iboot_outlets,
                                            args.driver_power_agent_type)
@@ -1472,6 +1472,9 @@ def make_parser(parser=None):
     pgroup.add_argument(
         '--gripper-iboot-outlets', nargs='+', type=int,
         help="Outlets for gripper iboot power")
+    pgroup.add_argument(
+        '--gripper-power-agent-type', choices=['iboot', 'synaccess'], default=None,
+        help="Type of agent used for controlling the gripper power")
 
     pgroup.add_argument('--forward-dir', choices=['cw', 'ccw'], default="cw",
                         help="Whether the PID 'forward' direction is cw or ccw")


### PR DESCRIPTION
Make IBootState compatible with synaccess agent originally it was only compatible with ibootbar agent.

## Description
Make IBootState compatible with synaccess agent and add encoder timestamp
This PR addresses https://github.com/simonsobs/socs/issues/691 and https://github.com/simonsobs/socs/issues/681

## Motivation and Context
https://github.com/simonsobs/socs/issues/691 and https://github.com/simonsobs/socs/issues/681

## How Has This Been Tested?
Tested in daq-dev for satp3

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
