### PR TITLE
Inconsequential correction to IFM SBN246 temperature decode.

### DIFF
--- a/socs/agents/ifm_sbn246_flowmeter/agent.py
+++ b/socs/agents/ifm_sbn246_flowmeter/agent.py
@@ -26,7 +26,7 @@ def extract(value):
     """
     binary = bin(int(value, 16))[2:].zfill(32)
     _b_flow = binary[0:16]
-    _b_temp = binary[17:30]
+    _b_temp = binary[16:30]
 
     flow = int(_b_flow, 2) / 10
     temp = int(_b_temp, 2)


### PR DESCRIPTION
## Description

I think the decode of the temperature data from the IFM SBN246 sensor drops the MSB here;

https://github.com/simonsobs/socs/blob/81e5916aca1442c798ead412c00cdeb8a79dd88c/socs/agents/ifm_sbn246_flowmeter/agent.py#L29

From the IO-Link process data description;

![Screenshot 2024-09-26 at 1 10 27 PM](https://github.com/user-attachments/assets/77a11ada-b3ab-4e31-b0e3-77526fafc72e)

but running a 32-bit word through the existing code;

```
value='abcdefghijklmnopqrstuvwxyz123456'
_b_flow = binary[0:16]
_b_temp = binary[17:30]
print(f'_b_flow = {_b_flow}')
print(f'_b_temp = {_b_temp}')
```

gives

```
_b_flow = abcdefghijklmnop
_b_temp = rstuvwxyz1234
```

which misses the MSB of the temperature process data field (letter 'q' here).  This PR fixes that.

## Motivation and Context
In my lab this makes no difference, probably because it would only matter if the temperatures were much higher.  The same is almost certainly true in the field.  This change probably doesn't matter, I just noticed it when I was working out the decode for a different IFM sensor.

## How Has This Been Tested?
I compiled and tested on my two SBN246 sensors in my lab at SLAC and it made no difference.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
