### PR TITLE
Update to Docker Compose v2 in docs and workflows

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -29,7 +29,7 @@ jobs:
     # Dockerize
     - name: Build docker images
       run: |
-        docker-compose build
+        docker compose build
 
     - name: Login to Docker Hub
       uses: docker/login-action@v3
@@ -44,13 +44,13 @@ jobs:
         export DOCKER_TAG=`git describe --tags --always`
 
         # Tag all images for upload to the registry
-        docker-compose config | grep 'image: ' | awk -F ': ' '{ print $2 }' | xargs -I {} docker tag {}:latest ${DOCKERHUB_ORG}/{}:latest
-        docker-compose config | grep 'image: ' | awk -F ': ' '{ print $2 }' | xargs -I {} docker tag {}:latest ${DOCKERHUB_ORG}/{}:${DOCKER_TAG}
+        docker compose config | grep 'image: ' | awk -F ': ' '{ print $2 }' | xargs -I {} docker tag {}:latest ${DOCKERHUB_ORG}/{}:latest
+        docker compose config | grep 'image: ' | awk -F ': ' '{ print $2 }' | xargs -I {} docker tag {}:latest ${DOCKERHUB_ORG}/{}:${DOCKER_TAG}
 
         # Upload to docker registry
-        docker-compose config | grep 'image: ' | awk -F ': ' '{ print $2 }' | xargs -I {} docker push ${DOCKERHUB_ORG}/{}:latest
-        docker-compose config | grep 'image: ' | awk -F ': ' '{ print $2 }' | xargs -I {} docker push ${DOCKERHUB_ORG}/{}:${DOCKER_TAG}
-        docker-compose config | grep 'image: ' | awk -F ': ' '{ print $2 }' | xargs -I {} echo ${DOCKERHUB_ORG}/{}:${DOCKER_TAG} pushed
+        docker compose config | grep 'image: ' | awk -F ': ' '{ print $2 }' | xargs -I {} docker push ${DOCKERHUB_ORG}/{}:latest
+        docker compose config | grep 'image: ' | awk -F ': ' '{ print $2 }' | xargs -I {} docker push ${DOCKERHUB_ORG}/{}:${DOCKER_TAG}
+        docker compose config | grep 'image: ' | awk -F ': ' '{ print $2 }' | xargs -I {} echo ${DOCKERHUB_ORG}/{}:${DOCKER_TAG} pushed
 
   wheel:
     name: build and deploy to PyPI

--- a/.github/workflows/develop.yml
+++ b/.github/workflows/develop.yml
@@ -31,7 +31,7 @@ jobs:
     # Dockerize
     - name: Build docker images
       run: |
-        docker-compose build
+        docker compose build
 
     - name: Login to Docker Hub
       uses: docker/login-action@v3
@@ -47,11 +47,11 @@ jobs:
         echo "${DOCKER_TAG}"
 
         # Tag all images for upload to the registry
-        docker-compose config | grep 'image: ' | awk -F ': ' '{ print $2 }' | xargs -I {} docker tag {}:latest ${DOCKERHUB_ORG}/{}:${DOCKER_TAG}
+        docker compose config | grep 'image: ' | awk -F ': ' '{ print $2 }' | xargs -I {} docker tag {}:latest ${DOCKERHUB_ORG}/{}:${DOCKER_TAG}
 
         # Upload to docker registry
-        docker-compose config | grep 'image: ' | awk -F ': ' '{ print $2 }' | xargs -I {} docker push ${DOCKERHUB_ORG}/{}:${DOCKER_TAG}
-        docker-compose config | grep 'image: ' | awk -F ': ' '{ print $2 }' | xargs -I {} echo ${DOCKERHUB_ORG}/{}:${DOCKER_TAG} pushed
+        docker compose config | grep 'image: ' | awk -F ': ' '{ print $2 }' | xargs -I {} docker push ${DOCKERHUB_ORG}/{}:${DOCKER_TAG}
+        docker compose config | grep 'image: ' | awk -F ': ' '{ print $2 }' | xargs -I {} echo ${DOCKERHUB_ORG}/{}:${DOCKER_TAG} pushed
 
   # testing so we can catch any issues before release
   # if issues are found, test locally, or copy to pytest.yml for test on push

