### PR TITLE
RTSPCameraAgent: connection robustness

### DIFF
--- a/socs/agents/rtsp_camera/agent.py
+++ b/socs/agents/rtsp_camera/agent.py
@@ -177,6 +177,18 @@ class RTSPCameraAgent:
         else:
             return False
 
+    def _init_stream(self):
+        """Connect to camera and initialize video stream."""
+        if self.fake:
+            cap = FakeCamera()
+        else:
+            cap = cv2.VideoCapture(self.connection)
+        if not cap.isOpened():
+            self.log.error(f"Cannot open RTSP stream at {self.connection}")
+            return False, "Could not open RTSP stream"
+
+        return cap
+
     @ocs_agent.param("test_mode", default=False, type=bool)
     def acq(self, session, params=None):
         """acq(test_mode=False)
@@ -209,13 +221,10 @@ class RTSPCameraAgent:
         self.is_streaming = True
 
         # Open camera stream
-        if self.fake:
-            cap = FakeCamera()
-        else:
-            cap = cv2.VideoCapture(self.connection)
-        if not cap.isOpened():
-            self.log.error(f"Cannot open RTSP stream at {self.connection}")
-            return False, "Could not open RTSP stream"
+        cap = self._init_stream()
+        connected = True
+        if not cap:
+            connected = False
 
         # Tracking state of whether we are currently recording motion detection
         detecting = False
@@ -225,6 +234,10 @@ class RTSPCameraAgent:
 
         snap_count = 0
         while self.is_streaming:
+            if not connected:
+                self.log.info("Trying to reconnect.")
+                cap = self._init_stream()
+
             # Use UTC
             timestamp = time.time()
             data = dict()
@@ -237,7 +250,9 @@ class RTSPCameraAgent:
             if not success:
                 msg = "Failed to retrieve snapshot image from stream"
                 self.log.error(msg)
-                return False, "Broken stream"
+                connected = False
+                continue
+            connected = True
 
             # Motion detection.  We ignore the first few snapshots and also
             # any changes that happen while we are already recording.
@@ -276,6 +291,7 @@ class RTSPCameraAgent:
                 "address": self.address,
                 "timestamp": timestamp,
                 "path": path,
+                "connected": connected
             }
 
             # Update session.data and publish
@@ -288,6 +304,7 @@ class RTSPCameraAgent:
                 "data": {
                     "address": self.address,
                     "path": path,
+                    "connected": connected
                 },
             }
             session.app.publish_to_feed(self.feed_name, message)
@@ -338,13 +355,9 @@ class RTSPCameraAgent:
 
             # Open camera stream
             self.log.info("Recording:  opening camera stream")
-            if self.fake:
-                cap = FakeCamera()
-            else:
-                cap = cv2.VideoCapture(self.connection)
-            if not cap.isOpened():
-                self.log.error(f"Cannot open RTSP stream at {self.connection}")
-                return False, "Cannot connect to camera"
+            cap = self._init_stream()
+            if not cap:
+                return False
 
             # Total number of frames
             total_frames = int(self.record_fps * self.record_duration)

--- a/socs/agents/rtsp_camera/agent.py
+++ b/socs/agents/rtsp_camera/agent.py
@@ -185,7 +185,7 @@ class RTSPCameraAgent:
             cap = cv2.VideoCapture(self.connection)
         if not cap.isOpened():
             self.log.error(f"Cannot open RTSP stream at {self.connection}")
-            return False, "Could not open RTSP stream"
+            return None
 
         return cap
 
@@ -217,7 +217,6 @@ class RTSPCameraAgent:
 
         frames_per_snapshot = int(self.seconds * self.record_fps)
 
-        session.set_status("running")
         self.is_streaming = True
 
         # Open camera stream
@@ -326,7 +325,6 @@ class RTSPCameraAgent:
         **Task** - Stop task associated with acq process.
         """
         if self.is_streaming:
-            session.set_status("stopping")
             self.is_streaming = False
             return True, "Stopping Acquisition"
         else:
@@ -357,7 +355,7 @@ class RTSPCameraAgent:
             self.log.info("Recording:  opening camera stream")
             cap = self._init_stream()
             if not cap:
-                return False
+                return False, "Cannot connect to camera."
 
             # Total number of frames
             total_frames = int(self.record_fps * self.record_duration)


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
- Move connection to camera stream to its own function
- Continue loop instead of stopping `acq` process when snapshot fails
- Add `connected` to `session.data` and OCS feed

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Resolves #809 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
Tested on `daq-dev`

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
