### PR TITLE
Fixed custom-PID response time after being above setpoint

### DIFF
--- a/docs/agents/hwp_supervisor_agent.rst
+++ b/docs/agents/hwp_supervisor_agent.rst
@@ -35,6 +35,8 @@ Here is an example of a config block you can add to your ocs site-config file::
             '--hwp-encoder-id', 'hwp-bbb-e1',
             '--hwp-pmx-id', 'hwp-pmx',
             '--hwp-pid-id', 'hwp-pid',
+            '--hwp-pcu-id', 'hwp-pcu',
+            '--hwp-gripper-id', 'hwp-gripper',
             '--ups-id', 'power-ups-az',
             '--ups-minutes-remaining-thresh', 45,
             '--iboot-id', 'power-iboot-hwp-2',
@@ -43,6 +45,13 @@ Here is an example of a config block you can add to your ocs site-config file::
             '--driver-power-agent-type', 'synaccess',
             '--driver-power-cycle-twice',
             '--driver-power-cycle-wait-time', 300,
+
+            '--acu-instance-id', 'acu',
+            '--acu-min-el', 48.0,
+            '--acu-max-el', 90.0,
+            '--acu-max-time-since-update', 30.0,
+            '--mount-velocity-grip-thresh', 0.005,
+            '--grip-max-boresight-angle', 1.0,
         ]}
 
 For SATP1, we use an ibootbar to power the driver, and it is not necessary to
@@ -57,12 +66,20 @@ cycle the driver power twice, so the config will look like::
             '--hwp-encoder-id', 'hwp-bbb-e1',
             '--hwp-pmx-id', 'hwp-pmx',
             '--hwp-pid-id', 'hwp-pid',
+            '--hwp-pcu-id', 'hwp-pcu',
+            '--hwp-gripper-id', 'hwp-gripper',
             '--ups-id', 'power-ups-az',
             '--ups-minutes-remaining-thresh', 45,
             '--iboot-id', 'power-iboot-hwp-2',
             '--driver-iboot-id', 'power-iboot-hwp-2',
             '--driver-iboot-outlets', 1, 2,
             '--driver-power-agent-type', 'iboot',
+
+            '--acu-instance-id', 'acu',
+            '--acu-min-el', 48.0,
+            '--acu-max-el', 90.0,
+            '--acu-max-time-since-update', 30.0,
+            '--mount-velocity-grip-thresh', 0.005,
         ]}
 
 .. note::
@@ -139,6 +156,11 @@ in a safe state to perform the specified operation.
 Before spinning up the HWP, the agent will check that
 - The current elevation and commanded elevation are in the range ``(acu-min-el, acu-max-el)``.
 - The ACU state info has been updated within ``acu-max-time-since-update`` seconds.
