### PR TITLE
Add error handling to Cryomech PTC drivers and agent acq process

### DIFF
--- a/socs/agents/cryomech_cpa/agent.py
+++ b/socs/agents/cryomech_cpa/agent.py
@@ -72,7 +72,11 @@ class PTCAgent:
                            fake_errors=self.fake_errors)
 
             # Test connection and display identifying info
-            self.ptc.get_data()
+            try:
+                self.ptc.get_data()
+            except ConnectionError:
+                self.log.error("Could not establish connection to compressor.")
+                return False, "PTC agent initialization failed"
             print("PTC Model:", self.ptc.model)
             print("PTC Serial Number:", self.ptc.serial)
             print("Software Revision is:", self.ptc.software_revision)

--- a/socs/agents/cryomech_cpa/agent.py
+++ b/socs/agents/cryomech_cpa/agent.py
@@ -141,7 +141,16 @@ class PTCAgent:
                 # Publish data, waiting 1/f_sample seconds in between calls.
                 pub_data = {'timestamp': time.time(),
                             'block_name': 'ptc_status'}
-                data_flag, data = self.ptc.get_data()
+                try:
+                    data_flag, data = self.ptc.get_data()
+                    if session.degraded:
+                        self.log.info("Connection re-established.")
+                        session.degraded = False
+                except ConnectionError:
+                    self.log.error("Failed to get data from compressor. Check network connection.")
+                    session.degraded = True
+                    time.sleep(1)
+                    continue
                 pub_data['data'] = data
                 # If there is an error in compressor output (data_flag = True),
                 # do not publish

--- a/socs/agents/cryomech_cpa/drivers.py
+++ b/socs/agents/cryomech_cpa/drivers.py
@@ -1,4 +1,5 @@
 import random
+import selectors
 import socket
 import struct
 
@@ -16,24 +17,85 @@ ESC_ESC = '\x32'
 
 class PTC:
     def __init__(self, ip_address, port=502, timeout=10, fake_errors=False):
-        self.ip_address = ip_address
-        self.port = int(port)
         self.fake_errors = fake_errors
 
         self.model = None
         self.serial = None
         self.software_revision = None
 
-        self.comm = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
-        self.comm.connect((self.ip_address, self.port))  # connects to the PTC
-        self.comm.settimeout(timeout)
+        self.ip_address = ip_address
+        self.port = int(port)
+        self.timeout = timeout
+        self.comm = self._connect((self.ip_address, self.port))
+
+    def _connect(self, address):
+        sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+        sock.settimeout(self.timeout)
+        try:
+            sock.connect(address)
+        except TimeoutError:
+            print(f"Connection not established within {self.timeout}.")
+            return
+        except OSError as e:
+            print(f"Unable to connect. {e}")
+            return
+        except Exception as e:
+            print(f"Caught unexpected {type(e).__name__} while connecting:")
+            print(f"  {e}")
+            return
+        return sock
+
+    def reset(self):
+        print("Resetting the connection to the compressor.")
+        self.comm = self._connect((self.ip_address, self.port))
+
+    def _write(self, msg):
+        try:
+            self.comm.sendall(msg)
+            return
+        except (BrokenPipeError, ConnectionResetError) as e:
+            print(f"Connection error: {e}")
+            self.reset()
+        except TimeoutError as e:
+            print(f"Timeout error while writing: {e}")
+            self.reset()
+        except Exception as e:
+            print(f"Caught unexpected {type(e).__name__} during write:")
+            print(f"  {e}")
+            self.reset()
+
+        # Try a second time before giving up
+        try:
+            self.comm.sendall(msg)
+        except (BrokenPipeError, ConnectionResetError) as e:
+            print(f"Connection error: {e}")
+            raise ConnectionError
+        except TimeoutError as e:
+            print(f"Timeout error while writing: {e}")
+            raise ConnectionError
+        except Exception as e:
+            print(f"Caught unexpected {type(e).__name__} during write:")
+            print(f"  {e}")
+            raise ConnectionError
+
+    def _check_ready(self):
+        """Check socket is ready to read from."""
+        sel = selectors.DefaultSelector()
+        sel.register(self.comm, selectors.EVENT_READ)
+        if not sel.select(self.timeout):
+            raise ConnectionError
+
+    def _read(self):
+        self._check_ready()
+        data = self.comm.recv(1024)
+        return data
 
     def get_data(self):
         """
         Gets the raw data from the ptc and returns it in a usable format.
         """