--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -53,7 +53,7 @@ jobs:
 
     - name: Build docker test images
       run: |
-        docker-compose build socs
+        docker compose build socs
 
     # Integration Tests
     - name: Run integration tests

--- a/.github/workflows/test-build.yml
+++ b/.github/workflows/test-build.yml
@@ -26,4 +26,4 @@ jobs:
     # Dockerize
     - name: Build docker images
       run: |
-        docker-compose build
+        docker compose build

--- a/docs/agents/acti_camera.rst
+++ b/docs/agents/acti_camera.rst
@@ -48,7 +48,7 @@ Docker Compose
 ``````````````
 
 The iBootbar Agent should be configured to run in a Docker container. An
-example docker-compose service configuration is shown here::
+example docker compose service configuration is shown here::
 
   ocs-cameras:
     image: simonsobs/socs:latest

--- a/docs/agents/bluefors_agent.rst
+++ b/docs/agents/bluefors_agent.rst
@@ -38,7 +38,7 @@ An example configuration for your ocs config file::
 Docker Compose
 ``````````````
 
-Example docker-compose configuration::
+Example docker compose configuration::
 
   ocs-bluefors:
     image: simonsobs/socs:latest
@@ -145,7 +145,7 @@ tools, i.e. Docker for Windows, if possible) is:
 - Run docker terminal (this performs some Virtualbox setup)
 - Run docker login
 - Clone the ocs-site-configs repo and create a directory for your machine
-- Configure ocs/docker-compose files
+- Configure ocs/docker compose files
 - Make sure your system clock is set to UTC
 - Bring up the container(s)
 

--- a/docs/agents/cryomech_cpa.rst
+++ b/docs/agents/cryomech_cpa.rst
@@ -47,7 +47,7 @@ Docker Compose
 ``````````````
 
 The Cryomech CPA Agent should be configured to run in a Docker container.
-An example docker-compose service configuration is shown here::
+An example docker compose service configuration is shown here::
 
   ocs-ptc1:
     image: simonsobs/socs:latest

--- a/docs/agents/generator.rst
+++ b/docs/agents/generator.rst
@@ -45,7 +45,7 @@ Docker Compose
 ``````````````
 
 The Generator Agent should be configured to run in a Docker container. An
-example docker-compose service configuration is shown here::
+example docker compose service configuration is shown here::
 
   ocs-generator:
     image: simonsobs/socs:latest

--- a/docs/agents/hi6200.rst
+++ b/docs/agents/hi6200.rst
@@ -44,7 +44,7 @@ Docker Compose
 ``````````````
 
 The SCPI PSU Agent should be configured to run in a Docker container.
-An example docker-compose service configuration is shown here::
+An example docker compose service configuration is shown here::
 
   ocs-hi6200:
     image: simonsobs/socs:latest

--- a/docs/agents/hwp_encoder.rst
+++ b/docs/agents/hwp_encoder.rst
@@ -49,7 +49,7 @@ Docker Compose
 ``````````````
 
 The CHWP BBB agent can be run via a Docker container. The following is an
-example of what to insert into your institution's docker-compose file.
+example of what to insert into your institution's docker compose file.
 This again is an example to run multiple agents::
 
   ocs-hwpbbb-agent-HBA0:

