### PR TITLE
ld-monitor: Fix conifg examples and add to plugin file

### DIFF
--- a/docs/agents/ld_monitor.rst
+++ b/docs/agents/ld_monitor.rst
@@ -25,17 +25,19 @@ OCS Site Config
 An example site-config-file block::
 
     {'agent-class': 'LDMonitorAgent',
-     'instance-id': 'ld_monitor',
-     'arguments': [['--mode', 'acq']},
+     'instance-id': 'ld-monitor',
+     'arguments': ['--mode', 'acq']},
 
 Docker Compose
 ``````````````
 
 An example docker-compose configuration::
 
-    ocs-template:
+    ocs-ld-monitor:
         image: simonsobs/socs:latest
         hostname: ocs-docker
+        ports:
+          - "1110:1110"
         environment:
           - LOGLEVEL=info
         volumes:

--- a/docs/agents/ld_monitor.rst
+++ b/docs/agents/ld_monitor.rst
@@ -39,6 +39,9 @@ An example docker-compose configuration::
         ports:
           - "1110:1110"
         environment:
+          - INSTANCE_ID=ld-monitor
+          - SITE_HUB=ws://127.0.0.1:8001/ws
+          - SITE_HTTP=http://127.0.0.1:8001/call
           - LOGLEVEL=info
         volumes:
           - ${OCS_CONFIG_DIR}:/config

--- a/socs/plugin.py
+++ b/socs/plugin.py
@@ -25,6 +25,7 @@ agents = {
     'Lakeshore372Agent': {'module': 'socs.agents.lakeshore372.agent', 'entry_point': 'main'},
     'Lakeshore425Agent': {'module': 'socs.agents.lakeshore425.agent', 'entry_point': 'main'},
     'LATRtXYStageAgent': {'module': 'socs.agents.xy_stage.agent', 'entry_point': 'main'},
+    'LDMonitorAgent': {'module': 'socs.agents.ld_monitor.agent', 'entry_point': 'main'},
     'MagpieAgent': {'module': 'socs.agents.magpie.agent', 'entry_point': 'main'},
     'MeinbergM1000Agent': {'module': 'socs.agents.meinberg_m1000.agent', 'entry_point': 'main'},
     'MeinbergSyncboxAgent': {'module': 'socs.agents.meinberg_syncbox.agent', 'entry_point': 'main'},


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
This makes the naming convention between the instance-id and docker compose service name consistent, which host mangers need. It also adds the explicit port mapping, which the agent needs as data gets sent to it from another device, rather than it reaching out to the device (which would require the 'host' network mode.)

We also add the agent to the plugin file so it can be launched by `ocs-agent-cli`.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Noticed these while deploying the agent on site.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
Largely tested on site. The plugin part hasn't been tested yet.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
