### PR TITLE
ACU: more care when setting up go_to

### DIFF
--- a/socs/agents/acu/agent.py
+++ b/socs/agents/acu/agent.py
@@ -987,13 +987,15 @@ class ACUAgent:
         return limit_func, limits
 
     @inlineCallbacks
-    def _go_to_axis(self, session, axis, target):
+    def _go_to_axis(self, session, axis, target,
+                    state_feedback=None):
         """Execute a movement, using "Preset" mode, on a specific axis.
 
         Args:
           session: session object variable of the parent operation.
           axis (str): one of 'Azimuth', 'Elevation', 'Boresight'.
           target (float): target position.
+          state_feedback (dict): place to record state (see notes).
 
         Returns:
           ok (bool): True if the motion completed successfully and
@@ -1006,6 +1008,13 @@ class ACUAgent:
           warning horn sounds, this function should block until that
           completes, even if the requested position has been achieved
           (i.e. no actual motion was needed).
+
+          The state_feedback may be used to pipeline the initial parts
+          of the movement, so two functions aren't trying to command
+          at the same time.  The ``state_feedback`` dict should be
+          passed in initialized with ``{'state': 'init'}``.  When
+          initial commanding is finished, this function will update it
+          to `state="wait"`, and then on completion to `state="done"`.
 
         """
         # Step time in event loop.
@@ -1054,6 +1063,10 @@ class ACUAgent:
         State = Enum(f'{axis}State',
                      ['INIT', 'WAIT_MOVING', 'WAIT_STILL', 'FAIL', 'DONE'])
 
+        if state_feedback is None:
+            state_feedback = {}
+        state_feedback['state'] = 'init'
+
         # If this axis is "ignore", skip it.
         for _axis, short_name in [
                 ('Azimuth', 'az'),
@@ -1062,6 +1075,7 @@ class ACUAgent:
         ]:
             if _axis == axis and short_name in self.ignore_axes:
                 self.log.warn('Ignoring requested motion on {axis}', axis=axis)
+                state_feedback['state'] = 'done'
                 yield dsleep(1)
                 return True, 'axis successfully ignored'
 
@@ -1227,6 +1241,7 @@ class ACUAgent:
 
             elif state == State.WAIT_STILL:
                 # Once moving, watch for end of motion.
+                state_feedback['state'] = 'wait'
                 if not mode_ok:
                     self.log.error('Unexpected axis mode transition; exiting.')
                     state = State.FAIL
@@ -1263,6 +1278,8 @@ class ACUAgent:
             msg = 'Move aborted!'
         else:
             msg = 'Irregularity during motion!'
+
+        state_feedback['state'] = 'done'
         return success, msg
 
     @inlineCallbacks
@@ -1299,6 +1316,7 @@ class ACUAgent:
             if target is not None:
                 move_defs.append(
                     (short_name, (session, axis_name, target)))
+
         if len(move_defs) is None:
             return True, 'No motion requested.'
 
@@ -1306,8 +1324,18 @@ class ACUAgent:
             yield self.acu_control.clear_faults()
             yield dsleep(1)
 
-        moves = yield DeferredList([self._go_to_axis(*args)
-                                    for name, args in move_defs])
+        # Start each move, waiting for each to pass the "init" state
+        # before beginning the next one.
+        moves = []
+        for name, args in move_defs:
+            fb = {'state': 'init'}
+            move_def = self._go_to_axis(*args, state_feedback=fb)
+            while fb['state'] == 'init':
+                yield dsleep(.1)
+            moves.append(move_def)
+
+        # Now wait for all to complete.
+        moves = yield DeferredList(moves)
         all_ok, msgs = True, []
         for _ok, result in moves:
             if _ok:


### PR DESCRIPTION
## Description

ACU motion is initiated in a more carefully ordered way (clear_faults, start move in one axis, start move in next axis...).

## Motivation and Context

This responds to odd errors seen on the LAT (a while ago) and on SATP1 (recently).  Not clear that these fixes will resolve those issues, but it's quite possible.

## How Has This Been Tested?

Tested on SATP1.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
