### PR TITLE
hwp-pid direction read bugfix

### DIFF
--- a/socs/agents/hwp_pid/agent.py
+++ b/socs/agents/hwp_pid/agent.py
@@ -29,11 +29,18 @@ def parse_action_result(res):
 
 
 def get_pid_state(pid: pd.PID):
-    return {
-        "current_freq": pid.get_freq(),
-        "target_freq": pid.get_target(),
-        "direction": pid.get_direction(),
-    }
+    freq = pid.get_freq()
+    target = pid.get_target()
+    direction = pid.get_direction()
+
+    return_dict = {}
+    if freq is not None:
+        return_dict['current_freq'] = freq
+    if target is not None:
+        return_dict['target_freq'] = target
+    if direction is not None:
+        return_dict['direction'] = direction
+    return return_dict
 
 
 class Actions:

--- a/socs/agents/hwp_pid/agent.py
+++ b/socs/agents/hwp_pid/agent.py
@@ -132,12 +132,15 @@ class HWPPIDAgent:
 
         pid_state = get_pid_state(pid)
         if pid_state['healthy']:
-            data['data'].update(pid_state['state'])
-            session.data.update(pid_state['state'])
-            session.data['last_updated'] = time.time()
-            self.agent.publish_to_feed("hwppid", data)
+            pid_state['state'].update({'quality': 'ok'})
         else:
             print('Warning: state monitor degraded')
+            pid_state['state'].update({'quality': 'degraded'})
+
+        data['data'].update(pid_state['state'])
+        session.data.update(pid_state['state'])
+        session.data['last_updated'] = time.time()
+        self.agent.publish_to_feed("hwppid", data)
 
     def _process_actions(self, pid):
         while not self.action_queue.empty():

--- a/socs/agents/hwp_pid/agent.py
+++ b/socs/agents/hwp_pid/agent.py
@@ -33,13 +33,13 @@ def get_pid_state(pid: pd.PID):
                   'target_freq': pid.get_target,
                   'direction': pid.get_direction}
 
-    return_dict = {'healthy': True, 'state': {}}
+    return_dict = {'healthy': True}
     for name, func in state_func.items():
         resp = func()
         if resp.msg_type == 'error':
             return_dict['healthy'] = False
         else:
-            return_dict['state'][name] = resp.measure
+            return_dict[name] = resp.measure
     return return_dict
 
 
@@ -97,7 +97,7 @@ class Actions:
         def process(self, pid: pd.PID):
             pid_state = get_pid_state(pid)
             if pid_state['healthy']:
-                return pid_state['state']
+                return pid_state
             else:
                 print('Error getting state')
                 raise ValueError
@@ -137,8 +137,8 @@ class HWPPIDAgent:
             print('Warning: state monitor degraded')
             session.degraded = True
 
-        data['data'].update(pid_state['state'])
-        session.data.update(pid_state['state'])
+        data['data'].update(pid_state)
+        session.data.update(pid_state)
         session.data['last_updated'] = time.time()
         self.agent.publish_to_feed("hwppid", data)
 

--- a/socs/agents/hwp_pid/agent.py
+++ b/socs/agents/hwp_pid/agent.py
@@ -132,10 +132,10 @@ class HWPPIDAgent:
 
         pid_state = get_pid_state(pid)
         if pid_state['healthy']:
-            pid_state['state'].update({'quality': 'ok'})
+            session.degraded = False
         else:
             print('Warning: state monitor degraded')
-            pid_state['state'].update({'quality': 'degraded'})
+            session.degraded = True
 
         data['data'].update(pid_state['state'])
         session.data.update(pid_state['state'])