+
+Before gripping or ungripping the HWP, the agent will check that:
+- The current elevation and commanded elevation are in the range ``(acu-min-el, acu-max-el)``.
+- The ACU state info has been updated within ``acu-max-time-since-update`` seconds.
+- The az and el velocity is less than ``mount-velocity-grip-thresh``.
 
 Examples
 ```````````

--- a/socs/agents/scpi_psu/agent.py
+++ b/socs/agents/scpi_psu/agent.py
@@ -1,6 +1,7 @@
 import argparse
 import socket
 import time
+from typing import Optional
 
 from ocs import ocs_agent, site_config
 from ocs.ocs_twisted import TimeoutLock
@@ -19,7 +20,7 @@ class ScpiPsuAgent:
         self.gpib_slot = gpib_slot
         self.monitor = False
 
-        self.psu = None
+        self.psu: Optional[ScpiPsuAgent] = None
 
         # Registers Temperature and Voltage feeds
         agg_params = {
@@ -41,15 +42,24 @@ class ScpiPsuAgent:
             if not acquired:
                 return False, "Could not acquire lock"
 
-            try:
-                self.psu = PsuInterface(self.ip_address, self.gpib_slot)
-                self.idn = self.psu.identify()
-            except socket.timeout as e:
-                self.log.error(f"PSU timed out during connect: {e}")
-                return False, "Timeout"
-            self.log.info("Connected to psu: {}".format(self.idn))
-
+            while not self._initialize_module():
+                time.sleep(5)
         return True, 'Initialized PSU.'
+
+    def _initialize_module(self):
+        """Initialize the ScpiPsu module."""
+        try:
+            self.psu = PsuInterface(self.ip_address, self.gpib_slot)
+        except (socket.timeout, OSError) as e:
+            self.log.warn(f"Error establishing connection: {e}")
+            self.psu = None
+            return False
+
+        self.idn = self.psu.identify()
+        self.log.info("Connected to psu: {}".format(self.idn))
+        self.log.info("Clearing event registers and error queue")
+        self.psu.clear()
+        return True
 
     @ocs_agent.param('wait', type=float, default=1)
     @ocs_agent.param('channels', type=list, default=[1, 2, 3])
@@ -71,29 +81,36 @@ class ScpiPsuAgent:
         self.monitor = True
 
         while self.monitor:
+            time.sleep(params['wait'])
             with self.lock.acquire_timeout(1) as acquired:
-                if acquired:
-                    data = {
-                        'timestamp': time.time(),
-                        'block_name': 'output',
-                        'data': {}
-                    }
+                if not acquired:
+                    self.log.warn("Could not acquire in monitor_current")
+                    continue
 
+                if not self.psu:
+                    self._initialize_module()
+                    continue
+
+                data = {
+                    'timestamp': time.time(),
+                    'block_name': 'output',
+                    'data': {}
+                }
+
+                try:
                     for chan in params['channels']:
                         data['data']["Voltage_{}".format(chan)] = self.psu.get_volt(chan)
                         data['data']["Current_{}".format(chan)] = self.psu.get_curr(chan)
+                except socket.timeout as e:
+                    self.log.warn(f"TimeoutError: {e}")
+                    self.log.info("Attempting to reconnect")
+                    self.psu = None
+                    continue
 
-                    # self.log.info(str(data))
-                    # print(data)
-                    self.agent.publish_to_feed('psu_output', data)
+                self.agent.publish_to_feed('psu_output', data)
 
-                    # Allow this process to be queried to return current data
-                    session.data = data
-
-                else:
-                    self.log.warn("Could not acquire in monitor_current")
-
-            time.sleep(params['wait'])
+                # Allow this process to be queried to return current data
+                session.data = data
 
             if params['test_mode']:
                 break

--- a/socs/agents/scpi_psu/drivers.py
+++ b/socs/agents/scpi_psu/drivers.py
@@ -80,3 +80,9 @@ class PsuInterface(PrologixInterface):
         self.write('MEAS:CURR? CH' + str(ch))
         current = float(self.read())
         return current
+
+    def clear(self):
+        # Clear all the event registers and error queue, using a query such as *ESR? or MEAS:X?
+        # instead of *CLS can confuse the PSU
+        self.write('*CLS')
+        return True


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Fixed the slow response time the custom PID had to going under the setpoint after it was above the setpoint for a long time.

## Description
<!--- Describe your changes in detail -->
Updated the I term in the custom_PID function so it could no longer go negative.
Being above the setpoint for a long time would cause the I value to become very negative.
It would take a long time for the custom_PID to overcome that large negative value so the PID would be effectively off for that time.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
This issue was prominent after IV curves when the IV curves would heat the whole focal plane above the setpoint
The PID could take upwards of 30 mins to come back online after IV curves because of this.
The custom PID should respond in <5 minutes now, depending on the I value it is set to.
It is not perfect but this relatively simple solution doesn't affect normal PID operations and should improve functionality a lot.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

I tested this code on both satp1 and satp2.
For satp2 I simple heated the FPA and then dropped the setpoint to something very low.
The FP was above the setpoint for a few minutes while the FPA cooled. The PID then responded nearly instantly after the FPA dipped below the setpoint and turned the heater on immediately (slowly because the I value was untuned and low).

On satp1 I ran multiple IVs with the updated code. The new custom_PID function turned back on immediately after the IVs were finished and resumed a normal PID operating temperature in < 5minutes after they were done (instead of the ~30 minutes without the changes). I also ran a test scan for 15 minutes with the new custom_PID function to make sure the changes did not affect the operation. The custom_PID operated normally as intended during the scans.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
