### PR TITLE
Adds checks to grip_state before attempting HWP spinup

### DIFF
--- a/tests/integration/test_hwp_supervisor_agent_integration.py
+++ b/tests/integration/test_hwp_supervisor_agent_integration.py
@@ -6,6 +6,7 @@ import pytest
 from integration.util import docker_compose_file  # noqa: F401
 from integration.util import create_crossbar_fixture
 from ocs.testing import _AgentRunner, create_client_fixture
+from ocs.ocs_client import OCSReply
 
 from socs.testing.hwp_emulator import HWPEmulator
 
@@ -174,6 +175,13 @@ def test_supervisor_grip(hwp_em, supervisor_agent, sup_client) -> None:
     state = get_hwp_state(sup_client)
     assert state["gripper"]["grip_state"] == "warm"
 
+    # Verify that spinning is blocked while the HWP is gripped
+    reply: OCSReply = sup_client.pid_to_freq(target_freq=2.0)
+    if reply.session['success']:
+        print("Spin up process successful though  HWP was gripped...")
+        print(reply.session)
+        assert False
+
 
 @pytest.mark.integtest
 def test_hwp_spinup(supervisor_agent, sup_client) -> None:
@@ -182,3 +190,10 @@ def test_hwp_spinup(supervisor_agent, sup_client) -> None:
     assert get_hwp_state(sup_client)["is_spinning"]
     status = sup_client.pid_to_freq.status()
     pprint(status.session["data"])
+
+    # Verify that gripping the HWP is blocked while the HWP is spinning
+    reply: OCSReply = sup_client.grip_hwp()
+    if reply.session['success']:
+        print("Grip attempted even though HWP is spinning")
+        print(reply.session)
+        assert False

--- a/tests/integration/test_hwp_supervisor_agent_integration.py
+++ b/tests/integration/test_hwp_supervisor_agent_integration.py
@@ -5,8 +5,8 @@ import coverage.data
 import pytest
 from integration.util import docker_compose_file  # noqa: F401
 from integration.util import create_crossbar_fixture
-from ocs.testing import _AgentRunner, create_client_fixture
 from ocs.ocs_client import OCSReply
+from ocs.testing import _AgentRunner, create_client_fixture
 
 from socs.testing.hwp_emulator import HWPEmulator
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
This adds a check to the HWP supervisor to make sure the HWP is not gripped before attempting to spin up.
This also adds tests of this behavior, to make sure that the HWP cannot spin up while gripped or grip while spinning.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
This check is clearly needed, unfortunately it was missing before. From the slack messages I believe this was not attempted on real hardware.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
Added tests to validate this behavior.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
