### PR TITLE
Added ability to query more temperatures in agent acq

### DIFF
--- a/socs/agents/pfeiffer_tc400/agent.py
+++ b/socs/agents/pfeiffer_tc400/agent.py
@@ -96,9 +96,13 @@ class PfeifferTC400Agent:
                 'timestamp': 1598626144.5365012,
                 'block_name': 'turbo_output',
                 'data': {
+                    "Turbo_PowerStage_Temp": 30.5,
+                    "Turbo_Electronics_Temp": 29.2,
+                    "Turbo_PumpBottom_Temp": 31.4,
+                    "Turbo_Bearing_Temp": 39.5,
                     "Turbo_Motor_Temp": 40.054,
                     "Rotation_Speed": 823.655,
-                    "Error_Code": "Err001",
+                    "Error_Code": "1",
                 }
             }
 
@@ -120,7 +124,12 @@ class PfeifferTC400Agent:
                     }
 
                     try:
-                        data['data']["Turbo_Motor_Temp"] = self.turbo.get_turbo_motor_temperature()
+                        temp_data = self.turbo.get_turbo_temperatures()
+                        data['data']["Turbo_PowerStage_Temp"] = temp_data['pwrstg']
+                        data['data']["Turbo_Electronics_Temp"] = temp_data['electronic']
+                        data['data']["Turbo_PumpBottom_Temp"] = temp_data['pmpbot']
+                        data['data']["Turbo_Bearing_Temp"] = temp_data['bearing']
+                        data['data']["Turbo_Motor_Temp"] = temp_data['motor']
                         data['data']["Rotation_Speed"] = self.turbo.get_turbo_actual_rotation_speed()
                         data['data']['Error_Code'] = self.turbo.get_turbo_error_code()
                     except ValueError as e:

--- a/socs/agents/pfeiffer_tc400/drivers.py
+++ b/socs/agents/pfeiffer_tc400/drivers.py
@@ -51,6 +51,39 @@ class PfeifferTC400:
 
         self.turbo_address = turbo_address
 
+    def get_turbo_temperatures(self):
+        """Gets the temperatures of the various turbo parts from the turbo controller.
+
+        Returns:
+        --------
+        dict
+            pwrstg: The power stage temperature in Celsius
+            electronic: The electronic temperature in Celsius
+            pmpbot: The pump bottom temperature in Celsius
+            bearing: The bearing temperature in Celsius
+            motor: The motor temperature in Celsius
+        """
+
+        temp_dict = {"pwrstg": None,
+                     "electronic": None,
+                     "pmpbot": None,
+                     "bearing": None,
+                     "motor": None}
+
+        addr_dict = {"pwrstg": 324,
+                     "electronic": 326,
+                     "pmpbot": 330,
+                     "bearing": 342,
+                     "motor": 346}
+
+        for stage, stage_addr in addr_dict.items():
+            send_data_request(self.ser, self.turbo_address, stage_addr)
+            addr, rw, param_num, temp = read_gauge_response(self.ser)
+
+            temp_dict[stage] = int(temp)
+
+        return temp_dict
+
     def get_turbo_motor_temperature(self):
         """Gets the temperatures of the turbo rotor from the turbo controller.
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Added extra turbo Temperature queries in the agent acq. Added a new function in drivers.py that queries all available turbo temperatures.

## Description
<!--- Describe your changes in detail -->
Added `get_turbo_temperatures()` in drivers.py that queries all available turbo temperatures. 
Changed the acq in agent.py to use `get_turbo_temperatures()` instead of `get_turbo_motor_temperature()`,
Added powerstage, electronics, pumpbottom, and bearing temperatures to the data in acq.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
There are multiple turbo temperatures and previously only the motor temperature was being queried.
Added functionality to allow us to see all of the available temperatures on grafana in case one of the previously unqueried temps were to cause an error.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
I tested this on daq-dev and was able to show that the agent ran acq just fine.
All of the above temperatures were able to be seen on grafana.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
