### PR TITLE
Fix typo in pysmurf-controller relock function

### DIFF
--- a/socs/agents/pysmurf_controller/agent.py
+++ b/socs/agents/pysmurf_controller/agent.py
@@ -598,7 +598,7 @@ class PysmurfController:
             if result.traceback is not None:
                 self.log.error("Error occurred:\n{tb}", tb=result.traceback)
 
-            return result.success, "Finished UXM Setup"
+            return result.success, "Finished UXM Relock"
 
     @ocs_agent.param('duration', default=30., type=float)
     @ocs_agent.param('kwargs', default=None)


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

Fix typo in return string of uxm_relock.
## Description
<!--- Describe your changes in detail -->
Fix typo in return string of uxm_relock.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Misleading logs
