### PR TITLE
Wiregrid Actuator Agent: Add 'position' data in `session.data`

### DIFF
--- a/socs/agents/wiregrid_actuator/agent.py
+++ b/socs/agents/wiregrid_actuator/agent.py
@@ -758,7 +758,9 @@ class WiregridActuatorAgent:
                          'STR2': 0 or 1, (0: OFF, 1:ON)
                          .
                          .
-                         }
+                         },
+                     'position':
+                        'inside' or 'outside' or 'unknown'
                     },
                  'timestamp':1601925677.6914878
                 }
@@ -845,12 +847,26 @@ class WiregridActuatorAgent:
                         zip(onoff_st, self.actuator.st.io_names):
                     data['data']['stopper_{}'.format(name)] = onoff
                     onoff_dict_st[name] = onoff
+                # Data for position
+                if (onoff_dict_ls['LSR1'] == 1 or onoff_dict_ls['LSL1'] == 1) \
+                        and not (onoff_dict_ls['LSR2'] == 1 or onoff_dict_ls['LSL2'] == 1):
+                    position = 'outside'
+                elif (onoff_dict_ls['LSR2'] == 1 or onoff_dict_ls['LSL2'] == 1) \
+                        and not (onoff_dict_ls['LSR1'] == 1 or onoff_dict_ls['LSL1'] == 1):
+                    position = 'inside'
+                else:
+                    position = 'unknown'
+                    self.log.warn(
+                        'acq(): '
+                        'Unknown position!')
+                data['data']['position'] = position
                 # publish data
                 self.agent.publish_to_feed('wgactuator', data)
                 # store session.data
                 field_dict = {'motor': onoff_mt,
                               'limitswitch': onoff_dict_ls,
-                              'stopper': onoff_dict_st}
+                              'stopper': onoff_dict_st,
+                              'position': position}
                 session.data['timestamp'] = current_time
                 session.data['fields'] = field_dict
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
I added 'position' data, which means the wiregrid is in the view of the telescope (`'inside'`) or out of the view (`'outside'`), in `session.data`.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
This change enables to monitor the location of the wiregrid easily.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
no test

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
