### PR TITLE
ld-monitor: Remove `session.set_status()` calls and define protocol in compose example

### DIFF
--- a/docs/agents/ld_monitor.rst
+++ b/docs/agents/ld_monitor.rst
@@ -37,7 +37,7 @@ An example docker-compose configuration::
         image: simonsobs/socs:latest
         hostname: ocs-docker
         ports:
-          - "1110:1110"
+          - "1110:1110/udp"
         environment:
           - INSTANCE_ID=ld-monitor
           - SITE_HUB=ws://127.0.0.1:8001/ws

--- a/socs/agents/ld_monitor/agent.py
+++ b/socs/agents/ld_monitor/agent.py
@@ -270,8 +270,6 @@ class LDMonitorAgent:
                               "{} is already running".format(self.lock.job))
                 return False, "Could not acquire lock."
 
-            session.set_status('starting')
-
             self._connect()
             if not self.initialized:
                 return False, 'Could not connect to LD'
@@ -314,8 +312,6 @@ class LDMonitorAgent:
                 self.log.warn("Could not start acq because {} is already running"
                               .format(self.lock.job))
                 return False, "Could not acquire lock."
-
-            session.set_status('running')
 
             self.take_data = True
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
This removes the old `session.set_status()` calls that are automated in modern ocs. I also found another change to the configs we need, specifying UDP in the port mapping.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Ran into the status trying to go backwards when running at site:
```
2025-01-06T18:47:18+0000 startup-op: launching init_ld_monitor
2025-01-06T18:47:18+0000 start called for init_ld_monitor
2025-01-06T18:47:18+0000 init_ld_monitor:0 Status is now "starting".
2025-01-06T18:47:18+0000 init_ld_monitor:0 Status is now "running".
2025-01-06T18:47:18+0000 init_ld_monitor:0 CRASH: [Failure instance: Traceback: <class 'AssertionError'>:
/opt/venv/lib/python3.10/site-packages/twisted/internet/base.py:701:run
/opt/venv/lib/python3.10/site-packages/twisted/internet/base.py:709:mainLoop
/opt/venv/lib/python3.10/site-packages/twisted/internet/base.py:1063:runUntilCurrent
/opt/venv/lib/python3.10/site-packages/twisted/internet/threads.py:129:_callFromThread
--- <exception caught here> ---
/opt/venv/lib/python3.10/site-packages/twisted/python/threadpool.py:269:inContext
/opt/venv/lib/python3.10/site-packages/twisted/python/threadpool.py:285:<lambda>
/opt/venv/lib/python3.10/site-packages/twisted/python/context.py:117:callWithContext
/opt/venv/lib/python3.10/site-packages/twisted/python/context.py:82:callWithContext
/opt/venv/lib/python3.10/site-packages/ocs/ocs_agent.py:984:_running_wrapper
/opt/venv/lib/python3.10/site-packages/socs/agents/ld_monitor/agent.py:273:init_ld_monitor
/opt/venv/lib/python3.10/site-packages/ocs/ocs_agent.py:1279:set_status
/opt/venv/lib/python3.10/site-packages/twisted/internet/threads.py:135:blockingCallFromThread
/opt/venv/lib/python3.10/site-packages/twisted/python/failure.py:535:raiseException
/opt/venv/lib/python3.10/site-packages/twisted/internet/defer.py:212:maybeDeferred
/opt/venv/lib/python3.10/site-packages/ocs/ocs_agent.py:1285:set_status
]
2025-01-06T18:47:18+0000 init_ld_monitor:0 Status is now "done".
```

Also noticed the protocol defined as `tcp` when the container was online, though knew we wanted UDP.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
Tested the change at the site.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
