### PR TITLE
Modify the max current setting of the wiregrid kikusui agent

### DIFF
--- a/socs/agents/wiregrid_kikusui/agent.py
+++ b/socs/agents/wiregrid_kikusui/agent.py
@@ -289,14 +289,14 @@ class WiregridKikusuiAgent:
             return True, 'Set Kikusui off'
 
     @ocs_agent.param('current', default=0., type=float,
-                     check=lambda x: 0.0 <= x <= 4.5)
+                     check=lambda x: 0.0 <= x <= 4.9)
     def set_c(self, session, params):
         """set_c(current=0)
 
         **Task** - Set current [A]
 
         Parameters:
-            current (float): set current [A] (should be [0.0, 4.5])
+            current (float): set current [A] (should be [0.0, 4.9])
         """
         current = params.get('current')
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Modify the max current setting of the wiregrid kikusui agent from 4.5A to 4.9A

## Motivation and Context
Improve the current limitation applied the rotator motor of the wiregrid

## How Has This Been Tested?
This agent has worked at the previous max current 4.5A and this max current 4.9A should be safe according to the spec sheet. Therefore, this modification should be safe.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
