### PR TITLE
Install sodetlib in the pysmurf_controller docker.

### DIFF
--- a/docker/pysmurf_controller/Dockerfile
+++ b/docker/pysmurf_controller/Dockerfile
@@ -1,4 +1,13 @@
-FROM simonsobs/sodetlib:v0.5.2-20-gdd529b5
+FROM simonsobs/so_smurf_base:v0.0.4-1-g74a18de
+
+#################################################################
+# sodetlib Install
+#################################################################
+WORKDIR /
+RUN git clone --branch v0.5.3 --depth 1 https://github.com/simonsobs/sodetlib.git
+WORKDIR /sodetlib
+RUN pip3 install -e .
+RUN pip3 install -r requirements.txt
 
 ENV OCS_CONFIG_DIR /config
 
@@ -7,6 +16,6 @@ ENV PYTHONUNBUFFERED=1
 # SOCS installation
 RUN python3 -m pip install git+https://github.com/simonsobs/socs.git@main
 
-RUN pip3 install dumb-init
+RUN python3 -m pip install dumb-init
 
 ENTRYPOINT ["dumb-init", "ocs-agent-cli"]


### PR DESCRIPTION
## Description
Install `sodetlib` in the `pysmurf-controller` docker image and bypass the `sodetlib` docker image.

## Motivation and Context
Remove the `sodetlib` docker to simplify the docker inheritance hierarchy. Corresponding PR on `sodetllib`: simonsobs/sodetlib#460. 

## How Has This Been Tested?
Built the docker image with these changes.

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
