### PR TITLE
ls372: Make acq process robust to network disruptions

### DIFF
--- a/socs/Lakeshore/Lakeshore372.py
+++ b/socs/Lakeshore/Lakeshore372.py
@@ -1,10 +1,11 @@
 # Lakeshore372.py
 
-import socket
 import sys
 import time
 
 import numpy as np
+
+from socs.tcp import TCPInterface
 
 # Lookup keys for command parameters.
 autorange_key = {'0': 'off',
@@ -173,38 +174,7 @@ heater_display_key = {'1': 'current',
 heater_display_lock = {v: k for k, v in heater_display_key.items()}
 
 
-def _establish_socket_connection(ip, timeout, port=7777):
-    """Establish socket connection to the LS372.
-
-    Parameters
-    ----------
-    ip : str
-        IP address of the LS372
-    timeout : int
-        timeout period for the socket connection in seconds
-    port : int
-        Port for the connection, defaults to the default LS372 port of 7777
-
-    Returns
-    -------
-    socket.socket
-        The socket object with open connection to the 372
-
-    """
-    com = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
-    try:
-        com.connect((ip, port))
-    except OSError as e:
-        if 'No route to host' in e.strerror:
-            raise ConnectionError("Cannot connect to LS372")
-        else:
-            raise e
-    com.settimeout(timeout)
-
-    return com
-
-
-class LS372:
+class LS372(TCPInterface):
     """
         Lakeshore 372 class.
 
@@ -213,8 +183,10 @@ class LS372:
                    index 0 corresponding to the control channel, 'A'
     """
 
-    def __init__(self, ip, timeout=10, num_channels=16):
-        self.com = _establish_socket_connection(ip, timeout)
+    def __init__(self, ip_address, port=7777, timeout=10, num_channels=16):
+        # Setup the TCP Interface
+        super().__init__(ip_address, port, timeout)
+
         self.num_channels = num_channels
 
         self.id = self.get_id()
@@ -237,11 +209,7 @@ class LS372:
         self.still_heater = Heater(self, 2)
 
     def msg(self, message):
-        """Send message to the Lakeshore 372 over ethernet.
-
-        If we're asking for something from the Lakeshore (indicated by a ? in
-        the message string), then we will attempt to ask twice before giving up
-        due to potential communication timeouts.
+        """Send message to the Lakeshore 372 over TCP.
 
         Parameters
         ----------
@@ -257,20 +225,10 @@ class LS372:
         msg_str = f'{message}\r\n'.encode()
 
         if '?' in message:
-            self.com.send(msg_str)
-            # Try once, if we timeout, try again. Usually gets around single event glitches.
-            for attempt in range(2):
-                try:
-                    resp = str(self.com.recv(4096), 'utf-8').strip()
-                    break
-                except socket.timeout:
-                    print("Warning: Caught timeout waiting for response to '%s', trying again "
-                          "before giving up" % message)
-                    if attempt == 1:
-                        raise RuntimeError('Query response to Lakeshore timed out after two '
-                                           'attempts. Check connection.')
+            self.send(msg_str)
+            resp = str(self.recv(), 'utf-8').strip()
         else:
-            self.com.send(msg_str)
+            self.send(msg_str)
             resp = ''
 
         return resp

--- a/socs/Lakeshore/Lakeshore372.py
+++ b/socs/Lakeshore/Lakeshore372.py
@@ -226,7 +226,7 @@ class LS372(TCPInterface):
 
         if '?' in message:
             self.send(msg_str)
-            resp = str(self.recv(), 'utf-8').strip()
+            resp = str(self.recv(reset_on_error=True), 'utf-8').strip()
         else:
             self.send(msg_str)
             resp = ''

--- a/socs/agents/lakeshore372/agent.py
+++ b/socs/agents/lakeshore372/agent.py
@@ -162,6 +162,36 @@ class LS372_Agent:
 
         return True, 'Lakeshore module initialized.'
 
+    def _wait_for_channel_change(self, active_channel, previous_channel):
+        pause_time = active_channel.get_pause()
+        self.log.debug("Pause time for {c}: {p}",
+                       c=active_channel.channel_num,
+                       p=pause_time)
+
+        dwell_time = active_channel.get_dwell()
+        self.log.debug("User set dwell_time_delay: {p}",
+                       p=self.dwell_time_delay)
+
+        # Check user set dwell time isn't too long
+        if self.dwell_time_delay > dwell_time:
+            self.log.warn("WARNING: User set dwell_time_delay of "
+                          + "{delay} s is larger than channel "
+                          + "dwell time of {chan_time} s. If "
+                          + "you are autoscanning this will "
+                          + "cause no data to be collected. "
+                          + "Reducing dwell time delay to {s} s.",
+                          delay=self.dwell_time_delay,
+                          chan_time=dwell_time,
+                          s=dwell_time - 1)
+            total_time = pause_time + dwell_time - 1
+        else:
+            total_time = pause_time + self.dwell_time_delay
+
+        for i in range(total_time):
+            self.log.debug("Sleeping for {t} more seconds...",
+                           t=total_time - i)
+            time.sleep(1)
+
     @ocs_agent.param('sample_heater', default=False, type=bool)
     @ocs_agent.param('run_once', default=False, type=bool)
     def acq(self, session, params=None):
@@ -222,44 +252,20 @@ class LS372_Agent:
                                       f"currently held by {self._lock.job}.")
                         continue
 
-                active_channel = self.module.get_active_channel()
-
                 # The 372 reports the last updated measurement repeatedly
                 # during the "pause change time", this results in several
                 # stale datapoints being recorded. To get around this we
                 # query the pause time and skip data collection during it
                 # if the channel has changed (as it would if autoscan is
                 # enabled.)
+                # QUERY
+                active_channel = self.module.get_active_channel()
+
                 if previous_channel != active_channel:
                     if previous_channel is not None:
-                        pause_time = active_channel.get_pause()
-                        self.log.debug("Pause time for {c}: {p}",
-                                       c=active_channel.channel_num,
-                                       p=pause_time)
-
-                        dwell_time = active_channel.get_dwell()
-                        self.log.debug("User set dwell_time_delay: {p}",
-                                       p=self.dwell_time_delay)
-
-                        # Check user set dwell time isn't too long
-                        if self.dwell_time_delay > dwell_time:
-                            self.log.warn("WARNING: User set dwell_time_delay of "
-                                          + "{delay} s is larger than channel "
-                                          + "dwell time of {chan_time} s. If "
-                                          + "you are autoscanning this will "
-                                          + "cause no data to be collected. "
-                                          + "Reducing dwell time delay to {s} s.",
-                                          delay=self.dwell_time_delay,
-                                          chan_time=dwell_time,
-                                          s=dwell_time - 1)
-                            total_time = pause_time + dwell_time - 1
-                        else:
-                            total_time = pause_time + self.dwell_time_delay
-
-                        for i in range(total_time):
-                            self.log.debug("Sleeping for {t} more seconds...",
-                                           t=total_time - i)
-                            time.sleep(1)
+                        self._wait_for_channel_change(
+                            active_channel,
+                            previous_channel)
 
                     # Track the last channel we measured
                     previous_channel = self.module.get_active_channel()

--- a/socs/agents/lakeshore372/agent.py
+++ b/socs/agents/lakeshore372/agent.py
@@ -252,24 +252,40 @@ class LS372_Agent:
                                       f"currently held by {self._lock.job}.")
                         continue
 
