### PR TITLE
Fix wiregrid_encoder irig

### DIFF
--- a/socs/agents/wiregrid_encoder/agent.py
+++ b/socs/agents/wiregrid_encoder/agent.py
@@ -134,12 +134,7 @@ class WiregridEncoderAgent:
             irig_last_updated = 0
             irig_fdata = {'timestamps': [],
                           'block_name': 'wgencoder_irig_raw',
-                          'data': {
-                              'quadrature': [],
-                              'pru_clock': [],
-                              'reference_degree': [],
-                              'error': []
-            }
+                          'data': {}
             }
             enc_rdata = {
                 'timestamps': [],
@@ -178,6 +173,7 @@ class WiregridEncoderAgent:
                     synch_pulse_clock_counts = irig_data[3]
                     sys_time = irig_data[4]
 
+                    irig_rdata['timestamp'] = sys_time
                     irig_rdata['data']['irig_time'] = irig_time
                     irig_rdata['data']['rising_edge_count'] = rising_edge_count
                     irig_rdata['data']['edge_diff']\

--- a/socs/agents/wiregrid_encoder/drivers.py
+++ b/socs/agents/wiregrid_encoder/drivers.py
@@ -223,7 +223,7 @@ class EncoderParser:
         try:
             st_time = time.strptime(
                 "%d %d %d:%d:%d" % (year, day, hours, mins, secs),
-                "%Y %j %H:%M:%S")
+                "%y %j %H:%M:%S")
             self.current_time = calendar.timegm(st_time)
         except ValueError:
             self.log.error(f'Invalid IRIG-B timestamp: '


### PR DESCRIPTION
Satp3 configured irig for wiregrid encoder, irig was not configured for wiregrids at site before. This PR fixes several bugs we found.

## Description
- Fix typo in irig time conversion
- Add missing timestamp in rough irig data.
- Fix irig_fdata. 'quadrature', 'pru_clock', 'reference_degree', 'error' are encoder data not irig data.

## Motivation and Context
These fixes are necessary to properly acquire irig info.

## How Has This Been Tested?
tested at daq-dev for satp3

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