--- a/docs/agents/hwp_gripper.rst
+++ b/docs/agents/hwp_gripper.rst
@@ -39,7 +39,7 @@ An example site-config-file block::
 Docker Compose
 `````````````````````
 
-An example docker-compose configuration::
+An example docker compose configuration::
 
     ocs-hwp-gripper:
         image: simonsobs/socs:latest

--- a/docs/agents/hwp_picoscope.rst
+++ b/docs/agents/hwp_picoscope.rst
@@ -55,7 +55,7 @@ Docker
     yourself. A Dockerfile is provided in ``socs/docker/hwp_picoscope/``.
 
 The HWP picoscope agent can be run via a Docker container. The following is an
-example of what to insert into your institution's docker-compose file::
+example of what to insert into your institution's docker compose file::
 
   picoscope:
     image: ocs-hwp-picoscope-agent:latest

--- a/docs/agents/hwp_pid.rst
+++ b/docs/agents/hwp_pid.rst
@@ -30,7 +30,7 @@ An example site-config-file block::
 Docker Compose
 ``````````````
 
-An example docker-compose configuration::
+An example docker compose configuration::
 
   ocs-hwp-pid:
     image: simonsobs/socs:latest

--- a/docs/agents/hwp_pmx.rst
+++ b/docs/agents/hwp_pmx.rst
@@ -32,7 +32,7 @@ An example site-config-file block::
 Docker Compose
 ``````````````
 
-An example docker-compose configuration::
+An example docker compose configuration::
 
   ocs-hwp-pmx:
     image: simonsobs/socs:latest

--- a/docs/agents/ibootbar.rst
+++ b/docs/agents/ibootbar.rst
@@ -41,7 +41,7 @@ Docker Compose
 ``````````````
 
 The iBootbar Agent should be configured to run in a Docker container. An
-example docker-compose service configuration is shown here::
+example docker compose service configuration is shown here::
 
   ocs-ibootbar:
     image: simonsobs/socs:latest

--- a/docs/agents/ifm_sbn246_flowmeter.rst
+++ b/docs/agents/ifm_sbn246_flowmeter.rst
@@ -43,7 +43,7 @@ Docker Compose
 ``````````````
 
 The IFM SBN246 Flowmeter Agent should be configured to run in a Docker
-container. An example docker-compose service configuration is shown here::
+container. An example docker compose service configuration is shown here::
 
   ocs-flow:
     image: simonsobs/socs:latest

--- a/docs/agents/labjack.rst
+++ b/docs/agents/labjack.rst
@@ -102,7 +102,7 @@ Docker Compose
 ``````````````
 
 The LabJack Agent should be configured to run in a Docker container. An
-example docker-compose service configuration is shown here::
+example docker compose service configuration is shown here::
 
   ocs-labjack:
     image: simonsobs/socs:latest

--- a/docs/agents/lakeshore425.rst
+++ b/docs/agents/lakeshore425.rst
@@ -38,7 +38,7 @@ If you would like to chanege the setting or check the status of the lakeshore 42
 Docker Compose
 ``````````````
 The ocs-lakeshore425-agent can be run via a Docker container. The following is an
-example of what to insert into your institution's docker-compose file.::
+example of what to insert into your institution's docker compose file.::
 
   ocs-lakeshore425-agent:
     image: simonsobs/socs:latest

--- a/docs/agents/magpie.rst
+++ b/docs/agents/magpie.rst
@@ -22,7 +22,7 @@ frame is received.
 Configuration File Examples
 ------------------------------
 
-Below are example docker-compose and ocs configuration files for running the
+Below are example docker compose and ocs configuration files for running the
 magpie agent.
 
 OCS Site Config
@@ -67,7 +67,7 @@ fake data by adding the ``--fake-data`` argument.
 Docker Compose
 ``````````````````
 
-Below is an example docker-compose entry for running a magpie corresponding to
+Below is an example docker compose entry for running a magpie corresponding to
 crate-id 1 and slot 2. If crossbar is being run on a different server, you'll
 have to modify the ``site-hub`` and ``site-http`` args accordingly::
 

--- a/docs/agents/meinberg_m1000_agent.rst
+++ b/docs/agents/meinberg_m1000_agent.rst
@@ -72,7 +72,7 @@ Docker Compose
 ``````````````
 
 The Meinberg M1000 Agent should be configured to run in a Docker container. An
-example docker-compose service configuration is shown here::
+example docker compose service configuration is shown here::
 
   ocs-m1000:
     image: simonsobs/socs:latest

--- a/docs/agents/meinberg_syncbox_agent.rst
+++ b/docs/agents/meinberg_syncbox_agent.rst
@@ -43,7 +43,7 @@ Docker Compose
 ``````````````
 
 The Meinberg Syncbox Agent should be configured to run in a Docker container. An
-example docker-compose service configuration is shown here::
+example docker compose service configuration is shown here::
 
   ocs-timing-syncbox:
     image: simonsobs/socs:latest

--- a/docs/agents/pfeiffer.rst
+++ b/docs/agents/pfeiffer.rst
@@ -44,7 +44,7 @@ Docker Compose
 ``````````````
 
 The Pfeiffer Agent can be run via a Docker container. The following is an
-example of what to insest into your institution's docker-compose file. ::
+example of what to insest into your institution's docker compose file. ::
 
 
   ocs-pfeiffer:

--- a/docs/agents/pfeiffer_tc400.rst
+++ b/docs/agents/pfeiffer_tc400.rst
@@ -54,7 +54,7 @@ block using all of the available arguments::
 Docker Compose
 ``````````````
 The agent should be configured to run in a Docker container. An
-example docker-compose service configuration is shown here::
+example docker compose service configuration is shown here::
 
   ocs-pfeiffer-turboA:
     image: simonsobs/socs:latest

--- a/docs/agents/pysmurf-controller.rst
+++ b/docs/agents/pysmurf-controller.rst
@@ -64,7 +64,7 @@ mount in a development copy of SODETLIB so that we have the most recent version
 without having to rebuild this container.
 
 
-The docker-compose for the pysmurf-controller that publishes to a container
+The docker compose for the pysmurf-controller that publishes to a container
 named ``ocs-pysmurf-monitor`` might look something like::
 
     ocs-pysmurf:

--- a/docs/agents/pysmurf-monitor.rst
+++ b/docs/agents/pysmurf-monitor.rst
@@ -31,7 +31,7 @@ Example site-config entry::
 
 Docker Compose
 ````````````````
-An example docker-compose entry might look like::
+An example docker compose entry might look like::
 
     ocs-pysmurf-monitor:
         image: simonsobs/socs:latest
@@ -48,7 +48,7 @@ An example docker-compose entry might look like::
             - /data:/data
 
 Where SOCS_TAG and CB_HOST are set in the ``.env`` file in the same dir as the
-docker-compose file.
+docker compose file.
 
 Description
 -----------

--- a/docs/agents/scpi_psu.rst
+++ b/docs/agents/scpi_psu.rst
@@ -46,7 +46,7 @@ Docker Compose
 ``````````````
 
 The SCPI PSU Agent should be configured to run in a Docker container.
-An example docker-compose service configuration is shown here::
+An example docker compose service configuration is shown here::
 
   ocs-psuK:
     image: simonsobs/socs:latest

--- a/docs/agents/smurf_crate_monitor.rst
+++ b/docs/agents/smurf_crate_monitor.rst
@@ -55,7 +55,7 @@ steps:
 4. Copy ocs-user ssh key using 'ssh-copy-id'
 
 You also need to add the ocs-base anchor and mount the home directory of
-the ocs-user in your 'docker-compose' file, see below for an example.
+the ocs-user in your 'docker compose' file, see below for an example.
 
 The second argument, 'crate-id', is just an identifier for your feed names
 to distinguish between identical sensors on different crates.
@@ -64,7 +64,7 @@ Docker Compose
 ``````````````
 
 The SMuRF Crate Agent should be configured to run in a Docker container. An
-example docker-compose service configuration is shown here::
+example docker compose service configuration is shown here::
 
   ocs-smurf-crate-monitor:
     <<: *ocs-base

--- a/docs/agents/smurf_timing_card.rst
+++ b/docs/agents/smurf_timing_card.rst
@@ -16,7 +16,7 @@ timing software.
 Configuration File Examples
 ------------------------------
 Below are configuration examples for the ocs config file and for the
-docker-compose service.
+docker compose service.
 
 OCS Site Config
 `````````````````