-                # The 372 reports the last updated measurement repeatedly
-                # during the "pause change time", this results in several
-                # stale datapoints being recorded. To get around this we
-                # query the pause time and skip data collection during it
-                # if the channel has changed (as it would if autoscan is
-                # enabled.)
-                # QUERY
-                active_channel = self.module.get_active_channel()
+                try:
+                    # The 372 reports the last updated measurement repeatedly
+                    # during the "pause change time", this results in several
+                    # stale datapoints being recorded. To get around this we
+                    # query the pause time and skip data collection during it
+                    # if the channel has changed (as it would if autoscan is
+                    # enabled.)
+                    active_channel = self.module.get_active_channel()
 
-                if previous_channel != active_channel:
-                    if previous_channel is not None:
-                        self._wait_for_channel_change(
-                            active_channel,
-                            previous_channel)
+                    if previous_channel != active_channel:
+                        if previous_channel is not None:
+                            self._wait_for_channel_change(
+                                active_channel,
+                                previous_channel)
 
-                    # Track the last channel we measured
-                    previous_channel = self.module.get_active_channel()
+                        # Track the last channel we measured
+                        previous_channel = self.module.get_active_channel()
 
+                    # Collect both temperature and resistance values from each Channel
+                    channel_str = active_channel.name.replace(' ', '_')
+                    temp_reading = self.module.get_temp(unit='kelvin',
+                                                        chan=active_channel.channel_num)
+                    res_reading = self.module.get_temp(unit='ohms',
+                                                       chan=active_channel.channel_num)
+                    if session.degraded:
+                        self.log.info("Connection re-established.")
+                        session.degraded = False
+                except ConnectionError:
+                    self.log.error("Failed to get data from LS372. Check network connection.")
+                    session.degraded = True
+                    time.sleep(1)
+                    continue
+
+                # For data feed
                 current_time = time.time()
                 data = {
                     'timestamp': current_time,
@@ -277,14 +293,6 @@ class LS372_Agent:
                     'data': {}
                 }
 
