### PR TITLE
add irig_minus_sys in hwp_encoder agent

### DIFF
--- a/socs/agents/hwp_encoder/agent.py
+++ b/socs/agents/hwp_encoder/agent.py
@@ -29,6 +29,7 @@ HWPEncoder:
 
    (HWPEncoder_irig)
    irig_time: decoded time in second since the unix epoch
+   irig_minus_sys: difference between irig time and system time in second
    rising_edge_cont: BBB clcok count values
                      for the IRIG on-time reference marker risinge edge
    irig_sec: seconds decoded from IRIG-B
@@ -595,6 +596,7 @@ class HWPBBBAgent:
                     sys_time = irig_data[4]
                     data = {'timestamp': sys_time, 'block_name': 'HWPEncoder_irig', 'data': {}}
                     data['data']['irig_time'] = irig_time
+                    data['data']['irig_minus_sys'] = irig_time - sys_time
                     data['data']['rising_edge_count'] = rising_edge_count
                     data['data']['irig_sec'] = de_irig(irig_info[0], 1)
                     data['data']['irig_min'] = de_irig(irig_info[1], 0)


### PR DESCRIPTION
Add new data feed of irig time minus system time

## Description
Add new data feed of irig time minus system time to hwp encoder agent

## Motivation and Context
This is to help monitoring the PTP timing state.
With this value we can easily notice that we have synchronization loss either in NTP or PTP.

## How Has This Been Tested?
This has been tested by daq-dev using hwp-bbb-a2
The minus 1 second difference is reproduced.
![image](https://github.com/user-attachments/assets/3b39800e-4263-43f4-9305-baafd88bbc86)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