@@ -36,7 +36,7 @@ False by default.
 
 Docker Compose
 ````````````````
-Below is an example of the docker-compose service for the timing card agent::
+Below is an example of the docker compose service for the timing card agent::
 
     ocs-smurf-timing-card:
         image: simonsobs/socs:latest

--- a/docs/agents/suprsync.rst
+++ b/docs/agents/suprsync.rst
@@ -71,7 +71,7 @@ transferred files after 7 days, or 604800 seconds::
 Docker Compose
 ``````````````
 
-Below is a sample docker-compose entry for the SupRsync agents.
+Below is a sample docker compose entry for the SupRsync agents.
 Because the data we'll be transfering is owned by the ``cryo:smurf`` user, we
 set that as the user of the agent so it has the correct permissions. This is
 only possible because the ``cryo:smurf`` user is already built into the

--- a/docs/agents/synacc.rst
+++ b/docs/agents/synacc.rst
@@ -39,7 +39,7 @@ Docker Compose
 ``````````````
 
 The Synaccess Agent should be configured to run in a Docker container.
-An example docker-compose service configuration is shown here::
+An example docker compose service configuration is shown here::
 
   ocs-synacc:
     image: simonsobs/socs:latest

--- a/docs/agents/tektronix3021c.rst
+++ b/docs/agents/tektronix3021c.rst
@@ -45,7 +45,7 @@ Docker Compose
 ``````````````
 
 The Tektronix AWG Agent should be configured to run in a Docker container.