--- a/socs/agents/hwp_pid/drivers/pid_controller.py
+++ b/socs/agents/hwp_pid/drivers/pid_controller.py
@@ -524,7 +524,12 @@ class PID:
 
         """
         end_string = string.split('\r')[-1]
-        read_type = end_string[1:3]
+        if len(end_string) == 9:
+            read_type = end_string[1:3]
+        elif len(end_string) == 8:
+            read_type = '0' + end_string[1:2]
+        else:
+            return DecodedResponse(msg_type='error', msg='Unrecognized Read Length')
         # Decode target
         if read_type == '01':
             target = float(int(end_string[4:], 16) / 1000.)
@@ -536,7 +541,7 @@ class PID:
             else:
                 return DecodedResponse(msg_type='read', msg='Direction = Forward', measure=0)
         else:
-            return DecodedResponse(msg_type='error', msg='Unrecognized Read')
+            return DecodedResponse(msg_type='error', msg='Unrecognized Read Type')
 
     @staticmethod
     def _decode_write(string):

--- a/socs/agents/hwp_pid/drivers/pid_controller.py
+++ b/socs/agents/hwp_pid/drivers/pid_controller.py
@@ -257,9 +257,11 @@ class PID:
         if decoded_resp.msg_type == 'measure':
             return decoded_resp.measure
         elif decoded_resp.msg_type == 'error':
-            raise ValueError(f"Error reading freq: {decoded_resp.msg}")
+            print(f"Error reading freq: {decoded_resp.msg}")
+            raise ValueError
         else:
-            raise ValueError("Unknown freq response")
+            print("Unknown freq response")
+            raise ValueError
 
     @retry_multiple_times(loops=3)
     def get_target(self):
@@ -283,9 +285,11 @@ class PID:
         if decoded_resp.msg_type == 'read':
             return decoded_resp.measure
         elif decoded_resp.msg_type == 'error':
-            raise ValueError(f"Error reading target: {decoded_resp.msg}")
+            print(f"Error reading target: {decoded_resp.msg}")
+            raise ValueError
         else:
-            raise ValueError('Unknown target response')
+            print('Unknown target response')
+            raise ValueError
 
     @retry_multiple_times(loops=3)
     def get_direction(self):
@@ -312,9 +316,11 @@ class PID:
         if decoded_resp.msg_type == 'read':
             return decoded_resp.measure
         elif decoded_resp.msg_type == 'error':
-            raise ValueError(f"Error reading direction: {decoded_resp.msg}")
+            print(f"Error reading direction: {decoded_resp.msg}")
+            raise ValueError
         else:
-            raise ValueError('Unknown direction response')
+            print('Unknown direction response')
+            raise ValueError
 
     def set_pid(self, params):
         """Sets the PID parameters of the controller.

--- a/socs/agents/hwp_pid/drivers/pid_controller.py
+++ b/socs/agents/hwp_pid/drivers/pid_controller.py
@@ -11,7 +11,7 @@ def retry_multiple_times(loops=3):
             for i in range(loops):
                 try:
                     return func(*args, **kwargs)
-                except:
+                except BaseException:
                     time.sleep(0.2)
             print(f'Could not complete {func.__name__} after {loops} attempt(s)')
             return None

--- a/socs/agents/hwp_pid/drivers/pid_controller.py
+++ b/socs/agents/hwp_pid/drivers/pid_controller.py
@@ -5,6 +5,20 @@ from dataclasses import dataclass, field
 from typing import Optional, Union
 
 
+def retry_multiple_times(loops=3):
+    def dec_wrapper(func):
+        def inner(*args, **kwargs):
+            for i in range(loops):
+                try:
+                    return func(*args, **kwargs)
+                except:
+                    time.sleep(0.2)
+            print(f'Could not complete {func.__name__} after {loops} attempt(s)')
+            return None
+        return inner
+    return dec_wrapper
+
+
 @dataclass
 class DecodedResponse:
     msg_type: str
@@ -221,6 +235,7 @@ class PID:
         tune_params = [0.2, 63, 0]
         self.set_pid(tune_params)
 
