### PR TITLE
Add estimate of rotation direction to HWPSupervisor.HWPState

### DIFF
--- a/socs/agents/hwp_supervisor/agent.py
+++ b/socs/agents/hwp_supervisor/agent.py
@@ -2079,7 +2079,7 @@ def make_parser(parser=None):
         help="Time to wait for ACU motion to be blocked before aborting gripper command."
     )
     pgroup.add_argument(
-        '--forward-dir', choices=['cw', 'ccw'], default="cw",
+        '--forward-dir', choices=['cw', 'ccw'], default='cw',
         help="Whether the PID 'forward' direction is cw or ccw. "
              "cw or ccw is defined when hwp is viewed from the sky side."
     )

--- a/socs/agents/hwp_supervisor/agent.py
+++ b/socs/agents/hwp_supervisor/agent.py
@@ -363,6 +363,7 @@ class HWPState:
     gripper: Optional[GripperState] = None
 
     is_spinning: Optional[bool] = None
+    direction: Optional[str] = None
 
     supervisor_control_state: Optional[Dict[str, Any]] = None
 
@@ -556,6 +557,32 @@ class HWPState:
         self.ups_last_connection_attempt = data['ups_connection']['last_attempt']
         self.ups_connected = data['ups_connection']['connected']
 
+    def update_spin_state(self):
+        """
+        Updates hwp spin state values from the pid_state and control_state.
+        """
+        if self.pid_last_updated is None or self.pid_current_freq is None or \
+                self.pid_target_direction is None:
+            self.is_spinning = None
+            self.direction = None
+        elif time.time() - self.pid_last_updated > self.pid_max_time_since_update:
+            self.is_spinning = None
+            self.direction = None
+        elif self.pid_current_freq > self.pid_freq_tolerance:
+            self.is_spinning = True
+        else:
+            self.is_spinning = False
+            self.direction = None
+        if self.is_spinning and self.supervisor_control_state is not None:
+            control_state = self.supervisor_control_state['state_type']
+            # If hwp is braking, pid_direction is different from actual direction.
+            # Therefore, we keep previous value and do not update direction.
+            if control_state not in ('Brake', 'WaitForBrake'):
+                if self.pid_direction == 0:
+                    self.direction = 'cw' if self.forward_is_cw else 'ccw'
+                elif self.pid_direction == 1:
+                    self.direction = 'ccw' if self.forward_is_cw else 'cw'
+
     @property
     def pmx_action(self):
         """
@@ -594,6 +621,7 @@ class HWPState:
                 'pid': self.update_pid_state(test_mode=test_mode),
                 'ups': self.update_ups_state(),
             }
+            self.update_spin_state()
 
             self.last_updated = now
             if self.driver_iboot is not None:
@@ -604,15 +632,6 @@ class HWPState:
                 self.acu.update()
             if self.gripper is not None:
                 self.gripper.update()
-
-            if self.pid_last_updated is None or self.pid_current_freq is None:
-                self.is_spinning = None
-            elif now - self.pid_last_updated > self.pid_max_time_since_update:
-                self.is_spinning = None
-            elif self.pid_current_freq > self.pid_freq_tolerance:
-                self.is_spinning = True
-            else:
-                self.is_spinning = False
 
         return ops
 
@@ -2059,9 +2078,11 @@ def make_parser(parser=None):
         '--acu-block-motion-timeout', type=float, default=60.,
         help="Time to wait for ACU motion to be blocked before aborting gripper command."
     )
-
-    pgroup.add_argument('--forward-dir', choices=['cw', 'ccw'], default="cw",
-                        help="Whether the PID 'forward' direction is cw or ccw")
+    pgroup.add_argument(
+        '--forward-dir', choices=['cw', 'ccw'], default="cw",
+        help="Whether the PID 'forward' direction is cw or ccw. "
+             "cw or ccw is defined when hwp is viewed from the sky side."
+    )
     return parser
 
 

--- a/socs/agents/hwp_supervisor/agent.py
+++ b/socs/agents/hwp_supervisor/agent.py
@@ -1715,9 +1715,9 @@ class HWPSupervisor:
             }
         """
         if params['target_freq'] >= 0:
-            d = '0' if self.forward_is_cw else '1'
-        else:
             d = '1' if self.forward_is_cw else '0'
+        else:
+            d = '0' if self.forward_is_cw else '1'
 
         state = ControlState.PIDToFreq(
             target_freq=np.abs(params['target_freq']),

--- a/socs/agents/hwp_supervisor/agent.py
+++ b/socs/agents/hwp_supervisor/agent.py
@@ -562,7 +562,7 @@ class HWPState:
         Updates hwp spin state values from the pid_state and control_state.
         """
         if self.pid_last_updated is None or self.pid_current_freq is None or \
-                self.pid_target_direction is None:
+                self.pid_direction is None:
             self.is_spinning = None
             self.direction = None
         elif time.time() - self.pid_last_updated > self.pid_max_time_since_update:

--- a/socs/agents/hwp_supervisor/agent.py
+++ b/socs/agents/hwp_supervisor/agent.py
@@ -364,6 +364,7 @@ class HWPState:
 
     is_spinning: Optional[bool] = None
     direction: Optional[str] = None
+    forward_is_cw: Optional[bool] = True
 
     supervisor_control_state: Optional[Dict[str, Any]] = None
 
@@ -383,6 +384,7 @@ class HWPState:
             temp_thresh=args.ybco_temp_thresh,
             ups_minutes_remaining_thresh=args.ups_minutes_remaining_thresh,
             pid_max_time_since_update=args.pid_max_time_since_update,
+            forward_is_cw=args.forward_dir == 'cw',
         )
 
         if args.gripper_iboot_id is not None:


### PR DESCRIPTION
Add estimate of rotation direction to HWPSupervisor.HWPState

## Description
Estimate the absolute rotation direction from pid_state and control_state and add estimated direction to HWPSupervisor.HWPState
Need to merge https://github.com/simonsobs/ocs-deployment-configs/pull/436 to have correct rotation direction estimate.

## Motivation and Context
The real time absolute rotation direction estimate is necessary for wiregrid time constant measurement https://github.com/simonsobs/sorunlib/pull/179

## How Has This Been Tested?
Need to test

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