-An example docker-compose service configuration is shown here::
+An example docker compose service configuration is shown here::
 
   ocs-psuK:
     image: simonsobs/socs:latest

--- a/docs/agents/ucsc_radiometer.rst
+++ b/docs/agents/ucsc_radiometer.rst
@@ -47,7 +47,7 @@ Docker Compose
 ``````````````
 
 The UCSC Radiometer Agent should be configured to run in a Docker container. An
-example docker-compose service configuration is shown here::
+example docker compose service configuration is shown here::
 
   ocs-ucsc-radiometer:
        image: simonsobs/socs:latest

--- a/docs/agents/ups.rst
+++ b/docs/agents/ups.rst
@@ -43,7 +43,7 @@ Docker Compose
 ``````````````
 
 The UPS Agent should be configured to run in a Docker container. An
-example docker-compose service configuration is shown here::
+example docker compose service configuration is shown here::
 
   ocs-ups:
     image: simonsobs/socs:latest

--- a/docs/agents/vantage_pro2.rst
+++ b/docs/agents/vantage_pro2.rst
@@ -59,7 +59,7 @@ Docker Compose
 ``````````````
 
 The Vantage Pro2 Agent should be configured to run in a Docker container. An
-example docker-compose service configuration is shown here::
+example docker compose service configuration is shown here::
 
   ocs-vantage-pro2:
     image: simonsobs/socs:latest

--- a/docs/agents/wiregrid_actuator.rst
+++ b/docs/agents/wiregrid_actuator.rst
@@ -47,7 +47,7 @@ An example site-config-file block::
 Docker Compose
 ``````````````
 
-An example docker-compose configuration::
+An example docker compose configuration::
 
     ocs-wgactuator-agent:
         image: simonsobs/ocs-wgactuator-agent:latest

--- a/docs/agents/wiregrid_encoder.rst
+++ b/docs/agents/wiregrid_encoder.rst
@@ -48,7 +48,7 @@ The port number is determined in the script running in the BeagleBoneBlack.
 Docker Compose
 ``````````````
 
-An example docker-compose configuration::
+An example docker compose configuration::
 
     ocs-wgencoder-agent:
       image: simonsobs/socs:latest

--- a/docs/agents/wiregrid_kikusui.rst
+++ b/docs/agents/wiregrid_kikusui.rst
@@ -46,7 +46,7 @@ An example site-config-file block::
 Docker Compose
 ``````````````
 
-An example docker-compose configuration::
+An example docker compose configuration::
 
     ocs-wgkikusui-agent:
       image: simonsobs/socs:latest

--- a/docs/agents/wiregrid_tiltsensor.rst
+++ b/docs/agents/wiregrid_tiltsensor.rst
@@ -49,7 +49,7 @@ An example site-config-file block::
 Docker Compose
 ``````````````
 
-An example docker-compose configuration::
+An example docker compose configuration::
 
     ocs-wg-tilt-sensor-agent:
       image: simonsobs/socs:latest

--- a/docs/simulators/ls240_simulator.rst
+++ b/docs/simulators/ls240_simulator.rst
@@ -42,7 +42,7 @@ Lakeshore240Agent. This address must match the container name for the simulator:
 Docker
 ``````
 The simulator should be configured to run in a Docker container. An example
