### PR TITLE
ACU: acuconfigs.yaml setting for forcing sequential moves

### DIFF
--- a/docs/agents/acu_agent.rst
+++ b/docs/agents/acu_agent.rst
@@ -90,6 +90,7 @@ example configuration block is below::
                 'upper': 360.,
             },
             'acc': (8./1.88),
+            'axes_sequential': False,
         },
     }
 

--- a/tests/agents/test_acu_agent.py
+++ b/tests/agents/test_acu_agent.py
@@ -33,6 +33,14 @@ def test_avoidance():
     assert path is not None
     assert len(path['moves'].nodes) == 2
 
+    # .. even if policy forbids mixed-axis moves
+    sun.policy['axes_sequential'] = True
+    paths = sun.analyze_paths(270.01, 40.01, 270, 40)
+    path, analysis = sun.select_move(paths)
+    assert path is not None
+    assert len(path['moves'].nodes) == 3
+    sun.policy['axes_sequential'] = False
+
     # Find safe paths to here (no moves)
     paths = sun.analyze_paths(270, 40, 270, 40)
     path, analysis = sun.select_move(paths)


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->


## Description

This supports platforms where one generally doesn't want to move az and el axes simultaneously.  When setting "axes_sequential" is enabled in acu-configs.yaml, it will perform all moves as multi-legged, separating az and el.  This applies whether Sun Avoidance is on, or not.  But special handling is applied, for case of Sun Avoidance.

## Motivation and Context

Relates  to https://github.com/simonsobs/scheduler/issues/122, https://github.com/simonsobs/scheduler/pull/100.

## How Has This Been Tested?

Test case; tested on SATP1 today in sequential and simultaneous modes.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
