### PR TITLE
HWP supervisor iboot indexing bugfix

### DIFF
--- a/socs/agents/hwp_supervisor/agent.py
+++ b/socs/agents/hwp_supervisor/agent.py
@@ -133,7 +133,7 @@ class IBootState:
             return
 
         if self.agent_type == 'iboot':
-            self.outlet_labels = {o: f'outletStatus_{o}' for o in self.outlets}
+            self.outlet_labels = {o: f'outletStatus_{o - 1}' for o in self.outlets}
             self.outlet_state = {
                 outlet: op['data'][label]['status']
                 for outlet, label in self.outlet_labels.items()


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Changes how the supervisor indexes iboot outlets when querying their state. This change only effects how the outlet states are reported in the `monitor` session data (actual functions using the iboot outlets are uneffected)

## Description
<!--- Describe your changes in detail -->
Subtracts one from the supplied outlet number, as the iboot outlets are indexed 0-7 while the outlet input argument is indexed 1-8.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
This fix ensures that the session data is accurate. Additionally, the supervisor agent would previously crash with an index error whenever trying to use outlet 8 (which is the case for the satp2 gripper power supplies)

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
I tested this fix with the satp2 hwp. 
Outlet states:
![iboot outlet state](https://github.com/user-attachments/assets/31ba03cf-f75d-4e29-8af2-a045c4aed84b)

Before change:
![supervisor old outlet index](https://github.com/user-attachments/assets/eecf95db-3f6e-405d-85e7-82c427391ccd)

After change:
![supervisor new outlet index](https://github.com/user-attachments/assets/302eb60e-925d-4d8c-aaf3-e7ddd43fe2fa)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