+    @retry_multiple_times(loops=3)
     def get_freq(self):
         """Returns the current frequency of the CHWP.
 
@@ -236,17 +251,17 @@ class PID:
         responses = []
         responses.append(self.send_message("*X01"))
         decoded_resp = self.return_messages(responses)[0]
-        attempts = 3
-        for attempt in range(attempts):
-            if self.verb:
-                print(responses)
-                print(decoded_resp)
-            if decoded_resp.msg_type == 'measure':
-                return decoded_resp.measure
-            elif decoded_resp.msg_type == 'error':
-                print(f"Error reading freq: {decoded_resp.msg}")
-        raise ValueError('Could not get current frequency')
+        if self.verb:
+            print(responses)
+            print(decoded_resp)
+        if decoded_resp.msg_type == 'measure':
+            return decoded_resp.measure
+        elif decoded_resp.msg_type == 'error':
+            raise ValueError(f"Error reading freq: {decoded_resp.msg}")
+        else:
+            raise ValueError("Unknown freq response")
 
+    @retry_multiple_times(loops=3)
     def get_target(self):
         """Returns the target frequency of the CHWP.
 
@@ -262,17 +277,17 @@ class PID:
         responses = []
         responses.append(self.send_message("*R01"))
         decoded_resp = self.return_messages(responses)[0]
-        attempts = 3
-        for attempt in range(attempts):
-            if self.verb:
-                print(responses)
-                print(decoded_resp)
-            if decoded_resp.msg_type == 'read':
-                return decoded_resp.measure
-            elif decoded_resp.msg_type == 'error':
-                print(f"Error reading target: {decoded_resp.msg}")
-        raise ValueError('Could not get target frequency')
+        if self.verb:
+            print(responses)
+            print(decoded_resp)
+        if decoded_resp.msg_type == 'read':
+            return decoded_resp.measure
+        elif decoded_resp.msg_type == 'error':
+            raise ValueError(f"Error reading target: {decoded_resp.msg}")
+        else:
+            raise ValueError('Unknown target response')
 
+    @retry_multipe_times(loops=3)
     def get_direction(self):
         """Get the current rotation direction.
 
@@ -291,16 +306,15 @@ class PID:
         responses = []
         responses.append(self.send_message("*R02"))
         decoded_resp = self.return_messages(responses)[0]
-        attempts = 3
-        for attempt in range(attempts):
-            if self.verb:
-                print(responses)
-                print(decoded_resp)
-            if decoded_resp.msg_type == 'read':
-                return decoded_resp.measure
-            elif decoded_resp.msg_type == 'error':
-                print(f"Error reading direction: {decoded_resp.msg}")
-        raise ValueError('Could not get direction')
+        if self.verb:
+            print(responses)
+            print(decoded_resp)
+        if decoded_resp.msg_type == 'read':
+            return decoded_resp.measure
+        elif decoded_resp.msg_type == 'error':
+            raise ValueError(f"Error reading direction: {decoded_resp.msg}")
+        else:
+            raise ValueError('Unknown direction response')
 
     def set_pid(self, params):
         """Sets the PID parameters of the controller.
