### PR TITLE
HWP Gripper Updates (Alarm group and restart processes)

### DIFF
--- a/socs/agents/hwp_gripper/agent.py
+++ b/socs/agents/hwp_gripper/agent.py
@@ -303,7 +303,6 @@ class HWPGripperAgent:
         session.data['response'] = return_dict
         return return_dict['result'], f"Success: {return_dict['result']}"
 
-
     def reset(self, session, params=None):
         """reset()
         **Task** - Resets the current active controller alarm

--- a/socs/agents/hwp_gripper/agent.py
+++ b/socs/agents/hwp_gripper/agent.py
@@ -763,7 +763,7 @@ class HWPGripperAgent:
                                    0: 'E'}
 
             if bool(state['jxc']['alarm']):
-                out_value = int(state['jxc']['out'])%16
+                out_value = int(state['jxc']['out']) % 16
                 if out_value in alarm_group_mapping.keys():
                     alarm_message = self.decoded_alarm_group[alarm_group_mapping]
                 else:

--- a/socs/agents/hwp_gripper/agent.py
+++ b/socs/agents/hwp_gripper/agent.py
@@ -42,7 +42,7 @@ class HWPGripperAgent:
         self.client: Optional[cli.GripperClient] = None
 
         self.decoded_alarm_group = {False: 'No alarm was detected',
-                                    'A': 'Unrecognized error'
+                                    'A': 'Unrecognized error',
                                     'B': 'Controller saved parameter issue',
                                     'C': 'Issue with position calibration',
                                     'D': 'Could not reach position within time limit',
@@ -303,9 +303,9 @@ class HWPGripperAgent:
                  'log': ["ALARM GROUP B detected"]}
         """
         state_return_dict = self._run_client_func(
-            self.client.get_state, job='get_state', check_shutdown=False
+            self.client.get_state, job='get_state', check_shutdown=False)
 
