### PR TITLE
Adds grip and ungrip fns to hwp-supervisor with safety checks

### DIFF
--- a/docs/agents/hwp_supervisor_agent.rst
+++ b/docs/agents/hwp_supervisor_agent.rst
@@ -51,6 +51,7 @@ Here is an example of a config block you can add to your ocs site-config file::
             '--acu-max-el', 90.0,
             '--acu-max-time-since-update', 30.0,
             '--mount-velocity-grip-thresh', 0.005,
+            '--grip-max-boresight-angle', 1.0,
         ]}
 
 For SATP1, we use an ibootbar to power the driver, and it is not necessary to

--- a/docs/agents/hwp_supervisor_agent.rst
+++ b/docs/agents/hwp_supervisor_agent.rst
@@ -35,6 +35,8 @@ Here is an example of a config block you can add to your ocs site-config file::
             '--hwp-encoder-id', 'hwp-bbb-e1',
             '--hwp-pmx-id', 'hwp-pmx',
             '--hwp-pid-id', 'hwp-pid',
+            '--hwp-pcu-id', 'hwp-pcu',
+            '--hwp-gripper-id', 'hwp-gripper',
             '--ups-id', 'power-ups-az',
             '--ups-minutes-remaining-thresh', 45,
             '--iboot-id', 'power-iboot-hwp-2',
@@ -43,6 +45,12 @@ Here is an example of a config block you can add to your ocs site-config file::
             '--driver-power-agent-type', 'synaccess',
             '--driver-power-cycle-twice',
             '--driver-power-cycle-wait-time', 300,
+
+            '--acu-instance-id', 'acu',
+            '--acu-min-el', 48.0,
+            '--acu-max-el', 90.0,
+            '--acu-max-time-since-update', 30.0,
+            '--mount-velocity-grip-thresh', 0.005,
         ]}
 
 For SATP1, we use an ibootbar to power the driver, and it is not necessary to
@@ -57,12 +65,20 @@ cycle the driver power twice, so the config will look like::
             '--hwp-encoder-id', 'hwp-bbb-e1',
             '--hwp-pmx-id', 'hwp-pmx',
             '--hwp-pid-id', 'hwp-pid',
+            '--hwp-pcu-id', 'hwp-pcu',
+            '--hwp-gripper-id', 'hwp-gripper',
             '--ups-id', 'power-ups-az',
             '--ups-minutes-remaining-thresh', 45,
             '--iboot-id', 'power-iboot-hwp-2',
             '--driver-iboot-id', 'power-iboot-hwp-2',
             '--driver-iboot-outlets', 1, 2,
             '--driver-power-agent-type', 'iboot',
+
+            '--acu-instance-id', 'acu',
+            '--acu-min-el', 48.0,
+            '--acu-max-el', 90.0,
+            '--acu-max-time-since-update', 30.0,
+            '--mount-velocity-grip-thresh', 0.005,
         ]}
 
 .. note::
@@ -139,6 +155,11 @@ in a safe state to perform the specified operation.
 Before spinning up the HWP, the agent will check that
 - The current elevation and commanded elevation are in the range ``(acu-min-el, acu-max-el)``.
 - The ACU state info has been updated within ``acu-max-time-since-update`` seconds.
