### PR TITLE
ACU: program track keeps at least 3 seconds of points uploaded

### DIFF
--- a/socs/agents/acu/agent.py
+++ b/socs/agents/acu/agent.py
@@ -1921,13 +1921,21 @@ class ACUAgent:
         # refill threshold.
         MIN_STACK_POP = 6  # points
 
-        if point_batch_count is None:
-            point_batch_count = 0
+        # Minimum amount of time (seconds), in advance, to populate
+        # the trajectory.  In cases where step_time is short, this
+        # creates a longer track window to survive agent outages.
+        # (The cost is that stopping a scan may take a little longer.)
+        MIN_STACK_ADVANCE_TIME = 3.
 
-        STACK_REFILL_THRESHOLD = FULL_STACK - \
-            max(MIN_STACK_POP + LOOP_STEP / step_time, point_batch_count)
-        STACK_TARGET = FULL_STACK - \
-            max(MIN_STACK_POP * 2 + LOOP_STEP / step_time, point_batch_count * 2)
+        # Minimum nuber of points to keep in the stack.
+        _pbc = max(MIN_STACK_POP, MIN_STACK_ADVANCE_TIME / step_time)
+        if point_batch_count is None or _pbc > point_batch_count:
+            point_batch_count = _pbc
+
+        STACK_REFILL_THRESHOLD = \
+            FULL_STACK - point_batch_count - LOOP_STEP / step_time
+        STACK_TARGET = \
+            FULL_STACK - point_batch_count * 2 - LOOP_STEP / step_time
 
         # Special error bits to watch here
         PTRACK_FAULT_KEYS = [


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Modifies ACU Agent to always upload at least 3 seconds of ProgramTrack points, in advance.  Previously the amount of time "in advance" was simply enough time to hold 6 track points.  For normal CMB scans this will be about ~6 seconds but for small amplitude scans (1 deg, as on LAT) it can be ~1 second or less.  Now both criteria must be met.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

A few LAT scans have randomly failed in past few days, and that was traced to ~1s ACU Agent drop-outs (time periods where the data recording and scan management processes seemed to not be running).  The drop-outs themselves need to be investigated further, but this fix will help us survive them for the time being.

## How Has This Been Tested?

Tested against ACU Simulator in soaculib.  This change should be a NOP for SATs.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
