### PR TITLE
Enable more verbose codecov reporting

### DIFF
--- a/.github/codecov.yml
+++ b/.github/codecov.yml
@@ -1,6 +1,8 @@
 ---
 codecov:
   branch: main
+  # https://docs.codecov.com/docs/common-recipe-list#see-coverage-on-ci-test-failures
+  require_ci_to_pass: false
 
 # https://docs.codecov.com/docs/pull-request-comments#disable-comment
 comment: true

--- a/.github/codecov.yml
+++ b/.github/codecov.yml
@@ -3,7 +3,7 @@ codecov:
   branch: main
 
 # https://docs.codecov.com/docs/pull-request-comments#disable-comment
-comment: false
+comment: true
 
 # https://docs.codecov.com/docs/commit-status
 coverage:
@@ -14,7 +14,7 @@ coverage:
         threshold: 3
         paths:
           - "socs/"
-    patch: false
+    patch: true
 
 # When modifying this file, please validate using
 # curl -X POST --data-binary @codecov.yml https://codecov.io/validate

--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -70,7 +70,12 @@ jobs:
         coverage xml
         coverage report
 
+    # Temporary to verify coverage report is present
+    - name: List files
+      run: ls -R
+
     - name: Upload results to Codecov
       uses: codecov/codecov-action@v4
       with:
         token: ${{ secrets.CODECOV_TOKEN }}
+        verbose: true


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
This re-enables comments, patch statuses, the verbose flag in uploads, and does an ls in the pytest workflow to verify coveage reports are generated properly.

I'll plan to leave this as is for a while until I'm convinced I understand how codecov works. I think the main problem is the stale PRs don't have base reports, and rebasing sometimes doesn't actually work to update the reporting.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
PRs aren't showing their coverage status when reports are uploaded. This seems to mostly relate to the fact that the head commits don't have reports, so codecov can't report a difference in coverage. But I tried rebasing #778 to a commit that has a report and it still didn't work.

I'd like to not have codecov create comments, but having that on for now will be helpful, as those seem to report before the status checks.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
I've been testing a bunch of configuration changes and scenarios in a [test repo](https://github.com/BrianJKoopman/test). It's sort of convinced me that the configuration we have should be fine, but I still think these changes will be helpful until things are working smoothly.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
