### PR TITLE
HWP Encoder Update (Restart process)

### DIFF
--- a/docs/agents/hwp_encoder.rst
+++ b/docs/agents/hwp_encoder.rst
@@ -32,11 +32,13 @@ using all of the available arguments::
         'instance-id': 'HBA0',
         'arguments': [
           ['--port', '8080'],
+          ['--ip', '192.168.11.113'],
           ]}
        {'agent-class': 'HWPBBBAgent',
         'instance-id': 'HBA1',
         'arguments': [
           ['--port', '8081'],
+          ['--ip', '192.168.11.114'],
           ]}
 
 This is an example to run two agents because we usually have a couple of

--- a/socs/agents/hwp_encoder/agent.py
+++ b/socs/agents/hwp_encoder/agent.py
@@ -726,10 +726,10 @@ def make_parser(parser=None):
     # Add options specific to this agent.
     pgroup = parser.add_argument_group('Agent Options')
     pgroup.add_argument('--port', type=int, default=8080,
-                        help='IP of bbb running the corresponding encoder process')
-    pgroup.add_argument('--ip', type=str, default='None',
                         help='Listening port of Agent for receiving UDP encoder packets. '
                              'This should match what is defined in the bbb encoder process configs')
+    pgroup.add_argument('--ip', type=str, default='None',
+                        help='IP of bbb running the corresponding encoder process')
 
     return parser
 

--- a/socs/agents/hwp_encoder/agent.py
+++ b/socs/agents/hwp_encoder/agent.py
@@ -488,12 +488,13 @@ class HWPBBBAgent:
 
     """
 
-    def __init__(self, agent_obj, port=8080):
+    def __init__(self, agent_obj, port=8080, ip='None'):
         self.active = True
         self.agent = agent_obj
         self.log = agent_obj.log
         self.lock = TimeoutLock()
         self.port = port
+        self.ip = ip
         self.take_data = False
         self.initialized = False
         # For clock count to time conversion
@@ -510,6 +511,36 @@ class HWPBBBAgent:
         self.agent.register_feed('HWPEncoder_full', record=True,
                                  agg_params=agg_params)
         self.parser = EncoderParser(beaglebone_port=self.port)
+
+    def restart(self, session, params):
+        """restart()
+
+        **Task** - Restarts the beaglebone process
+
+        Notes:
+            The most recent data collected is stored in the session data in the
+            structure:
+
+                >>> response.session['response']
+                {'result': True,
+                 'log': ["Restart command response: Success"]}
+        """
+        if self.ip == 'None':
+            return False, "Could not restart process because beaglebone ip is not defined"
+
+        _restart_socket = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+        _restart_socket.connect((self.ip, 5656))
+        _restart_socket.sendall(('reset\n').encode())
+        time.sleep(0.5)
+
+        resp = _restart_socket.recv(4096).decode().strip()
+        log = f'Restart command response: {resp}'
+        result = True if resp == "Success" else False
+        _restart_socket.close()
+        time.sleep(10)
+
+        session.data['response'] = {'result': result, 'log': log}
+        return result, f'Success: {result}'
 
     def acq(self, session, params):
         """acq()
@@ -695,6 +726,7 @@ def make_parser(parser=None):
     # Add options specific to this agent.
     pgroup = parser.add_argument_group('Agent Options')
     pgroup.add_argument('--port', type=int, default=8080)
+    pgroup.add_argument('--ip', type=str, default='None')
 
     return parser
 
@@ -709,8 +741,9 @@ def main(args=None):
                                   parser=parser,
                                   args=args)
     agent, runner = ocs_agent.init_site_agent(args)
-    hwp_bbb_agent = HWPBBBAgent(agent, port=args.port)
+    hwp_bbb_agent = HWPBBBAgent(agent, port=args.port, ip=args.ip)
     agent.register_process('acq', hwp_bbb_agent.acq, hwp_bbb_agent._stop_acq, startup=True)
+    agent.register_task('restart', hwp_bbb_agent.restart)
 
     runner.run(agent, auto_reconnect=True)
 

--- a/socs/agents/hwp_encoder/agent.py
+++ b/socs/agents/hwp_encoder/agent.py
@@ -720,19 +720,16 @@ class HWPBBBAgent:
 
 
 def make_parser(parser=None):
-    """
-    Arguments:
-        port (int): Listening port of Agent for receiving UDP encoder packets. This
-                    should match what is defined in the bbb encoder process configs
-        ip (str): IP of bbb running the corresponding encoder process
-    """
     if parser is None:
         parser = argparse.ArgumentParser()
 
     # Add options specific to this agent.
     pgroup = parser.add_argument_group('Agent Options')
-    pgroup.add_argument('--port', type=int, default=8080)
-    pgroup.add_argument('--ip', type=str, default='None')
+    pgroup.add_argument('--port', type=int, default=8080,
+                        help='IP of bbb running the corresponding encoder process')
+    pgroup.add_argument('--ip', type=str, default='None',
+                        help='Listening port of Agent for receiving UDP encoder packets. '
+                             'This should match what is defined in the bbb encoder process configs')
 
     return parser
 

--- a/socs/agents/hwp_encoder/agent.py
+++ b/socs/agents/hwp_encoder/agent.py
@@ -722,7 +722,7 @@ class HWPBBBAgent:
 def make_parser(parser=None):
     """
     Arguments:
-        port (int): Listening port of Agent for receiving UDP encoder packets. This 
+        port (int): Listening port of Agent for receiving UDP encoder packets. This
                     should match what is defined in the bbb encoder process configs
         ip (str): IP of bbb running the corresponding encoder process
     """

--- a/socs/agents/hwp_encoder/agent.py
+++ b/socs/agents/hwp_encoder/agent.py
@@ -720,6 +720,12 @@ class HWPBBBAgent:
 
 
 def make_parser(parser=None):
+    """
+    Arguments:
+        port (int): Listening port of Agent for receiving UDP encoder packets. This 
+                    should match what is defined in the bbb encoder process configs
+        ip (str): IP of bbb running the corresponding encoder process
+    """
     if parser is None:
         parser = argparse.ArgumentParser()
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Adds a `restart` task to the agent, similarly to what is done for the hwp-gripper agent in #737. This task, when called, will remotely restart the process running separately on a beaglebone microcontroller.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Currently, any time there is a power cycle to the hwp enclosure, a remote user needs to manually ssh into the encoder beaglebone microcontrollers and restart a process on each. This is both a hassle and requires an expert's knowledge. The restart task condenses this process into a single button on OCS-Web which can be run by anyone.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
This task has been tested to work on the satp2 hwp. The encoder processing portion of the code is completely unaffected.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