-docker-compose service configuration is shown here::
+docker compose service configuration is shown here::
 
   ls240-sim:
     image: simonsobs/ocs-lakeshore240-simulator:latest

--- a/docs/simulators/ls372_simulator.rst
+++ b/docs/simulators/ls372_simulator.rst
@@ -38,7 +38,7 @@ selected port.
 Docker
 ``````
 The simulator can be configured to run in a Docker container. An example
-docker-compose service configuration is shown here::
+docker compose service configuration is shown here::
 
   ocs-LS372-sim:
     image: ocs-lakeshore372-simulator

--- a/docs/simulators/smurf_stream_simulator.rst
+++ b/docs/simulators/smurf_stream_simulator.rst
@@ -38,7 +38,7 @@ using all of the available arguments::
 Docker
 ``````
 The simulator should be configured to run in a Docker container. An example
-docker-compose service configuration is shown here::
+docker compose service configuration is shown here::
 
   smurf-stream-sim:
     image: simonsobs/socs:latest

--- a/docs/user/sequencer.rst
+++ b/docs/user/sequencer.rst
@@ -137,7 +137,7 @@ that config is:
     The entire point of the tool is remote code execution, making it dangerous
     if exposed to the open internet.
 
-Once you bring these containers up (with ``docker-compose up -d``), you should
+Once you bring these containers up (with ``docker compose up -d``), you should
 be able to access the Sequencer by pointing your web browser to
 http://localhost/nextline/.
 

--- a/docs/user/webserver.rst
+++ b/docs/user/webserver.rst
@@ -16,11 +16,11 @@ nginx
 nginx is a lightweight, open source, web server which we will use as a reverse
 proxy.
 
-docker-compose Configuration
+Docker Compose Configuration
 ----------------------------
 We will setup nginx in a docker container. First, ensure you do not currently
 have a web server running (we need to make sure port 80 is available.) Then add
-nginx to your docker-compose file::
+nginx to your docker compose file::
 
   web:
     image: nginx
@@ -105,7 +105,7 @@ htaccesstools.com_. It will look something like this::
 
 Once you have created these two files you can bring up the webserver with::
 
-    $ sudo docker-compose up -d
+    $ sudo docker compose up -d
 
 Your webserver should now be accessible via the configured domain, or through
 `http://localhost <http://localhost>`_.
@@ -114,7 +114,7 @@ Grafana Proxy
 -------------
 If you are proxying Grafana and accessing it externally (i.e. not on
 ``localhost``), then you need to configure several additional environment
-variables. In your docker-compose configuration file add::
+variables. In your docker compose configuration file add::
 
     environment:
       - GF_SERVER_ROOT_URL=http://{{ domain }}/grafana

--- a/socs/agents/ups/agent.py
+++ b/socs/agents/ups/agent.py
@@ -437,7 +437,7 @@ class UPSAgent:
                 break
 
         # Exit agent to release memory
-        # Add "restart: unless-stopped" to docker-compose to automatically restart container
+        # Add "restart: unless-stopped" to docker compose to automatically restart container
         if ((not params['test_mode']) and (timeout != 0) and (self.is_streaming)):
             self.log.info(f"{self.restart} minutes have elasped. Exiting agent.")
             os.kill(os.getppid(), signal.SIGTERM)

--- a/tests/integration/util.py
+++ b/tests/integration/util.py
@@ -14,7 +14,7 @@ def create_crossbar_fixture():
     # def wait_for_crossbar(function_scoped_container_getter):
     @pytest.fixture(scope="session")
     def wait_for_crossbar(docker_services):
-        """Wait for the crossbar server from docker-compose to become
+        """Wait for the crossbar server from docker compose to become
         responsive.
 
         """


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
This replaces `docker-compose` with `docker compose` where needed to make the switch from v1 to v2.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
It appears `docker-compose` [is no longer available](https://github.com/simonsobs/socs/actions/runs/10208886063/job/28246020637?pr=708) in the actions runners.

`ocs` just made this switch too: https://github.com/simonsobs/ocs/pull/395

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
Need to test in the CI on this PR.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
