### PR TITLE
Update ocs base image to use newly reworked image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@
 # A container setup with an installation of socs.
 
 # Use the ocs image as a base
-FROM simonsobs/ocs:v0.11.1
+FROM simonsobs/ocs:v0.11.1-1-gb6cbd88
 
 # Set up the cryo/smurf user and group so this can run on smurf-servers
 # See link for how all other smurf-containers are set up:

--- a/Dockerfile
+++ b/Dockerfile
@@ -16,10 +16,9 @@ RUN useradd -d /home/cryo -M cryo -u 1000 && \
 
 # Install packages
 # suprsync agent - rsync
-# labjack agent - wget, python3-pip, libusb-1.0-0-dev, udev
+# labjack agent - wget, libusb-1.0-0-dev, udev
 RUN apt-get update && apt-get install -y rsync \
     wget \
-    python3-pip \
     libusb-1.0-0-dev \
     udev
 
@@ -36,14 +35,14 @@ COPY requirements/ /app/socs/requirements
 COPY requirements.txt /app/socs/requirements.txt
 WORKDIR /app/socs/
 # Work around https://github.com/pypa/setuptools/issues/4483/ temporarily
-RUN pip3 install -U "setuptools<71.0.0"
-RUN pip3 install -r requirements.txt
+RUN python -m pip install -U "setuptools<71.0.0"
+RUN python -m pip install -r requirements.txt
 
 # Copy the current directory contents into the container at /app
 COPY . /app/socs/
 
 # Install socs
-RUN pip3 install .
+RUN python -m pip install .
 
 # Reset workdir to avoid local imports
 WORKDIR /


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
This PR updates the base image to be `simonsobs/ocs:v0.11.1-1-gb6cbd88`, which is the first image after `ocs` removed several redundant base layers (see https://github.com/simonsobs/ocs/pull/397). 

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
This should reduce the image size for socs images.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
Builds and tests have been run locally and all pass.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
