### PR TITLE
Added timeout after setting PID parameters

### DIFF
--- a/socs/agents/hwp_pid/drivers/pid_controller.py
+++ b/socs/agents/hwp_pid/drivers/pid_controller.py
@@ -355,6 +355,7 @@ class PID:
         responses.append(self.send_message(f"*W18{i_value}"))
         responses.append(self.send_message(f"*W19{d_value}"))
         responses.append(self.send_message("*Z02"))
+        time.sleep(2)
         if self.verb:
             print(responses)
             print(self.return_messages(responses))


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Adds a timeout after setting the PID parameters. This is the last thing done after calling a spin up/down

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Immediately after a spin up/down is called, the first frequency query always returns as a zero.
![pid_freq_before](https://github.com/user-attachments/assets/c6227b2e-2032-43c9-a43c-e25864f74414)
I believe this is because we are querying the PID controller too soon after the spin up/down command. After adding this timeout the incorrect data point is removed.
![pid_freq_after](https://github.com/user-attachments/assets/60a1719c-7d39-43b0-b026-05fda51805de)

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
I have tested this on satp1

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
