### PR TITLE
Pin setuptools

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -35,6 +35,8 @@ RUN ./labjack_ljm_software_2020_03_30_x86_64/labjack_ljm_installer.run -- --no-r
 COPY requirements/ /app/socs/requirements
 COPY requirements.txt /app/socs/requirements.txt
 WORKDIR /app/socs/
+# Work around https://github.com/pypa/setuptools/issues/4483/ temporarily
+RUN pip3 install -U "setuptools<71.0.0"
 RUN pip3 install -r requirements.txt
 
 # Copy the current directory contents into the container at /app

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@
 # A container setup with an installation of socs.
 
 # Use the ocs image as a base
-FROM simonsobs/ocs:v0.11.0
+FROM simonsobs/ocs:v0.11.0-5-g3909484
 
 # Set up the cryo/smurf user and group so this can run on smurf-servers
 # See link for how all other smurf-containers are set up:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,7 @@
 [build-system]
 requires = [
-    "setuptools>=42",
+    # Upper bound needed until https://github.com/pypa/setuptools/issues/4483/ is fixed
+    "setuptools>=61.0,<71.0.0",
     "wheel",
     "versioneer-518",
 ]


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Setuptools needs to be updated before installing some of our other packages, like soaculib, so explicitly upgrade it before installing from the requirements file. I also expect to run into issues when we build, so we pin setuptools in the pyproject.yaml like ocs [1].

[1] - https://github.com/simonsobs/ocs/pull/392

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
All recent builds on PRs are failing.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
Docker image and wheel built locally.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
