### PR TITLE
suprsync: add support to chmod files on transfer

### DIFF
--- a/socs/agents/suprsync/agent.py
+++ b/socs/agents/suprsync/agent.py
@@ -68,6 +68,7 @@ class SupRsync:
         self.db_echo: bool = args.db_echo
         self.db_pool_size: int = args.db_pool_size
         self.db_pool_max_overflow: int = args.db_pool_max_overflow
+        self.chmod = args.chmod
 
         # Feed for counting transfer errors, loop iterations.
         self.agent.register_feed('transfer_stats',
@@ -124,7 +125,7 @@ class SupRsync:
             srfm, self.archive_name, self.remote_basedir, ssh_host=self.ssh_host,
             ssh_key=self.ssh_key, cmd_timeout=self.cmd_timeout,
             copy_timeout=self.copy_timeout, compression=self.compression,
-            bwlimit=self.bwlimit
+            bwlimit=self.bwlimit, chmod=self.chmod
         )
 
         self.running = True
@@ -267,6 +268,9 @@ def make_parser(parser=None):
         '--db-pool-max-overflow', type=int, default=10,
         help="Number of connections to allow in the overflow pool."
     )
+    pgroup.add_argument('--chmod', type=str, default="ug+w",
+                        help="Comma-separated chmod strings to apply to file permissions "
+                             "on transfer. Defauls to making sure files are group-writeable.")
     return parser
 
 

--- a/socs/agents/suprsync/agent.py
+++ b/socs/agents/suprsync/agent.py
@@ -268,7 +268,7 @@ def make_parser(parser=None):
         '--db-pool-max-overflow', type=int, default=10,
         help="Number of connections to allow in the overflow pool."
     )
-    pgroup.add_argument('--chmod', type=str, default="ug+w",
+    pgroup.add_argument('--chmod', type=str, default="g+rwX",
                         help="Comma-separated chmod strings to apply to file permissions "
                              "on transfer. Defauls to making sure files are group-writeable.")
     return parser

--- a/socs/db/suprsync.py
+++ b/socs/db/suprsync.py
@@ -555,7 +555,8 @@ class SupRsyncFileHandler:
 
     def __init__(self, file_manager, archive_name, remote_basedir,
                  ssh_host=None, ssh_key=None, cmd_timeout=None,
-                 copy_timeout=None, compression=None, bwlimit=None):
+                 copy_timeout=None, compression=None, bwlimit=None,
+                 chmod=None):
         self.srfm = file_manager
         self.archive_name = archive_name
         self.ssh_host = ssh_host
@@ -566,6 +567,7 @@ class SupRsyncFileHandler:
         self.copy_timeout = copy_timeout
         self.compression = compression
         self.bwlimit = bwlimit
+        self.chmod = chmod
 
     def run_on_remote(self, cmd, timeout=None):
         """
@@ -655,6 +657,8 @@ class SupRsyncFileHandler:
                     file_map[remote_path] = file
 
                 cmd = ['rsync', '-Lrt']
+                if self.chmod:
+                    cmd += [f'--chmod={self.chmod}']
                 if self.compression:
                     cmd.append('-z')
                 if self.bwlimit:

--- a/socs/db/suprsync.py
+++ b/socs/db/suprsync.py
@@ -658,7 +658,7 @@ class SupRsyncFileHandler:
 
                 cmd = ['rsync', '-Lrt']
                 if self.chmod:
-                    cmd += [f'--chmod={self.chmod}']
+                    cmd += ['-p', f'--chmod={self.chmod}']
                 if self.compression:
                     cmd.append('-z')
                 if self.bwlimit:

--- a/tests/agents/test_suprsync_agent.py
+++ b/tests/agents/test_suprsync_agent.py
@@ -10,6 +10,9 @@ from socs.db.suprsync import (SupRsyncFileHandler, SupRsyncFilesManager,
 
 txaio.use_twisted()
 
+def check_group_write_perms(path: str) -> bool:
+    return os.stat(path).st_mode & stat.S_IWGRP
+
 
 def test_suprsync_files_manager(tmp_path):
     """
@@ -133,6 +136,8 @@ def test_suprsync_handle_files(tmp_path):
     ncopied = len(os.listdir(os.path.join(remote_basedir, 'test_remote')))
     for f in os.listdir(os.path.join(remote_basedir, 'test_remote')):
         path = os.path.join(remote_basedir, 'test_remote', f)
