### PR TITLE
hwp_supervisor: add wait in pmx_off, add max_duration for spin up.

### DIFF
--- a/socs/agents/hwp_supervisor/agent.py
+++ b/socs/agents/hwp_supervisor/agent.py
@@ -1222,7 +1222,7 @@ class ControlStateMachine:
                 time_within_tol = time.time() - state.freq_within_tol_start
                 # if the frequency doen't get close enough within tolerance, power off
                 if time_within_tol > state.freq_tol_duration:
-                    self.action.set_state(ControlState.PMXOff(
+                    self.action.set_state(ControlState.PmxOff(
                         success=True,
                         wait_stop=False,
                     ))

--- a/socs/agents/hwp_supervisor/agent.py
+++ b/socs/agents/hwp_supervisor/agent.py
@@ -1763,9 +1763,9 @@ class HWPSupervisor:
 
         Args
         -------
-        freq_thresh : float
-            Frequency threshold (Hz) for determining when the HWP is at the target frequency.
-        freq_thresh_duration : float
+        freq_tol : float
+            Frequency tolerance (Hz) for determining when the HWP is at the target frequency.
+        freq_tol_duration : float
             Duration (seconds) for which the HWP must be within ``freq_thresh`` of the
             ``target_freq`` to be considered successful.
         brake_voltage: float
@@ -1806,6 +1806,10 @@ class HWPSupervisor:
         -------
         wait_stop : bool
             Whether to wait until hwp stops.
+        freq_tol : float
+            Tolerance of frequency to consider hwp is stopped.
+        freq_tol_duration : float
+            Duration in seconds that the frequency must be within the tolerance
 
         Notes
         --------


### PR DESCRIPTION
Add wait in pmx_off, add max_duration for spin up.

## Description
- In pmx_off added an option to wait and block other commands until hwp stops.
- Added max_duration for spin up. If the spin up time exceeds max_duration, supervisor calls pmx_off.

## Motivation and Context
- wait of pmx_off is motivated from the scheduler. satp3 has been using pmx_off and time.sleep for safe spin down, but we would like to replace it with this. I plan to update sorunlib to use this by default.
- max_duration is for hwp instrument safety. This will avoid applying large current to motor for a long time when spin up is not successful. Typical spin up time is 7-10 mins.

## How Has This Been Tested?
Tested by daq-dev at satp3

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