-        if not bool(state_return_dict['jxc']['alarm']):
+        if not bool(state_return_dict['result']['jxc']['alarm']):
             return_dict = {'result': False, 'log': ['Alarm not triggered']}
         else:
             return_dict = self._run_client_func(

--- a/socs/agents/hwp_gripper/agent.py
+++ b/socs/agents/hwp_gripper/agent.py
@@ -274,6 +274,36 @@ class HWPGripperAgent:
         session.data['response'] = return_dict
         return return_dict['result'], f"Success: {return_dict['result']}"
 
+    def alarm_group(self, session, params=None):
+        """alarm_group()
+
+        **Task** - Queries the actuator controller alarm group
+
+        Notes:
+            Return one of five values depending on the controller alarm state
+                False: No alarm was detected
+                'B': Controller saved parameter issue
+                'C': Issue with position calibration
+                'D': Could not reach position within time limit
+                'E': General controller error
+
+            The most recent data collected is stored in session data in the
+            structure:
+
+                >>> response.session['response']
+                {'result': 'B',
+                 'log': ["ALARM GROUP B detected"]}
+        """
+        return_dict = self._run_client_func(
+            self.client.alarm_group, job='alarm_group', check_shutdown=False)
+
+        if return_dict['result'] is None:
+            return_dict['result'] = False
+
+        session.data['response'] = return_dict
+        return return_dict['result'], f"Success: {return_dict['result']}"
+
+
     def reset(self, session, params=None):
         """reset()
         **Task** - Resets the current active controller alarm
@@ -633,6 +663,26 @@ class HWPGripperAgent:
         self.shutdown_mode = False
         return True, 'Cancelled shutdown mode'
 
+    def restart(self, session, params=None):
+        """restart()
+
+        **Task** - Restarts the beaglebone processes and the socket connection
+
+        Notes:
+            The most recent data collected is stored in session data in the
+            structure:
+
+                >>> response.session['response']
+                {'result': True,
+                 'log': ["Previous connection closed",
+                         "Restart command response: Success",
+                         "Control socket reconnected"]}
+        """
+        return_dict = self._run_client_func(
+            self.client.restart, job='restart', check_shutdown=False)
+        session.data['response'] = return_dict
+        return return_dict['result'], f"Success: {return_dict['result']}"
+
     def monitor_state(self, session, params=None):
         """monitor_state()
 
@@ -851,6 +901,7 @@ def main(args=None):
     agent.register_task('home', gripper_agent.home)
     agent.register_task('inp', gripper_agent.inp)
     agent.register_task('alarm', gripper_agent.alarm)
+    agent.register_task('alarm_group', gripper_agent.alarm_group)
     agent.register_task('reset', gripper_agent.reset)
     agent.register_task('act', gripper_agent.act)
     agent.register_task('is_cold', gripper_agent.is_cold)
@@ -859,6 +910,7 @@ def main(args=None):
     agent.register_task('grip', gripper_agent.grip)
     agent.register_task('ungrip', gripper_agent.ungrip)
     agent.register_task('cancel_shutdown', gripper_agent.cancel_shutdown)
+    agent.register_task('restart', gripper_agent.restart)
 
     runner.run(agent, auto_reconnect=True)
 

--- a/socs/agents/hwp_gripper/drivers/gripper_client.py
+++ b/socs/agents/hwp_gripper/drivers/gripper_client.py
@@ -1,15 +1,19 @@
 import pickle as pkl
 import socket
+import time
 
 
 class GripperClient(object):
     def __init__(self, ip, port):
         self.ip = ip
         self.port = port
-        self.s = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
-        self.s.connect((self.ip, self.port))
-
+        self.control_socket = self._init_connection(self.ip, self.port)
         self.data = b''
+
+    def _init_connection(self, ip, port):
+        s = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+        s.connect((ip, port))
+        return s
 
     def power(self, state):
         if not isinstance(state, bool):
@@ -76,6 +80,9 @@ class GripperClient(object):
     def alarm(self):
         return self.send_command('ALARM')
 
+    def alarm_group(self):
+        return self.send_command('ALARM_GROUP')
+
     def reset(self):
         return self.send_command('RESET')
 
@@ -105,12 +112,34 @@ class GripperClient(object):
 
     def send_command(self, command):
         if isinstance(command, str):
-            self.s.sendall(bytes(command, 'utf-8'))
+            self.control_socket.sendall(bytes(command, 'utf-8'))
         elif isinstance(command, bytes):
-            self.s.sendall(command)
+            self.control_socket.sendall(command)
 
-        return pkl.loads(self.s.recv(4096))
+        return pkl.loads(self.control_socket.recv(4096))
+
+    def restart(self):
+        log = []
+        try:
+            self.close()
+            log.append('Previous connection closed')
+        except:
+            log.append('Previous connection already closed')
+
+        _restart_socket = self._init_connection(self.ip, 5656)
+        _restart_socket.sendall(('reset\n').encode())
+        time.sleep(0.5)
+
+        resp = _restart_socket.recv(4096).decode().strip()
+        log.append(f'Restart command response: {resp}')
+        result = True if resp == 'Success' else False
+        _restart_socket.close()
+        time.sleep(10)
+
+        self.control_socket = self._init_connection(self.ip, self.port)
+        log.append('Control socket reconnected')
+        return {'result': result, 'log': log}
 
     def close(self):
         """Close socket connection"""
-        self.s.close()
+        self.control_socket.close()

--- a/socs/agents/hwp_gripper/drivers/gripper_client.py
+++ b/socs/agents/hwp_gripper/drivers/gripper_client.py
@@ -123,7 +123,7 @@ class GripperClient(object):
         try:
             self.close()
             log.append('Previous connection closed')
-        except:
+        except BaseException:
             log.append('Previous connection already closed')
 
         _restart_socket = self._init_connection(self.ip, 5656)


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Adds two new tasks to the agent. `alarm_group` queries the specific type of generated alarm. This function will return a value of (False, 'B', 'C', 'D', 'E') depending on the current alarm state, where the letters correspond to specific groups of alarms. `restart` remotely restarts the processes which are running separately on beaglebone microcontrollers

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Currently the agent is only able to query whether an alarm is present and does not have any way to distinguish different alarms from each other. The `alarm_group` task adds more specificity to what alarms are generated. As a seperate issue, any time there is a power cycle to the hwp enclosure, a remote user needs to manually ssh into the gripper beaglebone microcontroller and restart two processes. This is both a hassle and requires an expert's knowledge. The `restart` task condenses this process into a single button on OCS-Web which can be run by anyone.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
These two tasks have been tested to work with the satp2 hwp. Note that these changes require running the most recent version of the beaglebone code located in the `sobonelib` repo. There are likely still edge cases which I haven't fully considered, but these should be isolated to these two methods and should not effect the rest of the code.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
