### PR TITLE
Disable ocs-wgactuator-agent build

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -14,11 +14,12 @@ services:
     image: "ocs-pysmurf-agent"
     build: ./docker/pysmurf_controller/
 
-  ocs-wgactuator-agent:
-    image: "ocs-wgactuator-agent"
-    build: ./docker/wiregrid_actuator/
-    depends_on:
-      - "socs"
+  # Temporarily disabled until build is fixed.
+  #ocs-wgactuator-agent:
+  #  image: "ocs-wgactuator-agent"
+  #  build: ./docker/wiregrid_actuator/
+  #  depends_on:
+  #    - "socs"
 
   # Only works with --privileged, will insist users build image themselves
   # ocs-hwp-picoscope-agent:


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
This temporarily disables the wgactuator image build. This should be reverted once that build is fixed.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Installation broke in a way that's causing all builds to fail. Disable until resolved.

Example of failed build: https://github.com/simonsobs/socs/actions/runs/13312323581/job/37177745465

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
Built locally. Build fails without this patch, and then works with the patch (though of course doesn't build the removed image.)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
