### PR TITLE
Ls372 custom pid update

### DIFF
--- a/socs/agents/lakeshore372/agent.py
+++ b/socs/agents/lakeshore372/agent.py
@@ -897,12 +897,12 @@ class LS372_Agent:
     @ocs_agent.param('P', type=float)
     @ocs_agent.param('I', type=float)
     @ocs_agent.param('update_time', type=float)
-    @ocs_agent.param('sample_heater_range', type=float, default=10e-3)
     @ocs_agent.param('query_rate', type=float, default=10.)
+    @ocs_agent.param('sample_heater_range', type=float, default=10e-3)
     @ocs_agent.param('test_mode', type=bool, default=False)
     def custom_pid(self, session, params):
         """custom_pid(setpoint, heater, channel, P, \
-                      I, update_time, sample_heater_range=10e-3, \
+                      I, update_time, query_rate=10., sample_heater_range=10e-3, \
                       test_mode=False)
 
         **Process** - Set custom software PID parameters for servo control of fridge
@@ -915,6 +915,7 @@ class LS372_Agent:
             P (float): Proportional value in Watts/Kelvin
             I (float): Integral Value in Hz
             update_time (float): Time between PID updates in seconds
+            query_rate (float): Rate at which to query temp data in Hz.
             sample_heater_range (float): Range for sample heater in Amps.
                                          Default is 10e-3.
             test_mode (bool, optional): Run the Process loop only once.
@@ -931,7 +932,6 @@ class LS372_Agent:
                     {"Channel_02": {"T": 293.644, "R": 33.752, "timestamps": 1601924482.722671}}
                 }
         """
-
         pm = Pacemaker(params['query_rate'])
 
         with self._acq_proc_lock.acquire_timeout(timeout=0, job='custom_pid') \


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Fixed the slow response time the custom PID had to going under the setpoint after it was above the setpoint for a long time.

## Description
<!--- Describe your changes in detail -->
Updated the I term in the custom_PID function so it could no longer go negative.
Being above the setpoint for a long time would cause the I value to become very negative.
It would take a long time for the custom_PID to overcome that large negative value so the PID would be effectively off for that time.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
This issue was prominent after IV curves when the IV curves would heat the whole focal plane above the setpoint
The PID could take upwards of 30 mins to come back online after IV curves because of this.
The custom PID should respond in <5 minutes now, depending on the I value it is set to.
It is not perfect but this relatively simple solution doesn't affect normal PID operations and should improve functionality a lot.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

I tested this code on both satp1 and satp2.

For satp2 I simple heated the FPA and then dropped the setpoint to something very low.
The FP was above the setpoint for a few minutes while the FPA cooled. The PID then responded nearly instantly after the FPA dipped below the setpoint and turned the heater on immediately (slowly because the I value was untuned and low).

On satp1 I ran multiple IVs with the updated code. The new custom_PID function turned back on immediately after the IVs were finished and resumed a normal PID operating temperature in < 5minutes after they were done (instead of the ~30 minutes without the changes). I also ran a test scan for 15 minutes with the new custom_PID function to make sure the changes did not affect the operation. The custom_PID operated normally as intended during the scans.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
