### PR TITLE
fixing minor issues in scpi_psu and bluefors agents

### DIFF
--- a/socs/agents/bluefors/agent.py
+++ b/socs/agents/bluefors/agent.py
@@ -342,10 +342,10 @@ class LogParser:
                       'heater': '(heaters)'}
 
         for k, v in file_types.items():
-            if re.search(v, filename):
+            if re.search(v, filename, flags=re.I):
                 _type = k
 
-                m = re.search(file_types[_type], filename)
+                m = re.search(file_types[_type], filename, flags=re.I)
                 if _type == 'lakeshore':
                     return _type, "{}_{}".format(_type, m.group(0).lower().replace(' ', '_'))
                 else:

--- a/socs/agents/scpi_psu/agent.py
+++ b/socs/agents/scpi_psu/agent.py
@@ -268,6 +268,7 @@ class ScpiPsuAgent:
                         'channel': chan,
                         'current': self.psu.get_curr(chan)
                     }
+
                     session.data = data
                 else:
                     return False, "Cannot measure output when output is disabled."
@@ -329,6 +330,7 @@ class ScpiPsuAgent:
                     'state': self.psu.get_output(chan)
                 }
                 session.data = data
+                enabled = bool(data['state'])
             else:
                 return False, "Could not acquire lock."
         if enabled:


### PR DESCRIPTION
log result of scpi_psu's get_output task always returned 'disabled' even when it was actually enabled; bluefors agent not recognizing log file types based on capitalization (e.g. Heaters vs. heaters)


## Description
For SCPI_PSU: set the `enabled` variable based on the outcome of the get_output() driver function. This was the original intent, but the check was lost during rearranging of the session data structure.

For bluefors:
Added the `flags=re.I` option to each of the regex checks to make them case-insensitive.

## Motivation and Context
For SCPI_PSU: The change is mostly for debugging. The correct state of the output was already being reported in the session data, but the log output wasn't properly reflecting this.

For bluefors: The new Bluefors Temperature Controller saves the Heaters log files with a capital 'H' whereas Lakeshore is lower-case. The contents and other formatting is identical however. This change should now treat both cases the same.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
Attempted to run `python3 -m pytest --cov` but execution seem to hang at the HWP Supervisor.

Otherwise, the only testing has been with our lab's setup:
Influxdb Agent
Aggregator Agent
Bluefors Agent
SCPI PSU Agent
Fakedata Agent
Labjack Agent
Cryomech CPA Agent


## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
