### PR TITLE
Dump configs on IV

### DIFF
--- a/socs/agents/pysmurf_controller/smurf_subprocess_util.py
+++ b/socs/agents/pysmurf_controller/smurf_subprocess_util.py
@@ -83,7 +83,7 @@ def encode_dataclass(obj):
     return json.dumps(data).encode()
 
 
-def get_smurf_control():
+def get_smurf_control(dump_configs=False):
     """
     Get the SMuRF control object and sodetlib configuration object for the
     current slot
@@ -91,7 +91,7 @@ def get_smurf_control():
     slot = os.environ['SLOT']
     cfg = DetConfig()
     cfg.load_config_files(slot=slot)
-    S = cfg.get_smurf_control()
+    S = cfg.get_smurf_control(dump_configs=dump_configs)
     S.load_tune(cfg.dev.exp['tunefile'])
     return S, cfg
 
@@ -129,7 +129,7 @@ def take_bgmap(kwargs=None):
 
 def take_iv(iv_kwargs=None):
     """Runs and analyzes an IV curve"""
-    S, cfg = get_smurf_control()
+    S, cfg = get_smurf_control(dump_configs=True)
     if iv_kwargs is None:
         iv_kwargs = {}
     iva = iv.take_iv(S, cfg, **iv_kwargs)


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Dumps smurf configs on pysmurf-controller take_iv.
## Description
<!--- Describe your changes in detail -->
Dumps smurf configs on pysmurf-controller take_iv.


## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
During the smurf software town hall meeting I mistakenly claimed that smurf configs were dumped every operation. After checking the data, this turns out not to have been the case, and configs were only dumped each hammer. This changes it so that configs are dumped every IV, which I believe is roughly once a day. I think this is a good middle ground between every operation and every hammer.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
This has not been tested.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project.
- [X] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
