### PR TITLE
Fix typo in the docstrings for bias commands

### DIFF
--- a/socs/agents/pysmurf_controller/agent.py
+++ b/socs/agents/pysmurf_controller/agent.py
@@ -994,7 +994,7 @@ class PysmurfController:
 
         Args
         -----
-        bg: int, list, optional
+        bgs: int, list, optional
             Bias group (bg), or list of bgs to set. If None, will set all bgs.
         bias: int, float, list
             Biases to set. If a float is passed, this will be used for all
@@ -1031,7 +1031,7 @@ class PysmurfController:
 
         Args
         -----
-        bg: int, list, optional
+        bgs: int, list, optional
             bg, or list of bgs to zero. If None, will zero all bgs.
         """
         params['bias'] = 0


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Fix the typo of 'bg' -> 'bgs', as specified in the param decorator.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Ran into an error on satp3 due to submitting 'bg' as the argument instead of 'bgs'. See https://github.com/simonsobs/daq-discussions/discussions/118#discussioncomment-10965165.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
Docstring only change.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
