### PR TITLE
ACU Agent: take most configuration from the acu-configs.yaml

### DIFF
--- a/socs/agents/acu/agent.py
+++ b/socs/agents/acu/agent.py
@@ -570,7 +570,7 @@ class ACUAgent:
                     output[collection] = (
                         yield self.acu_read.Values(self.datasets[short]))
                 else:
-                    output['collection'] = {}
+                    output[collection] = {}
             return output
 
         session.data['StatusResponseRate'] = n_ok / (query_t - report_t)

--- a/socs/agents/acu/agent.py
+++ b/socs/agents/acu/agent.py
@@ -105,7 +105,7 @@ class ACUAgent:
                  min_el=None, max_el=None,
                  ):
 
-        ### Agent support
+        # Agent support
 
         self.agent = agent
         self.log = agent.log
@@ -114,8 +114,7 @@ class ACUAgent:
         self.azel_lock = TimeoutLock()
         self.boresight_lock = TimeoutLock()
 
-
-        ### Config file processing
+        # Config file processing
 
         self.acu_config_name = acu_config
         self.acu_config = aculib.guess_config(acu_config)
@@ -140,7 +139,7 @@ class ACUAgent:
 
         self.monitor_fields = status_keys.status_fields[self.platform_type]['status_fields']
 
-        ### Config file + overrides processing
+        # Config file + overrides processing
 
         # Motion limits (az / el / third ranges).
         self.motion_limits = self.acu_config['motion_limits']
@@ -195,8 +194,7 @@ class ACUAgent:
         startup_idle_reset = (self.platform_type in ['lat', 'ccat']
                               and not disable_idle_reset)
 
-
-        ### The connections to the ACU.
+        # The connections to the ACU.
 
         tclient._HTTP11ClientFactory.noisy = False
 
@@ -205,7 +203,7 @@ class ACUAgent:
         self.acu_read = aculib.AcuControl(
             acu_config, backend=TwistedHttpBackend(persistent=True), readonly=True)
 
-        ### Structures for passing status data around
+        # Structures for passing status data around
 
         # self.data provides a place to reference data from the monitors.
         # 'status' is populated by the monitor operation
@@ -237,7 +235,7 @@ class ACUAgent:
             'time_offset': 0,
         }
 
