### PR TITLE
hw_pid: delete initial set_direction

### DIFF
--- a/socs/agents/hwp_pid/drivers/pid_controller.py
+++ b/socs/agents/hwp_pid/drivers/pid_controller.py
@@ -26,11 +26,8 @@ class PID:
         self.ip = ip
         self.port = port
         self.hex_freq = '00000'
-        self.direction = None
-        self.target = 0
         # Need to setup connection before setting direction
         self.conn = self._establish_connection(self.ip, int(self.port))
-        self.set_direction('0')
 
     @staticmethod
     def _establish_connection(ip, port, timeout=2):
@@ -119,12 +116,10 @@ class PID:
             if self.verb:
                 print('Forward')
             resp = self.send_message("*W02400000")
-            self.direction = 0
         elif direction == '1':
             if self.verb:
                 print('Reverse')
             resp = self.send_message("*W02401388")
-            self.direction = 1
 
         if self.verb:
             print(self.return_messages([resp])[0])

--- a/socs/agents/hwp_pid/drivers/pid_controller.py
+++ b/socs/agents/hwp_pid/drivers/pid_controller.py
@@ -14,8 +14,6 @@ class PID:
     Attributes:
         verb (bool): Verbose output setting.
         hex_freq (str): Currently declared rotation frequency in hexadecimal.
-        direction (int): Current direction of the HWP. 0 for forward and 1 for
-            backwards.
         conn (socket.socket): Socket object with open connection to the PID
             controller.
 
@@ -26,7 +24,6 @@ class PID:
         self.ip = ip
         self.port = port
         self.hex_freq = '00000'
-        # Need to setup connection before setting direction
         self.conn = self._establish_connection(self.ip, int(self.port))
 
     @staticmethod


### PR DESCRIPTION
Delete initial hwp rotation direction setting of hwp_pid agent to resolve the hwp rotation direction ambiguities.

## Description
The "direction" in the hwp_pid memory register doesn't reflect the actual action of pid agent until hwp_pid.tune_freq is called. The default setting of "direction" on the agent startup lead to the ambiguity of hwp rotation direction. This PR delete the default setting. 

As long as we use `hwp_supervisor.pid_to_freq`, we can avoid this issue. https://github.com/simonsobs/socs/blob/4902d3be867b51ea77514825d5a301581fb1828b/socs/agents/hwp_supervisor/agent.py#L739-L750
However, if `hwp_supervisor.pid_to_freq` fails in the middle of its command sequence, we may still have a potential ambiguity in rotation direction, so maybe we should make it more robust?

## Motivation and Context
https://github.com/simonsobs/chwp-discussions/discussions/24

## How Has This Been Tested?
This has been tested by daq-dev for satp3. Confirmed that the restart of hwp_pid agent doen't lead to the direction ambiguity in both directions.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
