### PR TITLE
Replace coveralls with codecov

### DIFF
--- a/.github/codecov.yml
+++ b/.github/codecov.yml
@@ -1,0 +1,20 @@
+---
+codecov:
+  branch: main
+
+# https://docs.codecov.com/docs/pull-request-comments#disable-comment
+comment: false
+
+# https://docs.codecov.com/docs/commit-status
+coverage:
+  status:
+    project:
+      default:
+        target: auto
+        threshold: 3
+        paths:
+          - "socs/"
+    patch: false
+
+# When modifying this file, please validate using
+# curl -X POST --data-binary @codecov.yml https://codecov.io/validate

--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -64,15 +64,11 @@ jobs:
 
     # Coverage
     - name: Report test coverage
-      env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       run: |
         mv ./tests/.coverage.* ./
-        pip install -U coveralls
         coverage combine
         coverage xml
         coverage report
-        coveralls --service=github
 
     - name: Upload results to Codecov
       uses: codecov/codecov-action@v4

--- a/README.rst
+++ b/README.rst
@@ -125,8 +125,8 @@ This project is licensed under the BSD 2-Clause License - see the
 .. _LICENSE.txt: https://github.com/simonsobs/socs/blob/main/LICENSE.txt
 
 
-.. |coverage| image:: https://coveralls.io/repos/github/simonsobs/socs/badge.svg
-    :target: https://coveralls.io/github/simonsobs/socs
+.. |coverage| image:: https://codecov.io/gh/simonsobs/socs/graph/badge.svg?token=07SF75W0AZ
+    :target: https://codecov.io/gh/simonsobs/socs
 
 .. |docker| image:: https://img.shields.io/badge/dockerhub-latest-blue
     :target: https://hub.docker.com/r/simonsobs/socs


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
This PR replaces code coverage reporting using coveralls.io with codecov.io. It also configures codecov.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Coveralls is often very slow to navigate, making it difficult to use. I've been migrating repos I manage off of it.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
Setup already in sorunlib and ocs. Tested in #780 and when that was merged to `main`.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Repository infrastructure change

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
