### PR TITLE
Various HTTPCameraAgent Fixes

### DIFF
--- a/socs/agents/http_camera/agent.py
+++ b/socs/agents/http_camera/agent.py
@@ -11,7 +11,7 @@ import yaml
 from ocs import ocs_agent, site_config
 from ocs.ocs_twisted import Pacemaker, TimeoutLock
 # Disable unverified HTTPS warnings (https://urllib3.readthedocs.io/en/latest/advanced-usage.html#ssl-warnings)
-from urllib3.exceptions import InsecureRequestWarning
+from urllib3.exceptions import InsecureRequestWarning, ReadTimeoutError
 
 requests.packages.urllib3.disable_warnings(category=InsecureRequestWarning)
 
@@ -112,7 +112,7 @@ class HTTPCameraAgent:
                                                      "password": camera['password']}}}]
                         try:
                             resp = requests.post(login_url, data=json.dumps(login_payload), verify=False)
-                        except requests.exceptions.RequestException as e:
+                        except (requests.exceptions.RequestException, ReadTimeoutError) as e:
                             self.log.error(f'{e}')
                             self.log.info("Unable to get response from camera.")
                             connected = False
@@ -159,7 +159,7 @@ class HTTPCameraAgent:
                     elif camera['brand'] == 'acti':
                         response = requests.get(url, params=payload, stream=True, timeout=5)
                     connected = True
-                except requests.exceptions.RequestException as e:
+                except (requests.exceptions.RequestException, ReadTimeoutError) as e:
                     self.log.error(f'{e}')
                     self.log.info("Unable to get response from camera.")
                     connected = False

--- a/socs/agents/http_camera/agent.py
+++ b/socs/agents/http_camera/agent.py
@@ -90,6 +90,7 @@ class HTTPCameraAgent:
 
         self.is_streaming = True
         while self.is_streaming:
+            pm.sleep()
             # Use UTC
             timestamp = time.time()
             data = {}
@@ -171,6 +172,9 @@ class HTTPCameraAgent:
                 # Write screenshot to file and update latest file
                 with open(filename, 'wb') as out_file:
                     shutil.copyfileobj(response.raw, out_file)
+                    # Ensure all data is written to the disk before copying to latest
+                    out_file.flush()
+                    os.fsync(out_file.fileno())
                 self.log.debug(f"Wrote {ctime}.jpg to /{camera['location']}/{ctime_dir}.")
                 shutil.copy2(filename, latest_filename)
                 self.log.debug(f"Updated latest.jpg in /{camera['location']}.")
@@ -197,7 +201,6 @@ class HTTPCameraAgent:
 
             if params['test_mode']:
                 break
-            pm.sleep()
 
         return True, "Finished Recording"
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
- Catch `ReadTimeoutError` in HTTP requests
- Ensure all data is written to the disk before copying
- Move `pm.sleep()` to start of loop

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
- `ReadTimeoutError` caused agent to crash
- Sometimes `latest.jpg` would not be up-to-date if the original file is not done writing
- Noticed on acq startup that the loop runs twice right away. Moved `pm.sleep()` to start to fix.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
Tested on `daq-dev`

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
