### PR TITLE
HWP supervisor agent brake bugfix

### DIFF
--- a/socs/agents/hwp_supervisor/agent.py
+++ b/socs/agents/hwp_supervisor/agent.py
@@ -957,10 +957,10 @@ class ControlStateMachine:
                 self.run_and_validate(clients.pid.set_direction,
                                       kwargs=dict(direction=new_d))
                 self.run_and_validate(clients.pid.tune_stop)
-                self.run_and_validate(clients.pmx.set_on)
 
-                self.run_and_validate(clients.pmx.set_v, kwargs={'volt': state.brake_voltage})
                 self.run_and_validate(clients.pmx.ign_ext)
+                self.run_and_validate(clients.pmx.set_v, kwargs={'volt': state.brake_voltage})
+                self.run_and_validate(clients.pmx.set_on)
 
                 time.sleep(10)
                 self.action.set_state(ControlState.WaitForBrake(


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
This PR switches a couple lines in the brake functionality of the hwp-supervisor agent.

## Description
<!--- Describe your changes in detail -->
In the logic of the brake function I switched the order of lines so that the setting of the voltage occurs after switching the pmx to direct voltage control.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Currently the brake function of the hwp-supervisor has an argument `brake_voltage` which does not work because of a bug. To brake, the hwp uses a PMX power supply. This power supply can be configured to use an external voltage to control the output. This configuration is enabled during rotation and takes a PID feedback as an input. To brake however, this configuration is disabled and a static voltage is used instead. The issue is that while the external voltage configuration is enabled, commands to change the static voltage are ignored. Thus as the code was previously, commands to change the brake voltage would be ignored, and the PMX would simply use the last commanded static voltage value as the brake voltage (for satp1 this was 31V and for satp3 this was 10V).

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
I tested these changes with the satp2 hwp. After implementing the changes the brake issue was resolved

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