+
+Before gripping or ungripping the HWP, the agent will check that:
+- The current elevation and commanded elevation are in the range ``(acu-min-el, acu-max-el)``.
+- The ACU state info has been updated within ``acu-max-time-since-update`` seconds.
+- The az and el velocity is less than ``mount-velocity-grip-thresh``.
 
 Examples
 ```````````

--- a/socs/agents/hwp_supervisor/agent.py
+++ b/socs/agents/hwp_supervisor/agent.py
@@ -3,9 +3,9 @@ import os
 import threading
 import time
 import traceback
+from contextlib import contextmanager
 from dataclasses import asdict, dataclass, field
 from typing import Any, Dict, List, Literal, Optional
-from contextlib import contextmanager
 
 import numpy as np
 import ocs
@@ -209,7 +209,7 @@ class ACUState:
 
     # This will only be set by spin-control agent for communication with ACU
     request_block_ACU_motion: bool = False
-    ACU_motion_blocked: Optional[bool] = None # This flag is only set by the ACU agent
+    ACU_motion_blocked: Optional[bool] = None  # This flag is only set by the ACU agent
     use_acu_blocking: bool = False
 
     def update(self):
@@ -796,7 +796,7 @@ class ControlAction:
 
 
 @contextmanager
-def ensure_grip_safety(hwp_state: HWPState, timeout: float=60.):
+def ensure_grip_safety(hwp_state: HWPState, timeout: float = 60.):
     """
     Run required checks for gripper safety. This will check ACU parameters such
     as az/el position and velocity. If `use_acu_blocking` is set, this will
@@ -866,7 +866,7 @@ def ensure_grip_safety(hwp_state: HWPState, timeout: float=60.):
         yield
         return
 
-    try: #If use_acu_blocking, do handshake with ACU agent to block motino
+    try:  # If use_acu_blocking, do handshake with ACU agent to block motino
         acu.request_block_ACU_motion = True
         start_time = time.time()
         while not acu.ACU_motion_blocked:

--- a/socs/agents/hwp_supervisor/agent.py
+++ b/socs/agents/hwp_supervisor/agent.py
@@ -4,7 +4,7 @@ import threading
 import time
 import traceback
 from dataclasses import asdict, dataclass, field
-from typing import Dict, List, Literal, Optional, Any
+from typing import Any, Dict, List, Literal, Optional
 
 import numpy as np
 import ocs

--- a/socs/agents/hwp_supervisor/agent.py
+++ b/socs/agents/hwp_supervisor/agent.py
@@ -1793,7 +1793,7 @@ def make_parser(parser=None):
         help="Max amount of time since last ACU update before allowing HWP spin up",
     )
     pgroup.add_argument(
-        '--mount-vel-grip-thresh', type=float, default=0.005,
+        '--mount-velocity-grip-thresh', type=float, default=0.005,
         help="Max mount velocity (both az and el) for gripping the HWP"
     )
     pgroup.add_argument(
@@ -1828,9 +1828,11 @@ def main(args=None):
     agent.register_task('set_const_voltage', hwp.set_const_voltage)
     agent.register_task('brake', hwp.brake)
     agent.register_task('pmx_off', hwp.pmx_off)
-    agent.register_task('abort_action', hwp.abort_action)
+    agent.register_task('grip_hwp', hwp.grip_hwp)
+    agent.register_task('ungrip_hwp', hwp.ungrip_hwp)
     agent.register_task('enable_driver_board', hwp.enable_driver_board)
     agent.register_task('disable_driver_board', hwp.disable_driver_board)
+    agent.register_task('abort_action', hwp.abort_action)
 
     runner.run(agent, auto_reconnect=True)
 

--- a/socs/agents/hwp_supervisor/agent.py
+++ b/socs/agents/hwp_supervisor/agent.py
@@ -10,7 +10,7 @@ import numpy as np
 import ocs
 import txaio
 from ocs import client_http, ocs_agent, site_config
-from ocs.client_http import ControlClientError, ControlClient
+from ocs.client_http import ControlClient, ControlClientError
 from ocs.ocs_client import OCSClient, OCSReply
 from ocs.ocs_twisted import Pacemaker
 


### PR DESCRIPTION
Adds grip and ungrip fns to hwp-supervisor with safety checks.

<!--- Provide a general summary of your changes in the Title above -->
This PR adds two additional operations to the HWP supervisor to grip/ungrip the HWP

## Description
<!--- Describe your changes in detail -->
For these two actions, the HWP and ACU states are first checked based on [kyohei's daq-discussion.](https://github.com/simonsobs/daq-discussions/discussions/96)
If checks pass, the gripper agent grip/ungrip operations will be called.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
This is to centralize the gripping procedure and to implement safety checks.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
This has not been tested yet. @ykyohei any chance we can test at site sometime soon?

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)


## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project.
- [X] My change requires a change to the documentation.
- [X] I have updated the documentation accordingly.