@@ -524,19 +538,16 @@ class PID:
 
         """
         end_string = string.split('\r')[-1]
-        if len(end_string) == 9:
-            read_type = end_string[1:3]
-        elif len(end_string) == 8:
-            read_type = '0' + end_string[1:2]
-        else:
+        read_type = end_string[1:3]
+        if len(end_string) != 9:
             return DecodedResponse(msg_type='error', msg='Unrecognized Read Length')
         # Decode target
         if read_type == '01':
-            target = float(int(end_string[-5:], 16) / 1000.)
+            target = float(int(end_string[4:], 16) / 1000.)
             return DecodedResponse(msg_type='read', msg='Setpoint = ' + str(target), measure=target)
         # Decode direction
         elif read_type == '02':
-            if int(end_string[-5:], 16) / 1000. > 2.5:
+            if int(end_string[4:], 16) / 1000. > 2.5:
                 return DecodedResponse(msg_type='read', msg='Direction = Reverse', measure=1)
             else:
                 return DecodedResponse(msg_type='read', msg='Direction = Forward', measure=0)

--- a/socs/agents/hwp_pid/drivers/pid_controller.py
+++ b/socs/agents/hwp_pid/drivers/pid_controller.py
@@ -14,7 +14,7 @@ def retry_multiple_times(loops=3):
                 except BaseException:
                     time.sleep(0.2)
             print(f'Could not complete {func.__name__} after {loops} attempt(s)')
-            return None
+            return DecodedResponse(msg_type='error', msg='Read Error')
         return inner
     return dec_wrapper
 
@@ -255,7 +255,7 @@ class PID:
             print(responses)
             print(decoded_resp)
         if decoded_resp.msg_type == 'measure':
-            return decoded_resp.measure
+            return decoded_resp
         elif decoded_resp.msg_type == 'error':
             print(f"Error reading freq: {decoded_resp.msg}")
             raise ValueError
@@ -283,7 +283,7 @@ class PID:
             print(responses)
             print(decoded_resp)
         if decoded_resp.msg_type == 'read':
-            return decoded_resp.measure
+            return decoded_resp
         elif decoded_resp.msg_type == 'error':
             print(f"Error reading target: {decoded_resp.msg}")
             raise ValueError
@@ -314,7 +314,7 @@ class PID:
             print(responses)
             print(decoded_resp)
         if decoded_resp.msg_type == 'read':
-            return decoded_resp.measure
+            return decoded_resp
         elif decoded_resp.msg_type == 'error':
             print(f"Error reading direction: {decoded_resp.msg}")
             raise ValueError

--- a/socs/agents/hwp_pid/drivers/pid_controller.py
+++ b/socs/agents/hwp_pid/drivers/pid_controller.py
@@ -532,11 +532,11 @@ class PID:
             return DecodedResponse(msg_type='error', msg='Unrecognized Read Length')
         # Decode target
         if read_type == '01':
-            target = float(int(end_string[4:], 16) / 1000.)
+            target = float(int(end_string[-5:], 16) / 1000.)
             return DecodedResponse(msg_type='read', msg='Setpoint = ' + str(target), measure=target)
         # Decode direction
         elif read_type == '02':
-            if int(end_string[4:], 16) / 1000. > 2.5:
+            if int(end_string[-5:], 16) / 1000. > 2.5:
                 return DecodedResponse(msg_type='read', msg='Direction = Reverse', measure=1)
             else:
                 return DecodedResponse(msg_type='read', msg='Direction = Forward', measure=0)

--- a/socs/agents/hwp_pid/drivers/pid_controller.py
+++ b/socs/agents/hwp_pid/drivers/pid_controller.py
@@ -287,7 +287,7 @@ class PID:
         else:
             raise ValueError('Unknown target response')
 
-    @retry_multipe_times(loops=3)
+    @retry_multiple_times(loops=3)
     def get_direction(self):
         """Get the current rotation direction.
 

--- a/socs/testing/hwp_emulator.py
+++ b/socs/testing/hwp_emulator.py
@@ -189,7 +189,7 @@ class HWPEmulator:
             elif cmd == "*X01":  # Get frequency
                 return f"X01{self.state.cur_freq:0.3f}"
             elif cmd == "*R01":  # Get Target
-                return f"R01{PID._convert_to_hex(self.state.pid.freq_setpoint, 3)}"
+                return f"R0140{PID._convert_to_hex(self.state.pid.freq_setpoint, 3)}"
             elif cmd == "*R02":  # Get Direction
                 if self.state.pid.direction == "forward":
                     return "R02400000"


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Initial attempt to fix occasional issues in reading the hwp-pid direction

## Description
<!--- Describe your changes in detail -->
Adds additional logic to handle read strings that are formatted in a non standard way.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Recently changes were pushed to the hwp-pid agent #686 which changed how response messages were processed. As an unintended consequence, a new bug surfaced when reading the rotation direction #727. From these error logs it appears as though the response message is mostly correct, but it is missing an initial 0 digit. This PR is a simple fix which will remedy this specific issue. Feedback is appreciated if the issue is more complicated than described above.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
This fix has not been tested and needs to be before it is merged into main

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