-        self.comm.sendall(self.buildRegistersQuery())
-        data = self.comm.recv(1024)
+        self._write(self.buildRegistersQuery())
+        data = self._read()
         data_flag, brd = self.breakdownReplyData(data)
 
         return data_flag, brd


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->
This PR implements error handling for the Cryomech PTC class and most of the agent, with the main goal of making the `acq()` process robust to network interruptions.

In doing this I moved the "drivers" out to their own module. That's perhaps a bit noisy overall in this PR, but the interesting diffs are separated to:
* Driver error handling implementation: 41f5f8f3fe039a597fc12521739a4274d9668863
* Agent error handling in acq process: 1470e0acec6124ba18bbb09af94dabda4a8729ac

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
This implementation is the one outlined in "Reconnecting in the Drivers" in #538, heavily inspired by #325.

Resolves #766.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
Tested by running the agent locally with an actual Cryomech compressor. Tested the agent remains online while disconnecting the network cable from the compressor and re-establishes connection when the cable is plugged back in. Example logs:
```
2024-10-02T15:18:47-0400 start called for acq
2024-10-02T15:18:47-0400 acq:1 Status is now "starting".
2024-10-02T15:18:47-0400 Response from acq.start(): Started process "acq".
2024-10-02T15:18:47-0400 init:0 PTC agent initialized
2024-10-02T15:18:47-0400 init:0 Status is now "done".
2024-10-02T15:18:47-0400 acq:1 Status is now "running".
2024-10-02T15:19:12-0400 Failed to get data from compressor. Check network connection.
2024-10-02T15:19:23-0400 Failed to get data from compressor. Check network connection.
2024-10-02T15:19:32-0400 Connection re-established.
```

Also tested shutting down the compressor and bringing it back up, which causes the `reset()` to trigger and produces a slightly different set of errors. It still reconnects once the compressor is back online. Example logs:
```
2024-10-02T15:19:51-0400 Failed to get data from compressor. Check network connection.
2024-10-02T15:20:02-0400 Failed to get data from compressor. Check network connection.
2024-10-02T15:20:12-0400 Failed to get data from compressor. Check network connection.
2024-10-02T15:20:13-0400 Connection error: [Errno 32] Broken pipe
2024-10-02T15:20:13-0400 Resetting the connection to the compressor.
2024-10-02T15:20:14-0400 Unable to connect. [Errno 111] Connection refused
2024-10-02T15:20:14-0400 Caught unexpected AttributeError during write:
2024-10-02T15:20:14-0400   'NoneType' object has no attribute 'sendall'
2024-10-02T15:20:14-0400 Failed to get data from compressor. Check network connection.
2024-10-02T15:20:15-0400 Caught unexpected AttributeError during write:
2024-10-02T15:20:15-0400   'NoneType' object has no attribute 'sendall'
2024-10-02T15:20:15-0400 Resetting the connection to the compressor.
2024-10-02T15:20:15-0400 Unable to connect. [Errno 111] Connection refused
2024-10-02T15:20:15-0400 Caught unexpected AttributeError during write:
2024-10-02T15:20:15-0400   'NoneType' object has no attribute 'sendall
2024-10-02T15:20:47-0400 Resetting the connection to the compressor.
2024-10-02T15:20:47-0400 Connection re-established.
```

(There will be a lot of the `AttributeError` logs, as the acq process loops.)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