-        assert os.stat(path).st_mode & stat.S_IWGRP, f"File {path} not granted write permissions"
+        group_perms = check_group_write_perms(path)
+        print(path, group_perms)
+        assert group_perms, f"File {path} not granted write permissions"
 
     assert ncopied == nfiles + 1

--- a/tests/agents/test_suprsync_agent.py
+++ b/tests/agents/test_suprsync_agent.py
@@ -1,5 +1,6 @@
 import os
 import time
+import stat
 
 import numpy as np
 import txaio
@@ -109,6 +110,8 @@ def test_suprsync_handle_files(tmp_path):
         fname = f"{i}.npy"
         path = str(data_dir / fname)
         np.save(path, file_data)
+        perms = os.stat(path).st_mode
+        os.chmod(path, perms & ~stat.S_IWGRP)  #remove group-write permissions
         srfm.add_file(path, f'test_remote/{fname}', archive_name,
                       deletable=True)
 
@@ -119,12 +122,17 @@ def test_suprsync_handle_files(tmp_path):
                   deletable=False)
 
     # This is done in the suprsync run process
-    handler = SupRsyncFileHandler(srfm, 'test', remote_basedir)
+    handler = SupRsyncFileHandler(srfm, 'test', remote_basedir, chmod="ug+w")
     handler.copy_files()
     handler.delete_files(0)
 
     # Check data path is empty
     assert len(os.listdir(data_dir)) == 1
 
+     # Assert that group-write permissions are granted on copy
     ncopied = len(os.listdir(os.path.join(remote_basedir, 'test_remote')))
+    for f in os.listdir(os.path.join(remote_basedir, 'test_remote')):
+        path = os.path.join(remote_basedir, 'test_remote', f)
+        assert os.stat(path).st_mode & stat.S_IWGRP, f"File {path} not granted write permissions"
+
     assert ncopied == nfiles + 1

--- a/tests/agents/test_suprsync_agent.py
+++ b/tests/agents/test_suprsync_agent.py
@@ -1,6 +1,6 @@
 import os
-import time
 import stat
+import time
 
 import numpy as np
 import txaio
@@ -111,7 +111,7 @@ def test_suprsync_handle_files(tmp_path):
         path = str(data_dir / fname)
         np.save(path, file_data)
         perms = os.stat(path).st_mode
-        os.chmod(path, perms & ~stat.S_IWGRP)  #remove group-write permissions
+        os.chmod(path, perms & ~stat.S_IWGRP)  # remove group-write permissions
         srfm.add_file(path, f'test_remote/{fname}', archive_name,
                       deletable=True)
 
@@ -129,7 +129,7 @@ def test_suprsync_handle_files(tmp_path):
     # Check data path is empty
     assert len(os.listdir(data_dir)) == 1
 
-     # Assert that group-write permissions are granted on copy
+    # Assert that group-write permissions are granted on copy
     ncopied = len(os.listdir(os.path.join(remote_basedir, 'test_remote')))
     for f in os.listdir(os.path.join(remote_basedir, 'test_remote')):
         path = os.path.join(remote_basedir, 'test_remote', f)

--- a/tests/agents/test_suprsync_agent.py
+++ b/tests/agents/test_suprsync_agent.py
@@ -138,7 +138,6 @@ def test_suprsync_handle_files(tmp_path):
     for f in os.listdir(os.path.join(remote_basedir, 'test_remote')):
         path = os.path.join(remote_basedir, 'test_remote', f)
         group_perms = check_group_write_perms(path)
-        print(path, group_perms)
         assert group_perms, f"File {path} not granted write permissions"
 
     assert ncopied == nfiles + 1

--- a/tests/agents/test_suprsync_agent.py
+++ b/tests/agents/test_suprsync_agent.py
@@ -10,6 +10,7 @@ from socs.db.suprsync import (SupRsyncFileHandler, SupRsyncFilesManager,
 
 txaio.use_twisted()
 
+
 def check_group_write_perms(path: str) -> bool:
     return os.stat(path).st_mode & stat.S_IWGRP
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
This PR adds a `chmod` option to the SuprsyncFileHandler that can be used to modify permissions of transferred files.
By default, this sets the default of the suprsync agent so that it adds group-write permissions if they are not there already.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
We have seen several instances of problems where level2 file deletion is not able to work properly because sometimes copied files do not give the suprsync group write permissions. This should change that, enforcing that copied files are group-writeable.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
Added a test to make sure permissions are adjusted properly.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
