### PR TITLE
Bug fix of wiregrid_actuator/Dockerfile for Ubuntu update

### DIFF
--- a/docker/wiregrid_actuator/Dockerfile
+++ b/docker/wiregrid_actuator/Dockerfile
@@ -2,6 +2,9 @@ FROM socs:latest
 
 WORKDIR /home/ocs/
 
+# This line is to avoid warnings during the build.
+ENV DEBIAN_FRONTEND="noninteractive"
+
 # Galil installation information:
 # -https://www.galil.com/sw/pub/all/doc/global/install/linux/ubuntu/
 # -https://www.galil.com/sw/pub/all/doc/gclib/html/python.html
@@ -19,7 +22,7 @@ RUN apt-get update \
  && rm -r /tmp/gcapsd/ \
  && cp /usr/share/gclib/src/wrappers/python/* . \
  && cp /usr/share/gclib/doc/examples/python/* . \
- && python3 setup.py install \
+ && python3 -m pip install . \
  && python3 -c "import gclib; print(f'gclib location: {gclib.__file__}')"
 
 COPY . .

--- a/docker/wiregrid_actuator/Dockerfile
+++ b/docker/wiregrid_actuator/Dockerfile
@@ -2,23 +2,25 @@ FROM socs:latest
 
 WORKDIR /home/ocs/
 
+# Galil installation information:
+# -https://www.galil.com/sw/pub/all/doc/global/install/linux/ubuntu/
+# -https://www.galil.com/sw/pub/all/doc/gclib/html/python.html
 RUN apt-get update \
  && apt-get install -y apt-utils \
  && apt-get install -y wget libavahi-common-dev libavahi-client-dev libavahi-core-dev libcap-dev libdaemon-dev avahi-daemon \
- && wget http://www.galil.com/sw/pub/all/crypto/GALIL-GPG-KEY-E29D0E4B.asc \
- && apt-key add GALIL-GPG-KEY-E29D0E4B.asc \
- && wget http://www.galil.com/sw/pub/ubuntu/20.04/galil.list \
- && cp galil.list /etc/apt/sources.list.d \
+ && wget https://www.galil.com/sw/pub/apt/all/galil-release_1_all.deb \
+ && apt-get install -y ./galil-release_1_all.deb \
+ && rm ./galil-release_1_all.deb \
  && apt-get update \
- && apt-get install -y --download-only gclib \
- && dpkg -x $(find / -name "gclib*.deb") / \
- && apt-get install -y gclib \
+ && apt install -y gclib \
  && apt-get install -y --download-only gcapsd \
  && dpkg -x $(find / -name "gcapsd*.deb") /tmp/gcapsd/ \
- && mv /tmp/gcapsd/usr/sbin/gcapsd /usr/sbin/ \
+ && mv -v /tmp/gcapsd/usr/sbin/gcapsd /usr/sbin/ \
  && rm -r /tmp/gcapsd/ \
- && tar -xvf /usr/share/doc/gclib/src/gclib_python.tar.gz \
- && python3 setup.py install
+ && cp /usr/share/gclib/src/wrappers/python/* . \
+ && cp /usr/share/gclib/doc/examples/python/* . \
+ && python3 setup.py install \
+ && python3 -c "import gclib; print(f'gclib location: {gclib.__file__}')"
 
 COPY . .
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
The `socs/docker/wiregrid_actuator/Dockerfile` was changed in this PR to make it compatible with the Ubuntu 22.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
The previous wiregrid_actuator/Dockerfile was incompatible with the recent OCS version, which is based on Ubuntu 22,  because the installation method for the actuator controller libraries (`gclib`, `gcapsd`) was changed from Ubuntu 20.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
The connection test to the actuator controller has been done at Kyoto.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
