### PR TITLE
Check controller alarm before grip and ungrip

### DIFF
--- a/socs/agents/hwp_gripper/agent.py
+++ b/socs/agents/hwp_gripper/agent.py
@@ -468,13 +468,20 @@ class HWPGripperAgent:
             data['responses'].append(return_dict)
             return return_dict
 
-        # Check controller alarm and if hwp is already gripper or not
+        # Check controller alarm
         return_dict = run_and_append(self.client.get_state, job='grip',
                                      check_shutdown=check_shutdown)
         if return_dict['result']['jxc']['alarm']:
+            return_dict = self._run_client_func(
+                self.client.alarm_group, job='alarm_group', check_shutdown=False)
+            if return_dict['result'] is None:
+                return_dict['result'] = 'A'
+            alarm_message = self.decoded_alarm_group[return_dict['result']]
             self.log.error(
-                f"Detected contoller alarm: {return_dict['result']['jxc']['alarm']}")
+                f"Abort grip. Detected contoller alarm: {alarm_message}")
             return False, data
+
+        # Check if hwp is already gripper or not
         act_results = return_dict['result']['actuators']
         limit_switch_state = act_results[0]['limits']['warm_grip']['state'] | \
             act_results[1]['limits']['warm_grip']['state'] | \
@@ -637,8 +644,13 @@ class HWPGripperAgent:
         return_dict = run_and_append(self.client.get_state, job='ungrip',
                                      check_shutdown=check_shutdown)
         if return_dict['result']['jxc']['alarm']:
+            return_dict = self._run_client_func(
+                self.client.alarm_group, job='alarm_group', check_shutdown=False)
+            if return_dict['result'] is None:
+                return_dict['result'] = 'A'
+            alarm_message = self.decoded_alarm_group[return_dict['result']]
             self.log.error(
-                f"Detected contoller alarm: {return_dict['result']['jxc']['alarm']}")
+                f"Abort ungrip. Detected contoller alarm: {alarm_message}")
             return False, data
 
         run_and_append(self.client.reset, job='ungrip', check_shutdown=check_shutdown)


### PR DESCRIPTION
Added alarm check before grip and ungrip.

## Description
Added a step to check the controller alarms before grip and ungrip to avoid silent failure of these tasks.

## Motivation and Context
There was an issue that grip or ungrip silently fail when the actuator controller had an alarm. Added a step to check the alarm before grip and ungrip so that these tasks will explicitly fail and prevent subsequent inappropriate hwp operations.
https://github.com/simonsobs/chwp-discussions/discussions/25

## How Has This Been Tested?
Tested at satp3 by daq-dev. I powered off the actuator controller and caused "General controller erorr" and tested that these tasks fail when the controller has an alarm.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
