### PR TITLE
Debug the wiregrid_tiltsensor agent

### DIFF
--- a/socs/agents/wiregrid_tiltsensor/agent.py
+++ b/socs/agents/wiregrid_tiltsensor/agent.py
@@ -179,9 +179,9 @@ def make_parser(parser_in=None):
         parser_in = argparse.ArgumentParser()
 
     pgroup = parser_in.add_argument_group('Agent Options')
-    pgroup.add_argument('--ip-address', dest='ip', default=None,
+    pgroup.add_argument('--ip-address', dest='ip', type=str, default=None,
                         help='The ip adress of the serial-to-ethernet converter')
-    pgroup.add_argument('--port', dest='port', default=None,
+    pgroup.add_argument('--port', dest='port', type=str, default=None,
                         help='The assigned port of the serial-to-ethernet converter '
                              'for the tilt sensor')
     pgroup.add_argument('--sensor-type',

--- a/socs/agents/wiregrid_tiltsensor/agent.py
+++ b/socs/agents/wiregrid_tiltsensor/agent.py
@@ -31,7 +31,7 @@ class WiregridTiltSensorAgent:
         self.take_data = False
 
         self.ip = ip
-        self.port = port
+        self.port = int(port)
         self.sensor_type = sensor_type
         self.tiltsensor = connect(self.ip, self.port, self.sensor_type)
         self.pm = Pacemaker(2, quantize=True)
@@ -179,9 +179,9 @@ def make_parser(parser_in=None):
         parser_in = argparse.ArgumentParser()
 
     pgroup = parser_in.add_argument_group('Agent Options')
-    pgroup.add_argument('--ip-address', dest='ip', type=str, default=None,
+    pgroup.add_argument('--ip-address', dest='ip', default=None,
                         help='The ip adress of the serial-to-ethernet converter')
-    pgroup.add_argument('--port', dest='port', type=str, default=None,
+    pgroup.add_argument('--port', dest='port', default=None,
                         help='The assigned port of the serial-to-ethernet converter '
                              'for the tilt sensor')
     pgroup.add_argument('--sensor-type',

--- a/socs/agents/wiregrid_tiltsensor/drivers/dwl.py
+++ b/socs/agents/wiregrid_tiltsensor/drivers/dwl.py
@@ -126,7 +126,7 @@ class DWL:
                 "Aborted DWL._conn() due to no "
                 "TCP port specified")
         elif tcp_ip is not None and tcp_port is not None:
-            self.ser = mx.Serial_TCPServer((tcp_ip, tcp_port), timeout)
+            self.ser = mx.Serial_TCPServer((tcp_ip, tcp_port), timeout, device='tilt_sensor')
             self.tcp_ip = tcp_ip
             self.tcp_port = int(tcp_port)
             self.using_tcp = True

--- a/socs/agents/wiregrid_tiltsensor/drivers/dwl.py
+++ b/socs/agents/wiregrid_tiltsensor/drivers/dwl.py
@@ -126,7 +126,7 @@ class DWL:
                 "Aborted DWL._conn() due to no "
                 "TCP port specified")
         elif tcp_ip is not None and tcp_port is not None:
-            self.ser = mx.Serial_TCPServer((tcp_ip, tcp_port), timeout, device='tilt_sensor')
+            self.ser = mx.Serial_TCPServer((tcp_ip, tcp_port), timeout, encoded=False)
             self.tcp_ip = tcp_ip
             self.tcp_port = int(tcp_port)
             self.using_tcp = True

--- a/socs/agents/wiregrid_tiltsensor/drivers/sherborne.py
+++ b/socs/agents/wiregrid_tiltsensor/drivers/sherborne.py
@@ -79,7 +79,7 @@ class Sherborne:
                 "Aborted Sherborne._conn() due to no TCP IP or "
                 "TCP port specified")
         elif tcp_ip is not None and tcp_port is not None:
-            self.ser = mx.Serial_TCPServer((tcp_ip, tcp_port), timeout, device='tiltsensor')
+            self.ser = mx.Serial_TCPServer((tcp_ip, tcp_port), timeout, encoded=False)
             self.tcp_ip = tcp_ip
             self.tcp_port = int(tcp_port)
             self.using_tcp = True

--- a/socs/agents/wiregrid_tiltsensor/drivers/sherborne.py
+++ b/socs/agents/wiregrid_tiltsensor/drivers/sherborne.py
@@ -79,7 +79,7 @@ class Sherborne:
                 "Aborted Sherborne._conn() due to no TCP IP or "
                 "TCP port specified")
         elif tcp_ip is not None and tcp_port is not None:
-            self.ser = mx.Serial_TCPServer((tcp_ip, tcp_port), timeout)
+            self.ser = mx.Serial_TCPServer((tcp_ip, tcp_port), timeout, device='tiltsensor')
             self.tcp_ip = tcp_ip
             self.tcp_port = int(tcp_port)
             self.using_tcp = True

--- a/socs/common/moxa_serial.py
+++ b/socs/common/moxa_serial.py
@@ -52,12 +52,14 @@ class Serial_TCPServer(object):
     Args:
         port (tuple): (IP addr, TCP port)
         timeout (float): Timeout for reading from the moxa box
+        encoded (bool): Encode/decode messages before/after sending/receiving if True.
+                        Send messages unmodified if False. Defaults to True.
 
     """
 
-    def __init__(self, port, timeout=MOXA_DEFAULT_TIMEOUT, device="kikusui"):
+    def __init__(self, port, timeout=MOXA_DEFAULT_TIMEOUT, encoded=True):
         self.port = port
-        self.device = device
+        self.encoded = encoded
 
         self.sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
         self.sock.setblocking(0)
@@ -89,9 +91,9 @@ class Serial_TCPServer(object):
                 pass
         # Flush the message out if you got everything
         if len(msg) == n:
-            if self.device == 'kikusui':
+            if self.encoded:
                 msg = self.sock.recv(n).decode()
-            elif self.device == 'tilt_sensor':
+            else:
                 msg = self.sock.recv(n)
         # Otherwise tell nothing and leave the data in the buffer
         else:
@@ -197,9 +199,9 @@ class Serial_TCPServer(object):
                 needed.
 
         """
-        if self.device == 'kikusui':
+        if self.encoded:
             self.sock.send(msg.encode())
-        elif self.device == 'tilt_sensor':
+        else:
             self.sock.send(msg)
 
     def writeread(self, msg):

--- a/socs/common/moxa_serial.py
+++ b/socs/common/moxa_serial.py
@@ -55,8 +55,9 @@ class Serial_TCPServer(object):
 
     """
 
-    def __init__(self, port, timeout=MOXA_DEFAULT_TIMEOUT):
+    def __init__(self, port, timeout=MOXA_DEFAULT_TIMEOUT, device="kikusui"):
         self.port = port
+        self.device = device
 
         self.sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
         self.sock.setblocking(0)
@@ -88,7 +89,10 @@ class Serial_TCPServer(object):
                 pass
         # Flush the message out if you got everything
         if len(msg) == n:
-            msg = self.sock.recv(n).decode()
+            if self.device == 'kikusui':
+                msg = self.sock.recv(n).decode()
+            elif self.device == 'tilt_sensor':
+                msg = self.sock.recv(n)
         # Otherwise tell nothing and leave the data in the buffer
         else:
             msg = ''
@@ -193,7 +197,10 @@ class Serial_TCPServer(object):
                 needed.
 
         """
-        self.sock.send(msg.encode())
+        if self.device == 'kikusui':
+            self.sock.send(msg.encode())
+        elif self.device == 'tilt_sensor':
+            self.sock.send(msg)
 
     def writeread(self, msg):
         self.flushInput()


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
I changed the wiregrid_tiltsensor agent and moxa_serial.py in the socs/common directory.
In the wiregrid_tiltsensor, I removed the type of argument from `add_argument` and added cast of the port.
In the moxa_serial.py, I added new argument, `device=kikusui`, to the class `Serial_TCPServer`. This argument is for recognize which device the serial-to-LAN converter communicate with. The tilt sensor needs to send commands not decoded and recieve commands not encoded. This change detect the device to communicate and judge the neccesity of encoding and decoding of commands.
## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
To debug the wiregrid_tiltsensor agent.

Resolves #716.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
Tested in my lab, using a serial-to-LAN converter.
## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