-        ### Task, Process, Feed registration.
+        # Task, Process, Feed registration.
 
         agent.register_process('monitor',
                                self.monitor,

--- a/socs/agents/acu/agent.py
+++ b/socs/agents/acu/agent.py
@@ -28,8 +28,8 @@ FULL_STACK = 10000
 #: Maximum update time (in s) for "monitor" process data, even with no changes
 MONITOR_MAX_TIME_DELTA = 2.
 
-#: Default scan params by platform type
-DEFAULT_SCAN_PARAMS = {
+#: Initial default scan params by platform type.
+INIT_DEFAULT_SCAN_PARAMS = {
     'ccat': {
         'az_speed': 2,
         'az_accel': 1,
@@ -41,27 +41,26 @@ DEFAULT_SCAN_PARAMS = {
 }
 
 
-#: Default Sun avoidance params by platform type (enabled, policy). If
-#: either of escape *or* monitoring is enabled, then the full policy
-#: must be specified.
-SUN_CONFIGS = {
+#: Default Sun avoidance configuration blocks, by platform type.
+#: Individual settings can be overridden in the platform config file.
+#: The full "policy" is constructed from these settings, the
+#: motion_limits, and the DEFAULT_POLICY in avoidance.py.  When
+#: active Sun Avoidance is not enabled, policy parameters are still
+#: useful for assessing Sun safety.
+INIT_SUN_CONFIGS = {
     'ccat': {
         'enabled': False,
-        'policy': {
-            'exclusion_radius': 20,
-            'el_horizon': 10,
-            'min_sun_time': 1800,
-            'response_time': 7200,
-        },
+        'exclusion_radius': 20,
+        'el_horizon': 10,
+        'min_sun_time': 1800,
+        'response_time': 7200,
     },
     'satp': {
         'enabled': True,
-        'policy': {
-            'exclusion_radius': 20,
-            'el_horizon': 10,
-            'min_sun_time': 1800,
-            'response_time': 7200,
-        },
+        'exclusion_radius': 20,
+        'el_horizon': 10,
+        'min_sun_time': 1800,
+        'response_time': 7200,
     },
 }
 
@@ -77,10 +76,6 @@ class ACUAgent:
         acu_config (str):
             The configuration for the ACU, as referenced in aculib.configs.
             Default value is 'guess'.
-        exercise_plan (str):
-            The full path to a scan config file describing motions to cycle
-            through on the ACU.  If this is None, the associated process and
-            feed will not be registered.
         startup (bool):
             If True, immediately start the main monitoring processes
             for status and UDP data.
@@ -89,55 +84,66 @@ class ACUAgent:
             will not be commanded.  If a user requests an action that
             would otherwise move the axis, it is not moved but the
             action is assumed to have succeeded.  The values in this
-            list should be drawn from "az", "el", and "third".
+            list should be drawn from "az", "el", "third", and "none".
+            This argument *replaces* the setting from the config file.
+            ("none" entries will simply be ignored.)
         disable_idle_reset (bool):
             If True, don't auto-start idle_reset process for LAT.
+        disable_sun_avoidance (bool): If set, start up with Sun
+            Avoidance completely disabled.
         min_el (float): If not None, override the default configured
             elevation lower limit.
         max_el (float): If not None, override the default configured
             elevation upper limit.
-        avoid_sun (bool): If set, override the default Sun
-            avoidance setting (i.e. force enable or disable the feature).
-        fov_radius (float): If set, override the default Sun
-            avoidance radius (i.e. the radius of the field of view, in
-            degrees, to use for Sun avoidance purposes).
-        named_positions (list of str): Names and target positions to
-            register for use with go_to_named task.  If provided, each
-            entry in the list should be of the form "name=az,el" with
-            az and el parseable as floats; e.g. "home=180,45.1".
 
     """
 
-    def __init__(self, agent, acu_config='guess', exercise_plan=None,
-                 startup=False, ignore_axes=None, disable_idle_reset=False,
+    def __init__(self, agent, acu_config='guess',
+                 startup=False, ignore_axes=None,
+                 disable_idle_reset=False,
+                 disable_sun_avoidance=False,
                  min_el=None, max_el=None,
-                 avoid_sun=None, fov_radius=None,
-                 named_positions=None):
+                 ):
+
+        ### Agent support
+
+        self.agent = agent
         self.log = agent.log
 
         # Separate locks for exclusive access to az/el, and boresight motions.
         self.azel_lock = TimeoutLock()
         self.boresight_lock = TimeoutLock()
 
+
+        ### Config file processing
+
         self.acu_config_name = acu_config
         self.acu_config = aculib.guess_config(acu_config)
-        self.sleeptime = self.acu_config['motion_waittime']
+        self.platform_type = self.acu_config['platform']  # ccat, satp.
+
         self.udp = self.acu_config['streams']['main']
         self.udp_schema = aculib.get_stream_schema(self.udp['schema'])
         self.udp_ext = self.acu_config['streams']['ext']
-        self.acu8100 = self.acu_config['status']['status_name']
 
-        # There may or may not be a special 3rd axis dataset that
-        # needs to be probed.
-        self.acu3rdaxis = self.acu_config['status'].get('3rdaxis_name')
-        self.monitor_fields = status_keys.status_fields[self.acu_config['platform']]['status_fields']
+        # The 'status' dataset is necessary; the 'third' axis can be
+        # None (in SATP it's all included in default); the 'shutter'
+        # is enabled for LAT.
+        _dsets = self.acu_config['_datasets']
+        self.datasets = {
+            'status': _dsets.get('default_dataset'),
+            'third': _dsets.get('third_axis_dataset'),
+            'shutter': _dsets.get('shutter_dataset'),
+        }
+        for k, v in self.datasets.items():
+            if v is not None:
+                self.datasets[k] = dict(_dsets['datasets'])[v]
+
+        self.monitor_fields = status_keys.status_fields[self.platform_type]['status_fields']
+
+        ### Config file + overrides processing
+
+        # Motion limits (az / el / third ranges).
         self.motion_limits = self.acu_config['motion_limits']
-
-        # And a shutter one...
-        self.shutter_dataset = None
-        if self.acu_config['platform'] == 'ccat':
-            self.shutter_dataset = 'DataSets.Shutter'
-
         if min_el:
             self.log.warn(f'Override: min_el={min_el}')
             self.motion_limits['elevation']['lower'] = min_el
@@ -145,38 +151,61 @@ class ACUAgent:
             self.log.warn(f'Override: max_el={max_el}')
             self.motion_limits['elevation']['upper'] = max_el
 
-        # This initializes self.scan_params; these become the default
-        # scan params when calling generate_scan.  They can be changed
-        # during run time; they can also be overridden when calling
-        # generate_scan.
-        self.scan_params = {}
-        self._set_default_scan_params()
+        # Sun avoidance (must be set up *after* finalizing motion limits)
+        self.sun_config = INIT_SUN_CONFIGS[self.platform_type]
+        self.sun_config.update(self.acu_config.get('sun_avoidance', {}))
+        if disable_sun_avoidance:
+            self.sun_config['enabled'] = False
+        self.log.info('On startup, sun_config={sun_config}',
+                      sun_config=self.sun_config)
+        self._reset_sun_params()
 
-        startup_idle_reset = (self.acu_config['platform'] in ['lat', 'ccat']
+        # Scan params (default vel / accel).
+        self.default_scan_params = \
+            dict(INIT_DEFAULT_SCAN_PARAMS[self.platform_type])
+        for _k in self.default_scan_params.keys():
+            _v = self.acu_config.get('scan_params', {}).get(_k)
+            if _v is not None:
+                self.default_scan_params[_k] = _v
+        agent.log.info('On startup, default scan_params={scan_params}',
+                       scan_params=self.default_scan_params)
+        self.scan_params = dict(self.default_scan_params)
+
+        # Axes to ignore.
+        self.ignore_axes = self.acu_config.get('ignore_axes', [])
+        if ignore_axes is not None:
+            self.ignore_axes = [x for x in ignore_axes if x != 'none']
+        if len(self.ignore_axes):
+            assert all([x in ['az', 'el', 'third'] for x in self.ignore_axes])
+            agent.log.warn('Note ignore_axes={i}', i=self.ignore_axes)
+
+        # Named positions.
+        self.named_positions = self.acu_config.get('named_positions', {})
+        for k, v in self.named_positions.items():
+            agent.log.info(f'Using named position {k}: {v[0]},{v[1]}')
+            try:
+                str(k), float(v[0]), float(v[1])
+            except Exception:
+                agent.log.error('Failed to parse named position "{k}"', k=k)
+
+        # Exercise plan.
+        self.exercise_plan = self.acu_config.get('exercise_plan')
+
+        # Other flags.
+        startup_idle_reset = (self.platform_type in ['lat', 'ccat']
                               and not disable_idle_reset)
 
-        if ignore_axes is None:
-            ignore_axes = []
-        assert all([x in ['az', 'el', 'third'] for x in ignore_axes])
-        self.ignore_axes = ignore_axes
-        if len(self.ignore_axes):
-            agent.log.warn('User requested ignore_axes={i}', i=self.ignore_axes)
 
-        self._reset_sun_params(enabled=avoid_sun,
-                               radius=fov_radius)
+        ### The connections to the ACU.
 
-        self.named_positions = {}
-        if named_positions:
-            for text in named_positions:
-                try:
-                    name, target = text.split('=')
-                    _az, _el = target.split(',')
-                    self.named_positions[name] = (float(_az), float(_el))
-                except Exception as e:
-                    agent.log.error('Failed to parse named_position string: {text}', text=text)
-                    raise e
+        tclient._HTTP11ClientFactory.noisy = False
 
-        self.exercise_plan = exercise_plan
+        self.acu_control = aculib.AcuControl(
+            acu_config, backend=TwistedHttpBackend(persistent=False))
+        self.acu_read = aculib.AcuControl(
+            acu_config, backend=TwistedHttpBackend(persistent=True), readonly=True)
+
+        ### Structures for passing status data around
 
         # self.data provides a place to reference data from the monitors.
         # 'status' is populated by the monitor operation
@@ -200,12 +229,6 @@ class ACUAgent:
                      'broadcast': {},
                      }
 
-        self.agent = agent
-
-        self.take_data = False
-
-        tclient._HTTP11ClientFactory.noisy = False
-
         # Structure for the broadcast process to communicate state to
         # the monitor process, for a data quality feed.
         self._broadcast_qual = {
@@ -214,10 +237,7 @@ class ACUAgent:
             'time_offset': 0,
         }
 
-        self.acu_control = aculib.AcuControl(
-            acu_config, backend=TwistedHttpBackend(persistent=False))
-        self.acu_read = aculib.AcuControl(
-            acu_config, backend=TwistedHttpBackend(persistent=True), readonly=True)
+        ### Task, Process, Feed registration.
 
         agent.register_process('monitor',
                                self.monitor,
@@ -253,42 +273,38 @@ class ACUAgent:
                              'exclude_influx': False,
                              'exclude_aggregator': True
                              }
-        self.stop_times = {'az': float('nan'),
-                           'el': float('nan'),
-                           'bs': float('nan'),
-                           }
-        self.agent.register_feed('acu_status',
-                                 record=True,
-                                 agg_params=fullstatus_agg_params,
-                                 buffer_time=1)
-        self.agent.register_feed('acu_status_influx',
-                                 record=True,
-                                 agg_params=influx_agg_params,
-                                 buffer_time=1)
-        self.agent.register_feed('acu_commands_influx',
-                                 record=True,
-                                 agg_params=influx_agg_params,
-                                 buffer_time=1)
-        self.agent.register_feed('acu_udp_stream',
-                                 record=True,
-                                 agg_params=fullstatus_agg_params,
-                                 buffer_time=1)
-        self.agent.register_feed('acu_broadcast_influx',
-                                 record=True,
-                                 agg_params=influx_agg_params,
-                                 buffer_time=1)
-        self.agent.register_feed('acu_error',
-                                 record=True,
-                                 agg_params=basic_agg_params,
-                                 buffer_time=1)
-        self.agent.register_feed('sun',
-                                 record=True,
-                                 agg_params=basic_agg_params,
-                                 buffer_time=0)
-        self.agent.register_feed('data_qual',
-                                 record=True,
-                                 agg_params=basic_agg_params,
-                                 buffer_time=0)
+        agent.register_feed('acu_status',
+                            record=True,
+                            agg_params=fullstatus_agg_params,
+                            buffer_time=1)
+        agent.register_feed('acu_status_influx',
+                            record=True,
+                            agg_params=influx_agg_params,
+                            buffer_time=1)
+        agent.register_feed('acu_commands_influx',
+                            record=True,
+                            agg_params=influx_agg_params,
+                            buffer_time=1)
+        agent.register_feed('acu_udp_stream',
+                            record=True,
+                            agg_params=fullstatus_agg_params,
+                            buffer_time=1)
+        agent.register_feed('acu_broadcast_influx',
+                            record=True,
+                            agg_params=influx_agg_params,
+                            buffer_time=1)
+        agent.register_feed('acu_error',
+                            record=True,
+                            agg_params=basic_agg_params,
+                            buffer_time=1)
+        agent.register_feed('sun',
+                            record=True,
+                            agg_params=basic_agg_params,
+                            buffer_time=0)
+        agent.register_feed('data_qual',
+                            record=True,
+                            agg_params=basic_agg_params,
+                            buffer_time=0)
         agent.register_task('go_to',
                             self.go_to,
                             blocking=False,
@@ -323,24 +339,24 @@ class ACUAgent:
                             self.escape_sun_now,
                             blocking=False,
                             aborter=self._simple_task_abort)
-        if self.shutter_dataset:
+        if self.datasets['shutter']:
             agent.register_task('set_shutter',
                                 self.set_shutter,
                                 blocking=False,
                                 aborter=self._simple_task_abort)
 
         # Automatic exercise program...
-        if exercise_plan:
+        if self.exercise_plan:
             agent.register_process(
                 'exercise', self.exercise, self._simple_process_stop,
                 stopper_blocking=False)
             # Use longer default frame length ... very low volume feed.
-            self.agent.register_feed('activity',
-                                     record=True,
-                                     buffer_time=0,
-                                     agg_params={
-                                         'frame_length': 600,
-                                     })
+            agent.register_feed('activity',
+                                record=True,
+                                buffer_time=0,
+                                agg_params={
+                                    'frame_length': 600,
+                                })
 
     @inlineCallbacks
     def _simple_task_abort(self, session, params):
@@ -372,7 +388,7 @@ class ACUAgent:
                 continue
             success = True
             try:
-                yield self.acu_control.http.Values(self.acu8100)
+                yield self.acu_control.http.Values(self.datasets['status'])
             except Exception as e:
                 self.log.info(' -- failed to reset Idle Stow time: {err}', err=e)
                 success = False
@@ -547,17 +563,17 @@ class ACUAgent:
 
         @inlineCallbacks
         def _get_status():
-            j1 = yield self.acu_read.Values(self.acu8100)
-            j2, j3 = {}, {}
-            if self.acu3rdaxis:
-                j2 = yield self.acu_read.Values(self.acu3rdaxis)
-            if self.shutter_dataset:
-                j3 = yield self.acu_read.Values(self.shutter_dataset)
-            return {
-                'StatusDetailed': j1,
-                'Status3rdAxis': j2,
-                'StatusShutter': j3,
-            }
+            output = {}
+            for short, collection in [
+                    ('status', 'StatusDetailed'),
+                    ('third', 'Status3rdAxis'),
+                    ('shutter', 'StatusShutter')]:
+                if self.datasets[short]:
+                    output[collection] = (
+                        yield self.acu_read.Values(self.datasets[short]))
+                else:
+                    output['collection'] = {}
+            return output
 
         session.data['StatusResponseRate'] = n_ok / (query_t - report_t)
         session.data.update((yield _get_status()))
@@ -1532,12 +1548,6 @@ class ACUAgent:
         else:
             return False, "Response was not as expected."
 
-    def _set_default_scan_params(self):
-        # A reference to scan_params is cached in monitor, so copy
-        # individual items rather than creating a new dict here.
-        for k, v in DEFAULT_SCAN_PARAMS[self.acu_config['platform']].items():
-            self.scan_params[k] = v
-
     @ocs_agent.param('az_speed', type=float, default=None)
     @ocs_agent.param('az_accel', type=float, default=None)
     @ocs_agent.param('reset', default=False, type=bool)
@@ -1557,7 +1567,7 @@ class ACUAgent:
 
         """
         if params['reset']:
-            self._set_default_scan_params()
+            self.scan_params.update(self.default_scan_params)
         for k in ['az_speed', 'az_accel']:
             if params[k] is not None:
                 self.scan_params[k] = params[k]
@@ -2094,20 +2104,13 @@ class ACUAgent:
     # Sun Safety Monitoring and Active Avoidance
     #
 
-    def _reset_sun_params(self, enabled=None, radius=None):
-        """Resets self.sun_params based on defaults for this platform.  Note
-        if enabled or radius are specified here, they update the
-        defaults (so they endure for the life of the agent).
+    def _reset_sun_params(self):
+        """Resets self.sun_params based on the instance defaults, and
+        motion_limits.  This must be called at least once, on startup,
+        to set up Sun monitoring and avoidance properly.
 
         """
-        config = SUN_CONFIGS[self.acu_config['platform']]
-
-        # These params update config for the entire run of agent.
-        if enabled is not None:
-            config['enabled'] = bool(enabled)
-        if radius is not None:
-            config['policy']['exclusion_radius'] = radius
-
+        # Set up sun_params data structure.
         _p = {
             # Global enable (but see "disable_until").
             'active_avoidance': False,
@@ -2133,14 +2136,13 @@ class ACUAgent:
             },
 
             # Avoidance policy, for use in avoidance decisions.
-            'policy': None,
+            'policy': {},
         }
 
-        # Populate default policy based on platform.
-        _p['active_avoidance'] = config['enabled']
-        _p['policy'] = config['policy']
+        # Active avoidance?
+        _p['active_avoidance'] = self.sun_config['enabled']
 
-        # And add in platform limits and move policies
+        # Avoidance requires platform limits and move policies
         _p['policy'].update({
             'min_az': self.motion_limits['azimuth']['lower'],
             'max_az': self.motion_limits['azimuth']['upper'],
@@ -2148,6 +2150,20 @@ class ACUAgent:
             'max_el': self.motion_limits['elevation']['upper'],
             'axes_sequential': self.motion_limits.get('axes_sequential', False),
         })
+
+        # User parameters defining the danger zone, and escape
+        # policies.  This list should be kept consistent with the
+        # preamble docs in avoidance.py.
+        for k in [
+                'exclusion_radius',
+                'min_sun_time',
+                'response_time',
+                'el_horizon',
+                'el_dodging',
+                'axes_sequential',
+        ]:
+            if k in self.sun_config:
+                _p['policy'][k] = self.sun_config[k]
 
         self.sun_params = _p
 
@@ -2417,11 +2433,11 @@ class ACUAgent:
     @ocs_agent.param('enable', type=bool, default=None)
     @ocs_agent.param('temporary_disable', type=float, default=None)
     @ocs_agent.param('escape', type=bool, default=None)
-    @ocs_agent.param('avoidance_radius', type=float, default=None)
+    @ocs_agent.param('exclusion_radius', type=float, default=None)
     @ocs_agent.param('shift_sun_hours', type=float, default=None)
     def update_sun(self, session, params):
-        """update_sun(reset=None, enable=None, temporary_disable=None,
-                      escape=None, avoidance_radius=None,
+        """update_sun(reset=None, enable=None, temporary_disable=None, \
+                      escape=None, exclusion_radius=None, \
                       shift_sun_hours=None)
 
         **Task** - Update Sun monitoring and avoidance parameters.
@@ -2439,7 +2455,7 @@ class ACUAgent:
             this number of seconds.
           escape (bool): If True, schedule an escape drill for 10
             seconds from now.
-          avoidance_radius (float): If set, change the FOV radius
+          exclusion_radius (float): If set, change the FOV radius
             (degrees), for Sun avoidance purposes, to this number.
           shift_sun_hours (float): If set, compute the Sun position as
             though it were this many hours in the future.  This is for
@@ -2464,9 +2480,9 @@ class ACUAgent:
         if params['escape']:
             self.log.warn('Setting sun escape drill to start in 10 seconds.')
             self.sun_params['next_drill'] = now + 10
-        if params['avoidance_radius'] is not None:
+        if params['exclusion_radius'] is not None:
             self.sun_params['policy']['exclusion_radius'] = \
-                params['avoidance_radius']
+                params['exclusion_radius']
             do_recompute = True
         if params['shift_sun_hours'] is not None:
             self.sun_params['safety_map_kw']['sun_time_shift'] = \
@@ -2716,7 +2732,7 @@ class ACUAgent:
 
             elif state == 'init':
                 # Issue the command
-                result = yield self.acu_control.Command(self.shutter_dataset, dset_cmd)
+                result = yield self.acu_control.Command(self.datasets['shutter'], dset_cmd)
                 if result == OK_RESPONSE:
                     state = 'wait-moving'
                     timeout = time.time() + STATE_WAIT
@@ -2892,10 +2908,9 @@ def add_agent_args(parser_in=None):
         parser_in = argparse.ArgumentParser()
     pgroup = parser_in.add_argument_group('Agent Options')
     pgroup.add_argument("--acu-config")
-    pgroup.add_argument("--exercise-plan")
     pgroup.add_argument("--no-processes", action='store_true',
                         default=False)
-    pgroup.add_argument("--ignore-axes", choices=['el', 'az', 'third'],
+    pgroup.add_argument("--ignore-axes", choices=['el', 'az', 'third', 'none'],
                         nargs='+', help="One or more axes to ignore.")
     pgroup.add_argument("--disable-idle-reset", action='store_true',
                         help="Disable idle_reset, even for LAT.")
@@ -2903,14 +2918,8 @@ def add_agent_args(parser_in=None):
                         help="Override the minimum el defined in platform config.")
     pgroup.add_argument("--max-el", type=float,
                         help="Override the maximum el defined in platform config.")
-    pgroup.add_argument("--avoid-sun", type=int,
-                        help="Pass 0 or 1 to disable or enable Sun avoidance. "
-                        "Overrides the platform default config.")
-    pgroup.add_argument("--fov-radius", type=float,
-                        help="Override the default field-of-view (radius in "
-                        "degrees) for Sun avoidance purposes.")
-    pgroup.add_argument("--named-positions", nargs='+',
-                        help="Define named positions, for go_to_named; e.g. 'home=180,60'.")
+    pgroup.add_argument("--disable-sun-avoidance", action='store_true',
+                        help="Disable Sun Avoidance before startup.")
 
     return parser_in
 
@@ -2922,15 +2931,13 @@ def main(args=None):
                                   args=args)
 
     agent, runner = ocs_agent.init_site_agent(args)
-    _ = ACUAgent(agent, args.acu_config, args.exercise_plan,
+    _ = ACUAgent(agent, args.acu_config,
                  startup=not args.no_processes,
                  ignore_axes=args.ignore_axes,
                  disable_idle_reset=args.disable_idle_reset,
-                 avoid_sun=args.avoid_sun,
-                 fov_radius=args.fov_radius,
+                 disable_sun_avoidance=args.disable_sun_avoidance,
                  min_el=args.min_el,
-                 max_el=args.max_el,
-                 named_positions=args.named_positions)
+                 max_el=args.max_el)
 
     runner.run(agent, auto_reconnect=True)
 

--- a/socs/agents/acu/avoidance.py
+++ b/socs/agents/acu/avoidance.py
@@ -667,7 +667,7 @@ class MoveSequence:
             assert (len(args) % 2 == 0)
             args = [(args[i], args[i + 1]) for i in range(0, len(args), 2)]
         for (az, el) in args:
-            self.nodes.append((az, el))
+            self.nodes.append((float(az), float(el)))
         if simplify:
             # Remove repeated nodes.
             idx = 0


### PR DESCRIPTION
## Description

- Sun avoidance, ignore_axes, named_positions, default_scan_params are all set up in the acu-configs file, now.  Sun avoidance can still be globally disabled from cmdline.  Ignore_axes can be overridden from command line. min/max el can still be overridden on command line.
- Requires latest soaculib (but soaculib will remain backwards compatible with previous agent, for a bit).
- Requires updates to agent instance args and active acu-configs.yaml.
- Small fix to sun avoidance to cast out a numpy scalar.
- Interface change; update_sun task "avoidance_radius" is now "exclusion_radius", to match all other usage.  This arg wasn't exposed to ocs-web and likely has never been used by anyone.

This agent version will not work without the latest soaculib (https://github.com/simonsobs/soaculib/pull/38); and upon deployment it will require changes to our running acu-configs.yaml / default.yaml (draft: https://github.com/simonsobs/ocs-deployment-configs/pull/417).

## Motivation and Context

As features of ACU agent evolve, it is less practical to configure everything on the command line.  In particular an upcoming feature of ACU Agent will be to allow/deny different motion types based on HWP state and current position.  Such a table of information is not safely expressed as command-line args.

Other advanced features, such as Sun avoidance, also benefit from file rather than command line config.

This PR does not add the HWP stuff, but does change the config system for existing Agent features.

## How Has This Been Tested?

I tested this on our ACU software simulator (which has led to significant upgrades in that simulator, along the way).

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