-                # Collect both temperature and resistance values from each Channel
-                channel_str = active_channel.name.replace(' ', '_')
-                temp_reading = self.module.get_temp(unit='kelvin',
-                                                    chan=active_channel.channel_num)
-                res_reading = self.module.get_temp(unit='ohms',
-                                                   chan=active_channel.channel_num)
-
-                # For data feed
                 data['data'][channel_str + '_T'] = temp_reading
                 data['data'][channel_str + '_R'] = res_reading
                 session.app.publish_to_feed('temperatures', data)
@@ -298,8 +306,18 @@ class LS372_Agent:
 
                 # Also queries control channel if enabled
                 if self.control_chan_enabled:
-                    temp = self.module.get_temp(unit='kelvin', chan=0)
-                    res = self.module.get_temp(unit='ohms', chan=0)
+                    try:
+                        temp = self.module.get_temp(unit='kelvin', chan=0)
+                        res = self.module.get_temp(unit='ohms', chan=0)
+                        if session.degraded:
+                            self.log.info("Connection re-established.")
+                            session.degraded = False
+                    except ConnectionError:
+                        self.log.error("Failed to get data from LS372. Check network connection.")
+                        session.degraded = True
+                        time.sleep(1)
+                        continue
+
                     cur_time = time.time()
                     data = {
                         'timestamp': time.time(),
@@ -321,7 +339,16 @@ class LS372_Agent:
                 if params.get("sample_heater", False):
                     # Sample Heater
                     heater = self.module.sample_heater
-                    hout = heater.get_sample_heater_output()
+                    try:
+                        hout = heater.get_sample_heater_output()
+                        if session.degraded:
+                            self.log.info("Connection re-established.")
+                            session.degraded = False
+                    except ConnectionError:
+                        self.log.error("Failed to get data from LS372. Check network connection.")
+                        session.degraded = True
+                        time.sleep(1)
+                        continue
 
                     current_time = time.time()
                     htr_data = {

--- a/tests/agents/test_ls372_agent.py
+++ b/tests/agents/test_ls372_agent.py
@@ -94,7 +94,7 @@ def mock_372_msg():
 
 
 # Tests
-@mock.patch('socs.Lakeshore.Lakeshore372._establish_socket_connection', mock_connection())
+@mock.patch('socs.tcp.TCPInterface._connect', mock_connection())
 @mock.patch('socs.Lakeshore.Lakeshore372.LS372.msg', mock_372_msg())
 def test_ls372_init_lakeshore(agent):
     """Run init_lakeshore, mocking a connection and the 372 messaging.
@@ -111,7 +111,7 @@ def test_ls372_init_lakeshore(agent):
     assert res[0] is True
 
 
-@mock.patch('socs.Lakeshore.Lakeshore372._establish_socket_connection', mock_connection())
+@mock.patch('socs.tcp.TCPInterface._connect', mock_connection())
 @mock.patch('socs.Lakeshore.Lakeshore372.LS372.msg', mock_372_msg())
 def test_ls372_init_lakeshore_already_initialized(agent):
     """Initializing an already initialized LS372_Agent should just return True.
@@ -126,32 +126,16 @@ def test_ls372_init_lakeshore_already_initialized(agent):
 
 # If we don't patch the reactor out, it'll mess up pytest when stop is called
 @mock.patch('socs.agents.lakeshore372.agent.reactor', mock.MagicMock())
+@mock.patch('socs.tcp.TCPInterface._connect', mock_failed_connection())
 @mock.patch('socs.Lakeshore.Lakeshore372.LS372.msg', mock_372_msg())
 def test_ls372_init_lakeshore_failed_connection(agent):
-    """Leaving off the connection Mock, if the connection fails the init task
-    should fail and return False.
-
-    """
+    """If the connection fails the init task should fail and return False."""
     session = create_session('init_lakeshore')
     res = agent.init_lakeshore(session, None)
     assert res[0] is False
 
 
-# If we don't patch the reactor out, it'll mess up pytest when stop is called
-@mock.patch('socs.agents.lakeshore372.agent.reactor', mock.MagicMock())
-@mock.patch('socs.Lakeshore.Lakeshore372._establish_socket_connection', mock_failed_connection())
-@mock.patch('socs.Lakeshore.Lakeshore372.LS372.msg', mock_372_msg())
-def test_ls372_init_lakeshore_unhandled_error(agent):
-    """If we cause an unhandled exception during connection init task should
-    also fail and return False.
-
-    """
-    session = create_session('init_lakeshore')
-    res = agent.init_lakeshore(session, None)
-    assert res[0] is False
-
-
-@mock.patch('socs.Lakeshore.Lakeshore372._establish_socket_connection', mock_connection())
+@mock.patch('socs.tcp.TCPInterface._connect', mock_connection())
 @mock.patch('socs.Lakeshore.Lakeshore372.LS372.msg', mock_372_msg())
 def test_ls372_init_lakeshore_auto_acquire(agent):
     """If we initalize and pass the auto_acquire param, we should expect the
@@ -165,7 +149,7 @@ def test_ls372_init_lakeshore_auto_acquire(agent):
 
 
 # enable_control_chan
-@mock.patch('socs.Lakeshore.Lakeshore372._establish_socket_connection', mock_connection())
+@mock.patch('socs.tcp.TCPInterface._connect', mock_connection())
 @mock.patch('socs.Lakeshore.Lakeshore372.LS372.msg', mock_372_msg())
 def test_ls372_enable_control_chan(agent):
     """Normal operation of 'enable_control_chan' task."""
@@ -179,7 +163,7 @@ def test_ls372_enable_control_chan(agent):
 
 
 # disable_control_chan
-@mock.patch('socs.Lakeshore.Lakeshore372._establish_socket_connection', mock_connection())
+@mock.patch('socs.tcp.TCPInterface._connect', mock_connection())
 @mock.patch('socs.Lakeshore.Lakeshore372.LS372.msg', mock_372_msg())
 def test_ls372_disable_control_chan(agent):
     """Normal operation of 'disable_control_chan' task."""
@@ -193,7 +177,7 @@ def test_ls372_disable_control_chan(agent):
 
 
 # acq
-@mock.patch('socs.Lakeshore.Lakeshore372._establish_socket_connection', mock_connection())
+@mock.patch('socs.tcp.TCPInterface._connect', mock_connection())
 @mock.patch('socs.Lakeshore.Lakeshore372.LS372.msg', mock_372_msg())
 def test_ls372_acq(agent):
     """Test running the 'acq' Process once."""
@@ -210,7 +194,7 @@ def test_ls372_acq(agent):
     assert session.data['fields']['Channel_01']['R'] == 108.278
 
 
-@mock.patch('socs.Lakeshore.Lakeshore372._establish_socket_connection', mock_connection())
+@mock.patch('socs.tcp.TCPInterface._connect', mock_connection())
 @mock.patch('socs.Lakeshore.Lakeshore372.LS372.msg', mock_372_msg())
 def test_ls372_acq_w_control_chan(agent):
     """Test running the 'acq' Process once with control channel active."""
@@ -230,7 +214,7 @@ def test_ls372_acq_w_control_chan(agent):
     assert session.data['fields']['control']['R'] == 0.0
 
 
-@mock.patch('socs.Lakeshore.Lakeshore372._establish_socket_connection', mock_connection())
+@mock.patch('socs.tcp.TCPInterface._connect', mock_connection())
 @mock.patch('socs.Lakeshore.Lakeshore372.LS372.msg', mock_372_msg())
 def test_ls372_acq_w_sample_heater(agent):
     """Test running the 'acq' Process once with sample heater active."""
@@ -245,7 +229,7 @@ def test_ls372_acq_w_sample_heater(agent):
 
 
 # stop_acq
-@mock.patch('socs.Lakeshore.Lakeshore372._establish_socket_connection', mock_connection())
+@mock.patch('socs.tcp.TCPInterface._connect', mock_connection())
 @mock.patch('socs.Lakeshore.Lakeshore372.LS372.msg', mock_372_msg())
 def test_ls372_stop_acq_not_running(agent):
     """'stop_acq' should return False if acq Process isn't running."""
@@ -258,7 +242,7 @@ def test_ls372_stop_acq_not_running(agent):
     assert res[0] is False
 
 
-@mock.patch('socs.Lakeshore.Lakeshore372._establish_socket_connection', mock_connection())
+@mock.patch('socs.tcp.TCPInterface._connect', mock_connection())
 @mock.patch('socs.Lakeshore.Lakeshore372.LS372.msg', mock_372_msg())
 def test_ls372_stop_acq_while_running(agent):
     """'stop_acq' should return True if acq Process is running."""
@@ -276,7 +260,7 @@ def test_ls372_stop_acq_while_running(agent):
 
 
 # set_heater_range
-@mock.patch('socs.Lakeshore.Lakeshore372._establish_socket_connection', mock_connection())
+@mock.patch('socs.tcp.TCPInterface._connect', mock_connection())
 @mock.patch('socs.Lakeshore.Lakeshore372.LS372.msg', mock_372_msg())
 def test_ls372_set_heater_range_sample_heater(agent):
     """Set sample heater to different range than currently set. Normal
@@ -293,7 +277,7 @@ def test_ls372_set_heater_range_sample_heater(agent):
     assert res[0] is True
 
 
-@mock.patch('socs.Lakeshore.Lakeshore372._establish_socket_connection', mock_connection())
+@mock.patch('socs.tcp.TCPInterface._connect', mock_connection())
 @mock.patch('socs.Lakeshore.Lakeshore372.LS372.msg', mock_372_msg())
 def test_ls372_set_heater_range_still_heater(agent):
     """Set still heater to different range than currently set. Normal
@@ -310,7 +294,7 @@ def test_ls372_set_heater_range_still_heater(agent):
     assert res[0] is True
 
 
-@mock.patch('socs.Lakeshore.Lakeshore372._establish_socket_connection', mock_connection())
+@mock.patch('socs.tcp.TCPInterface._connect', mock_connection())
 @mock.patch('socs.Lakeshore.Lakeshore372.LS372.msg', mock_372_msg())
 def test_ls372_set_heater_range_identical_range(agent):
     """Set heater to same range as currently set. Should not change range, just
@@ -333,7 +317,7 @@ def test_ls372_set_heater_range_identical_range(agent):
 
 
 # set_excitation_mode
-@mock.patch('socs.Lakeshore.Lakeshore372._establish_socket_connection', mock_connection())
+@mock.patch('socs.tcp.TCPInterface._connect', mock_connection())
 @mock.patch('socs.Lakeshore.Lakeshore372.LS372.msg', mock_372_msg())
 def test_ls372_set_excitation_mode(agent):
     """Normal operation of 'set_excitation_mode' task."""
@@ -348,7 +332,7 @@ def test_ls372_set_excitation_mode(agent):
 
 
 # set_excitation
-@mock.patch('socs.Lakeshore.Lakeshore372._establish_socket_connection', mock_connection())
+@mock.patch('socs.tcp.TCPInterface._connect', mock_connection())
 @mock.patch('socs.Lakeshore.Lakeshore372.LS372.msg', mock_372_msg())
 def test_ls372_set_excitation(agent):
     """Normal operation of 'set_excitation' task."""
@@ -362,7 +346,7 @@ def test_ls372_set_excitation(agent):
     assert res[0] is True
 
 
-@mock.patch('socs.Lakeshore.Lakeshore372._establish_socket_connection', mock_connection())
+@mock.patch('socs.tcp.TCPInterface._connect', mock_connection())
 @mock.patch('socs.Lakeshore.Lakeshore372.LS372.msg', mock_372_msg())
 def test_ls372_set_excitation_already_set(agent):
     """Setting to already set excitation value."""
@@ -377,7 +361,7 @@ def test_ls372_set_excitation_already_set(agent):
 
 
 # get_excitation
-@mock.patch('socs.Lakeshore.Lakeshore372._establish_socket_connection', mock_connection())
+@mock.patch('socs.tcp.TCPInterface._connect', mock_connection())
 @mock.patch('socs.Lakeshore.Lakeshore372.LS372.msg', mock_372_msg())
 def test_ls372_get_excitation(agent):
     session = create_session('get_excitation')
@@ -391,7 +375,7 @@ def test_ls372_get_excitation(agent):
 
 
 # set_resistance_range
-@mock.patch('socs.Lakeshore.Lakeshore372._establish_socket_connection', mock_connection())
+@mock.patch('socs.tcp.TCPInterface._connect', mock_connection())
 @mock.patch('socs.Lakeshore.Lakeshore372.LS372.msg', mock_372_msg())
 def test_ls372_set_resistance_range(agent):
     session = create_session('get_resistance_range')
@@ -404,7 +388,7 @@ def test_ls372_set_resistance_range(agent):
     assert res[0] is True
 
 
-@mock.patch('socs.Lakeshore.Lakeshore372._establish_socket_connection', mock_connection())
+@mock.patch('socs.tcp.TCPInterface._connect', mock_connection())
 @mock.patch('socs.Lakeshore.Lakeshore372.LS372.msg', mock_372_msg())
 def test_ls372_set_resistance_range_current_range(agent):
     session = create_session('get_resistance_range')
@@ -419,7 +403,7 @@ def test_ls372_set_resistance_range_current_range(agent):
 
 
 # get_resistance_range
-@mock.patch('socs.Lakeshore.Lakeshore372._establish_socket_connection', mock_connection())
+@mock.patch('socs.tcp.TCPInterface._connect', mock_connection())
 @mock.patch('socs.Lakeshore.Lakeshore372.LS372.msg', mock_372_msg())
 def test_ls372_get_resistance_range_current_range(agent):
     session = create_session('get_resistance_range')
@@ -434,7 +418,7 @@ def test_ls372_get_resistance_range_current_range(agent):
 
 
 # set_dwell
-@mock.patch('socs.Lakeshore.Lakeshore372._establish_socket_connection', mock_connection())
+@mock.patch('socs.tcp.TCPInterface._connect', mock_connection())
 @mock.patch('socs.Lakeshore.Lakeshore372.LS372.msg', mock_372_msg())
 def test_ls372_set_dwell(agent):
     session = create_session('set_dwell')
@@ -449,7 +433,7 @@ def test_ls372_set_dwell(agent):
 
 
 # get_dwell
-@mock.patch('socs.Lakeshore.Lakeshore372._establish_socket_connection', mock_connection())
+@mock.patch('socs.tcp.TCPInterface._connect', mock_connection())
 @mock.patch('socs.Lakeshore.Lakeshore372.LS372.msg', mock_372_msg())
 def test_ls372_get_dwell(agent):
     session = create_session('get_dwell')
@@ -464,7 +448,7 @@ def test_ls372_get_dwell(agent):
 
 
 # set_pid
-@mock.patch('socs.Lakeshore.Lakeshore372._establish_socket_connection', mock_connection())
+@mock.patch('socs.tcp.TCPInterface._connect', mock_connection())
 @mock.patch('socs.Lakeshore.Lakeshore372.LS372.msg', mock_372_msg())
 def test_ls372_set_pid(agent):
     """Normal operation of 'set_pid' task."""
@@ -479,7 +463,7 @@ def test_ls372_set_pid(agent):
 
 
 # set_active_channel
-@mock.patch('socs.Lakeshore.Lakeshore372._establish_socket_connection', mock_connection())
+@mock.patch('socs.tcp.TCPInterface._connect', mock_connection())
 @mock.patch('socs.Lakeshore.Lakeshore372.LS372.msg', mock_372_msg())
 def test_ls372_set_active_channel(agent):
     """Normal operation of 'set_active_channel' task."""
@@ -494,7 +478,7 @@ def test_ls372_set_active_channel(agent):
 
 
 # set_autoscan
-@mock.patch('socs.Lakeshore.Lakeshore372._establish_socket_connection', mock_connection())
+@mock.patch('socs.tcp.TCPInterface._connect', mock_connection())
 @mock.patch('socs.Lakeshore.Lakeshore372.LS372.msg', mock_372_msg())
 def test_ls372_set_autoscan_on(agent):
     """Normal operation of 'set_autoscan' task."""
@@ -508,7 +492,7 @@ def test_ls372_set_autoscan_on(agent):
     assert res[0] is True
 
 
-@mock.patch('socs.Lakeshore.Lakeshore372._establish_socket_connection', mock_connection())
+@mock.patch('socs.tcp.TCPInterface._connect', mock_connection())
 @mock.patch('socs.Lakeshore.Lakeshore372.LS372.msg', mock_372_msg())
 def test_ls372_set_autoscan_off(agent):
     """Normal operation of 'set_autoscan' task."""
@@ -529,7 +513,7 @@ def test_ls372_set_autoscan_off(agent):
 
 
 # set_output_mode
-@mock.patch('socs.Lakeshore.Lakeshore372._establish_socket_connection', mock_connection())
+@mock.patch('socs.tcp.TCPInterface._connect', mock_connection())
 @mock.patch('socs.Lakeshore.Lakeshore372.LS372.msg', mock_372_msg())
 def test_ls372_set_output_mode_still(agent):
     """Normal operation of 'set_output_mode' task for the still heater."""
@@ -543,7 +527,7 @@ def test_ls372_set_output_mode_still(agent):
     assert res[0] is True
 
 
-@mock.patch('socs.Lakeshore.Lakeshore372._establish_socket_connection', mock_connection())
+@mock.patch('socs.tcp.TCPInterface._connect', mock_connection())
 @mock.patch('socs.Lakeshore.Lakeshore372.LS372.msg', mock_372_msg())
 def test_ls372_set_output_mode_sample(agent):
     """Normal operation of 'set_output_mode' task for the sample heater."""
@@ -558,7 +542,7 @@ def test_ls372_set_output_mode_sample(agent):
 
 
 # set_heater_output
-@mock.patch('socs.Lakeshore.Lakeshore372._establish_socket_connection', mock_connection())
+@mock.patch('socs.tcp.TCPInterface._connect', mock_connection())
 @mock.patch('socs.Lakeshore.Lakeshore372.LS372.msg', mock_372_msg())
 def test_ls372_set_heater_output_still(agent):
     """Normal operation of 'set_heater_output' task for the still heater."""
@@ -572,7 +556,7 @@ def test_ls372_set_heater_output_still(agent):
     assert res[0] is True
 
 
-@mock.patch('socs.Lakeshore.Lakeshore372._establish_socket_connection', mock_connection())
+@mock.patch('socs.tcp.TCPInterface._connect', mock_connection())
 @mock.patch('socs.Lakeshore.Lakeshore372.LS372.msg', mock_372_msg())
 def test_ls372_set_heater_output_sample(agent):
     """Normal operation of 'set_heater_output' task for the sample heater."""
@@ -587,7 +571,7 @@ def test_ls372_set_heater_output_sample(agent):
 
 
 # set_still_output
-@mock.patch('socs.Lakeshore.Lakeshore372._establish_socket_connection', mock_connection())
+@mock.patch('socs.tcp.TCPInterface._connect', mock_connection())
 @mock.patch('socs.Lakeshore.Lakeshore372.LS372.msg', mock_372_msg())
 def test_ls372_set_still_output(agent):
     """Normal operation of 'set_still_output' task."""
@@ -602,7 +586,7 @@ def test_ls372_set_still_output(agent):
 
 
 # get_still_output
-@mock.patch('socs.Lakeshore.Lakeshore372._establish_socket_connection', mock_connection())
+@mock.patch('socs.tcp.TCPInterface._connect', mock_connection())
 @mock.patch('socs.Lakeshore.Lakeshore372.LS372.msg', mock_372_msg())
 def test_ls372_get_still_output(agent):
     """Normal operation of 'get_still_output' task."""


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
This converts the `LS372` class to be a subclass of the new `TCPInterface` class introduced in #769. Note that this depends on the change in #1064.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Resolves #774.

This also is a good demonstration of the use of the `TCPInterface` subclass beyond the initial Cryomech Agent example.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
This has been tested in the following scenarios:

- [x] Test error handling when Lakeshore is offline during agent startup
- [x] Test error handling with `acq` running when network connection is interrupted
- [x] Test error handling with `acq` running when the 372 is power cycled

Test with Lakeshore offline during startup:
```
2026-05-22T17:27:12-0400 startup-op: launching init_lakeshore
2026-05-22T17:27:12-0400 start called for init_lakeshore
2026-05-22T17:27:12-0400 init_lakeshore:0 Status is now "starting".
2026-05-22T17:27:12-0400 init_lakeshore:0 Status is now "running".
2026-05-22T17:27:15-0400 Unable to connect. [Errno 113] No route to host
2026-05-22T17:27:15-0400 Connection not established.
2026-05-22T17:27:15-0400 Resetting the connection to the device.
2026-05-22T17:27:19-0400 Unable to connect. [Errno 113] No route to host
2026-05-22T17:27:19-0400 Could not connect to the LS372. Exiting.
2026-05-22T17:27:19-0400 init_lakeshore:0 Lakeshore initialization failed
2026-05-22T17:27:19-0400 init_lakeshore:0 Status is now "done".
2026-05-22T17:27:19-0400 session left: CloseDetails(reason=<wamp.close.normal>, message='None')
2026-05-22T17:27:19-0400 stopping heartbeat
2026-05-22T17:27:19-0400 Stopping all running sessions
2026-05-22T17:27:19-0400 Stopping session init_lakeshore
2026-05-22T17:27:22-0400 transport disconnected
2026-05-22T17:27:22-0400 waiting for reconnection
2026-05-22T17:27:22-0400 waiting at least 9.99999475479126 more seconds before giving up
2026-05-22T17:27:22-0400 Scheduling retry 1 to connect <twisted.internet.endpoints.TCP4ClientEndpoint object at 0x7fe9b4ea3b10> in 2.0988886477790962 seconds.
2026-05-22T17:27:22-0400 Main loop terminated.
```

Test network disconnect:
```
2026-05-22T17:23:26-0400 startup-op: launching init_lakeshore
2026-05-22T17:23:26-0400 start called for init_lakeshore
2026-05-22T17:23:26-0400 init_lakeshore:0 Status is now "starting".
2026-05-22T17:23:26-0400 init_lakeshore:0 Status is now "running".
2026-05-22T17:23:26-0400 Initialized Lakeshore module: <socs.Lakeshore.Lakeshore372.LS372 object at 0x7fb9a56cf590>
2026-05-22T17:23:26-0400 start called for acq
2026-05-22T17:23:26-0400 init_lakeshore:0 Lakeshore initilized with ID: LSCI,MODEL372,LSA23JD,1.3
2026-05-22T17:23:26-0400 acq:1 Status is now "starting".
2026-05-22T17:23:26-0400 init_lakeshore:0 Lakeshore module initialized.
2026-05-22T17:23:26-0400 init_lakeshore:0 Status is now "done".
2026-05-22T17:23:26-0400 acq:1 Status is now "running".
2026-05-22T17:23:26-0400 Starting data acquisition for observatory.LSA23JD
2026-05-22T17:24:04-0400 Socket not ready to read. Possible timeout.
2026-05-22T17:24:04-0400 Resetting the connection to the device.
2026-05-22T17:24:14-0400 Connection not established within 10 seconds.
2026-05-22T17:24:14-0400 Failed to get data from LS372. Check network connection.
2026-05-22T17:24:15-0400 Connection not established.
2026-05-22T17:24:15-0400 Resetting the connection to the device.
2026-05-22T17:24:21-0400 Connection re-established.
```

Test through a power cycle:
```
2026-05-22T17:25:02-0400 Socket not ready to read. Possible timeout.
2026-05-22T17:25:02-0400 Resetting the connection to the device.
2026-05-22T17:25:12-0400 Connection not established within 10 seconds.
2026-05-22T17:25:12-0400 Failed to get data from LS372. Check network connection.
2026-05-22T17:25:13-0400 Connection not established.
2026-05-22T17:25:13-0400 Resetting the connection to the device.
2026-05-22T17:25:23-0400 Connection not established within 10 seconds.
2026-05-22T17:25:23-0400 Failed to get data from LS372. Check network connection.
2026-05-22T17:25:24-0400 Connection not established.
2026-05-22T17:25:24-0400 Resetting the connection to the device.
2026-05-22T17:25:34-0400 Connection not established within 10 seconds.
2026-05-22T17:25:34-0400 Failed to get data from LS372. Check network connection.
2026-05-22T17:25:35-0400 Connection not established.
2026-05-22T17:25:35-0400 Resetting the connection to the device.
2026-05-22T17:25:38-0400 Unable to connect. [Errno 113] No route to host
2026-05-22T17:25:38-0400 Failed to get data from LS372. Check network connection.
2026-05-22T17:25:39-0400 Connection not established.
2026-05-22T17:25:39-0400 Resetting the connection to the device.
2026-05-22T17:25:43-0400 Connection re-established.
```

The agent reconnects through a power cycle and network disconnect. And the agent halts if the Lakeshore isn't online during agent startup.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
