### PR TITLE
ACU: motions can be constrained by the HWP state.

### DIFF
--- a/socs/agents/acu/agent.py
+++ b/socs/agents/acu/agent.py
@@ -20,7 +20,7 @@ from twisted.internet.defer import DeferredList, inlineCallbacks
 
 from socs.agents.acu import avoidance
 from socs.agents.acu import drivers as sh
-from socs.agents.acu import exercisor
+from socs.agents.acu import exercisor, hwp_iface
 
 #: The number of free ProgramTrack positions, when stack is empty.
 FULL_STACK = 10000
@@ -92,6 +92,8 @@ class ACUAgent:
             If True, don't auto-start idle_reset process for LAT.
         disable_sun_avoidance (bool): If set, start up with Sun
             Avoidance completely disabled.
+        disable_hwp_interlocks (bool): If set, start up with HWP
+            Interlocks disabled.
         min_el (float): If not None, override the default configured
             elevation lower limit.
         max_el (float): If not None, override the default configured
@@ -103,6 +105,7 @@ class ACUAgent:
                  startup=False, ignore_axes=None,
                  disable_idle_reset=False,
                  disable_sun_avoidance=False,
+                 disable_hwp_interlocks=False,
                  min_el=None, max_el=None,
                  ):
 
@@ -188,6 +191,12 @@ class ACUAgent:
             except Exception:
                 agent.log.error('Failed to parse named position "{k}"', k=k)
 
+        # HWP interlocks.
+        self.hwp_rules = hwp_iface.HWPInterlocks.from_dict(
+            self.acu_config.get('hwp_interlocks'))
+        if disable_hwp_interlocks:
+            self.hwp_rules.enabled = False
+
         # Exercise plan.
         self.exercise_plan = self.acu_config.get('exercise_plan')
 
@@ -210,23 +219,26 @@ class ACUAgent:
         # 'status' is populated by the monitor operation
         # 'broadcast' is populated by the udp_monitor operation
 
-        self.data = {'status': {'summary': {},
-                                'position_errors': {},
-                                'axis_limits': {},
-                                'axis_faults_errors_overages': {},
-                                'axis_warnings': {},
-                                'axis_failures': {},
-                                'axis_state': {},
-                                'osc_alarms': {},
-                                'commands': {},
-                                'ACU_failures_errors': {},
-                                'platform_status': {},
-                                'ACU_emergency': {},
-                                'corotator': {},
-                                'shutter': {},
-                                },
-                     'broadcast': {},
-                     }
+        self.data = {
+            'status': {
+                'summary': {},
+                'position_errors': {},
+                'axis_limits': {},
+                'axis_faults_errors_overages': {},
+                'axis_warnings': {},
+                'axis_failures': {},
+                'axis_state': {},
+                'osc_alarms': {},
+                'commands': {},
+                'ACU_failures_errors': {},
+                'platform_status': {},
+                'ACU_emergency': {},
+                'corotator': {},
+                'shutter': {},
+            },
+            'hwp': {},
+            'broadcast': {},
+        }
 
         # Structure for the broadcast process to communicate state to
         # the monitor process, for a data quality feed.
@@ -250,6 +262,11 @@ class ACUAgent:
                                startup=startup)
         agent.register_process('monitor_sun',
                                self.monitor_sun,
+                               self._simple_process_stop,
+                               blocking=False,
+                               startup=startup)
+        agent.register_process('monitor_hwp',
+                               self.monitor_hwp,
                                self._simple_process_stop,
                                blocking=False,
                                startup=startup)
@@ -343,6 +360,9 @@ class ACUAgent:
                                 self.set_shutter,
                                 blocking=False,
                                 aborter=self._simple_task_abort)
+        agent.register_task('update_hwp',
+                            self.update_hwp,
+                            blocking=False)
 
         # Automatic exercise program...
         if self.exercise_plan:
@@ -951,6 +971,16 @@ class ACUAgent:
             return False
         return True
 
+    def _current_azel(self):
+        try:
+            az0, el0 = [self.data['status']['summary'][f'{ax}_current_position']
+                        for ax in ['Azimuth', 'Elevation']]
+            if az0 is None or el0 is None:
+                raise KeyError
+        except KeyError:
+            return (None, None), 'Current position could not be determined.'
+        return (az0, el0), f'Current (az, el) = ({az0:.4f},{el0:.4f})'
+
     @inlineCallbacks
     def _check_ready_motion(self, session):
         bcast_check = yield self._check_daq_streams('broadcast')
@@ -1427,16 +1457,21 @@ class ACUAgent:
 
             self.log.info(f'Requested position: az={target_az}, el={target_el}')
 
-            legs, msg = yield self._get_sunsafe_moves(target_az, target_el,
-                                                      zero_legs_ok=False)
+            legs, msg = yield self._get_sunsafe_moves(target_az, target_el)
             if msg is not None:
                 self.log.error(msg)
                 return False, msg
 
-            if len(legs) > 1:
-                self.log.info(f'Executing move via {len(legs)} separate legs (sun optimized)')
+            if len(legs) > 2:
+                self.log.info(f'Executing move via {len(legs)-1} separate legs (sun optimized)')
 
-            for leg_az, leg_el in legs:
+            # Check HWP safety
+            hwp_safe, msg = yield self._check_hwpsafe_legs(legs)
+            if not hwp_safe:
+                self.log.info('{msg}', msg=msg)
+                return False, msg
+
+            for leg_az, leg_el in legs[1:]:
                 all_ok, msg = yield self._go_to_axes(session, az=leg_az, el=leg_el)
                 if not all_ok:
                     break
@@ -1462,6 +1497,11 @@ class ACUAgent:
         with self.boresight_lock.acquire_timeout(0, job='set_boresight') as acquired:
             if not acquired:
                 return False, f"Operation failed: {self.boresight_lock.job} is running."
+
+            hwp_ok, msg = self._check_hwpsafe_here(['third'])
+            if not hwp_ok:
+                self.log.info('{msg}', msg=msg)
+                return False, f"Motion not HWP-safe: {msg}"
 
             self.log.info('Clearing faults to prepare for motion.')
             yield self.acu_control.clear_faults()
@@ -1888,17 +1928,29 @@ class ACUAgent:
         if not ok:
             return False, msg
 
-        # Seek to starting position.  Note we ask for at least one leg
-        # here, because go_to_axes knows how to wait for the warning
-        # horn to finish before returning, which relieves us from
-        # handling that delay in the (already onerous) scan point
-        # timing.
+        # Seek to starting position.  Execute a move even if we're
+        # already there, because go_to_axes knows how to wait (in an
+        # optimal way) for the warning horn to finish before
+        # returning, which relieves us from handling that delay in the
+        # ProgramTrack phase.
         self.log.info(f'Moving to start position, az={plan["init_az"]}, el={init_el}')
-        legs, msg = yield self._get_sunsafe_moves(plan['init_az'], init_el,
-                                                  zero_legs_ok=False)
+        legs, msg = yield self._get_sunsafe_moves(plan['init_az'], init_el)
         if msg is not None:
             self.log.error(msg)
             return False, msg
+        hwp_safe, msg = yield self._check_hwpsafe_legs(legs)
+        if not hwp_safe:
+            msg = f'Move to start position not permitted: {msg}'
+            self.log.info('{msg}', msg=msg)
+            return False, msg
+
+        # Also validate the scan generally -- need to be movable in az.
+        hwp_safe, msg = yield self._check_hwpsafe(init_el, init_el, axes=['az'])
+        if not hwp_safe:
+            msg = f'Const-el scan not permitted: {msg}'
+            self.log.info(msg)
+            return False, msg
+
         for leg_az, leg_el in legs:
             ok, msg = yield self._go_to_axes(session, az=leg_az, el=leg_el)
             if not ok:
@@ -2659,7 +2711,7 @@ class ACUAgent:
 
         return safe, msg
 
-    def _get_sunsafe_moves(self, target_az, target_el, zero_legs_ok=True):
+    def _get_sunsafe_moves(self, target_az, target_el):
         """Given a target position, find a Sun-safe way to get there.  This
         will either be a direct move, or else an ordered slew in az
         before el (or vice versa).
@@ -2668,32 +2720,29 @@ class ACUAgent:
         Sun-safe path could be found; msg is an error message.  If a
         path can be found, the legs is a list of intermediate move
         targets, ``[(az0, el0), (az1, el1) ...]``, terminating on
-        ``(target_az, target_el)``.  msg is None in that case.
+        ``(target_az, target_el)``.  msg is None in that case.  The
+        first position (az0, el0) is the current position of the
+        platform.
 
-        In the case that platform is already at the target position,
-        an empty list of legs will be returned unless zero_legs_ok is
-        False in which case a 1-entry list of legs is returned, with
-        the target position in it.
+        In the case that the platform is already at the target
+        position, the returned list will still have 2 entries.
 
         When Sun avoidance is not enabled, this function returns as
         though the direct path to the target is a safe one (though
-        axes_sequential=True may turn this into a move with two legs).
+        axes_sequential=True may cause an intermediate step to be
+        added).
 
         """
         # Get current position.
-        try:
-            az, el = [self.data['status']['summary'][f'{ax}_current_position']
-                      for ax in ['Azimuth', 'Elevation']]
-            if az is None or el is None:
-                raise KeyError
-        except KeyError:
-            return None, 'Current position could not be determined.'
+        (az0, el0), msg = self._current_azel()
+        if az0 is None:
+            return None, msg
 
         if not self._get_sun_policy('sunsafe_moves'):
             if self.motion_limits.get('axes_sequential'):
                 # Move in az first, then el.
-                return [(target_az, el), (target_az, target_el)], None
-            return [(target_az, target_el)], None
+                return [(target_az, el0), (target_az, target_el)], None
+            return [(az0, el0), (target_az, target_el)], None
 
         if not self._get_sun_policy('map_valid'):
             return None, 'Sun Safety Map not computed or stale; run the monitor_sun process.'
@@ -2702,15 +2751,228 @@ class ACUAgent:
         if self.sun.check_trajectory([target_az], [target_el])['sun_time'] <= 0:
             return None, 'Requested target position is not Sun-Safe.'
 
-        moves = self.sun.analyze_paths(az, el, target_az, target_el)
+        moves = self.sun.analyze_paths(az0, el0, target_az, target_el)
         move, decisions = self.sun.select_move(moves)
         if move is None:
             return None, 'No Sun-Safe moves could be identified!'
 
         legs = list(move['moves'].nodes)
-        if len(legs) == 1 and not zero_legs_ok:
-            return legs, None
-        return legs[1:], None
+        if len(legs) == 1:
+            # Pad to two entries.
+            return [legs[0], legs[0]], None
+        return legs, None
+
+    #
+    # HWP State Safety
+    #
+
+    @inlineCallbacks
+    def monitor_hwp(self, session, params):
+        """monitor_hwp()
+
+        **Process** - Monitors the state of a HWP, by querying a
+        HWPSupervisor's ``monitor`` Process session data.  Assesses
+        what motions are permitted, given the HWP state.
+
+        session.data example::
+
+        {
+          "interlocks_config": {
+            "configured": true,
+            "enabled": true,
+            "instance_id": "hwp-supervisor",
+            "limit_sun_avoidance": true,
+            "tolerance": 0.1,
+          },
+          "supervisor_data": {
+            "timestamp": 1744692973.185377,
+            "ok": true,
+            "err_msg": "",
+            "_grip_brakes": [1, 1, 1],
+            "_grip_state": "ungripped",
+            "_is_spinning": true,
+            "_target_freq": 2.1,
+            "grip_state": "ungripped",
+            "spin_state": "spinning",
+            "request_block_motion": null,
+            "request_block_motion_timestamp": null
+          },
+          "allowed": {
+            "el": [true, [40, 70], [
+              [40, 70],
+            ],
+            "az": [true, [40, 70], [
+              [40, 70],
+            ],
+            "third": [false, null, []],
+          }
+        }
+
+        """
+        if not self.hwp_rules.configured:
+            session.data = {
+                'interlocks_config': self.hwp_rules.encoded(basic=True),
+            }
+            return True, "HWP Interlocks not configured."
+
+        def _update_sun_lims(el_range):
+            if el_range is None:
+                el_range = (self.motion_limits['elevation']['lower'],
+                            self.motion_limits['elevation']['upper'])
+            # Is this a change to sun policy?
+            if tuple(el_range) != (self.sun_params['policy']['min_el'],
+                                   self.sun_params['policy']['max_el']):
+                self.sun_params['policy']['min_el'] = el_range[0]
+                self.sun_params['policy']['max_el'] = el_range[1]
+                self.sun_params['recompute_req'] = True
+
+        pacer = Pacemaker(1.)
+        last_enabled = False
+        hwp_supervisor = self.hwp_rules.get_client()
+
+        while session.status == 'running':
+            new_data = yield threads.deferToThread(hwp_supervisor.update)
+            new_sd = {
+                'interlocks_config': self.hwp_rules.encoded(basic=True),
+                'supervisor_data': new_data,
+            }
+            (_, el), msg = self._current_azel()
+            allowed = self.hwp_rules.test_range(
+                (None if el is None else (el, el)),
+                new_data.get('grip_state'),
+                new_data.get('spin_state'))
+            new_sd['allowed'] = allowed
+
+            session.data = new_sd
+            self.data['hwp'] = new_data
+
+            if self.hwp_rules.enabled:
+                if self.hwp_rules.limit_sun_avoidance and el is not None:
+                    tol = self.hwp_rules.tolerance
+                    if allowed['el'][0]:
+                        _update_sun_lims(allowed['el'][1])
+                    else:
+                        # If we're in a forbidden spot ... just try to
+                        # keep it at this el for now, and hopefully
+                        # HWPSupervisor will improve things soon.
+                        _update_sun_lims((el - tol, el + tol))
+            elif last_enabled and self.hwp_rules.limit_sun_avoidance:
+                # Restore the sun_params default elevation range.
+                _update_sun_lims(None)
+
+            last_enabled = self.hwp_rules.enabled
+            yield pacer.dsleep()
+        return True, "Bye."
+
+    @ocs_agent.param('enable', type=bool, default=None)
+    def update_hwp(self, session, params):
+        """update_hwp(enable=None)
+
+        **Task** - Update HWP state monitoring and safety parameters.
+
+        All arguments are optional.
+
+        Args:
+          enable (bool): If True, enable HWP state checks.  If False,
+            disable HWP state checks (non-temporarily).
+
+        """
+        self.log.info('update_hwp params: {params}',
+                      params={k: v for k, v in params.items()
+                              if v is not None})
+
+        if not self.hwp_rules.configured:
+            return False, 'HWP interlocks not configured in config file.'
+
+        if params['enable'] is not None:
+            self.hwp_rules.enabled = params['enable']
+
+        return True, 'Params updated.'
+
+    def _check_hwpsafe(self, el1, el2, axes, hwp_data=None):
+        """Checks whether certain axis motions are permitted, over a
+        certain range of elevations.
+
+        Args:
+          el1, el2: elevation range over which the checks should be
+            considered.
+          axes: list of axes to check for permission on (taken from
+            'el', 'az', 'third').
+          hwp_data: dict from which to get grip_state and spin_state;
+            if not provided, uses self.data['hwp'].
+
+        Returns:
+          motions_permitted (bool): whether all requested axes are
+            permitted to move, given the HWP state and el range.
+          message (str): helpful text.
+
+        Note that when hwp_rules are not enabled, motions are
+        generally permitted by this function.
+
+        See additional helper functions, _check_hwpsafe_here and
+        _check_hwpsafe_legs.
+
+        """
+        if not self.hwp_rules.enabled:
+            return (True, "HWP monitoring is disabled.")
+
+        # Grab a self-consistent copy...
+        if hwp_data is None:
+            hwp_data = self.data['hwp']
+
+        # Check staleness
+        if time.time() - hwp_data.get('timestamp', 0) > 10:
+            return False, "HWP monitoring dataset is stale; cannot validate move."
+
+        # Check it.
+        state_args = {
+            'el_range': [el1, el2],
+            'grip_state': hwp_data.get('grip_state'),
+            'spin_state': hwp_data.get('spin_state'),
+        }
+        axes_ok = self.hwp_rules.test_range(**state_args)
+        for ax in axes:
+            if not axes_ok[ax][0]:
+                return (False, (f"Motion in {ax} not permitted due to HWP rules "
+                                f"for {state_args}."))
+        return axes_ok, 'All requested axes pass the HWP rules.'
+
+    def _check_hwpsafe_here(self, axes):
+        """Check whether motion in ``axes`` is permitted, at the
+        present elevation and hwp state.
+
+        """
+        if not self.hwp_rules.enabled:
+            return (True, "HWP monitoring is disabled.")
+
+        (_, el), msg = self._current_azel()
+        if el is None:
+            return False, f'HWP safety could not be ensured: {msg}'
+        return self._check_hwpsafe(el, el, axes)
+
+    def _check_hwpsafe_legs(self, legs):
+        """Check whether motions specified by legs (list of (az, el)
+        positions) are permitted, given the current HWP state.
+
+        """
+        if not self.hwp_rules.enabled:
+            return (True, "HWP monitoring is disabled.")
+
+        hwp_data = self.data['hwp']
+        for (az1, el1), (az2, el2) in zip(legs[:-1], legs[1:]):
+            axes = []
+            if abs(el2 - el1) > self.hwp_rules.tolerance:
+                axes.append('el')
+            if abs(az2 - az1) > self.hwp_rules.tolerance:
+                axes.append('az')
+            ok, msg = self._check_hwpsafe(el1, el2, axes, hwp_data=hwp_data)
+            if not ok:
+                return False, msg
+        return (True, "All moves passed HWP safety checks.")
+
+    #
+    # Exercise!
+    #
 
     @ocs_agent.param('action', choices=['open', 'close'])
     @inlineCallbacks
@@ -2959,6 +3221,8 @@ def add_agent_args(parser_in=None):
                         help="Override the maximum el defined in platform config.")
     pgroup.add_argument("--disable-sun-avoidance", action='store_true',
                         help="Disable Sun Avoidance before startup.")
+    pgroup.add_argument("--disable-hwp-interlocks", action='store_true',
+                        help="Disable HWP interlocks before startup.")
 
     return parser_in
 
@@ -2975,6 +3239,7 @@ def main(args=None):
                  ignore_axes=args.ignore_axes,
                  disable_idle_reset=args.disable_idle_reset,
                  disable_sun_avoidance=args.disable_sun_avoidance,
+                 disable_hwp_interlocks=args.disable_hwp_interlocks,
                  min_el=args.min_el,
                  max_el=args.max_el)
 

--- a/socs/agents/acu/agent.py
+++ b/socs/agents/acu/agent.py
@@ -1463,7 +1463,7 @@ class ACUAgent:
                 return False, msg
 
             if len(legs) > 2:
-                self.log.info(f'Executing move via {len(legs)-1} separate legs (sun optimized)')
+                self.log.info(f'Executing move via {len(legs) - 1} separate legs (sun optimized)')
 
             # Check HWP safety
             hwp_safe, msg = yield self._check_hwpsafe_legs(legs)

--- a/socs/agents/acu/hwp_iface.py
+++ b/socs/agents/acu/hwp_iface.py
@@ -18,21 +18,15 @@ def _range_contains(a, b):
 
 def _simplify_ranges(*a):
     """Combine and order a set of intervals, to form an ordered,
-    non-abutting list of intevals.
+    non-abutting list of intervals.
 
     """
-    def _merge(a, b):
-        if a[0] > b[0]:
-            return _merge(b, a)
-        if a[1] >= b[0]:
-            return [(a[0], max(b[1], a[1]))]
-        return [a, b]
     reduced = sorted([tuple(_a) for _a in a])
     i0 = 1
     while i0 < len(reduced):
-        j = _merge(reduced[i0 - 1], reduced[i0])
-        if len(j) == 1:
-            reduced[i0 - 1] = j[0]
+        a, b = reduced[i0 - 1], reduced[i0]
+        if a[1] >= b[0]:
+            reduced[i0 - 1] = (a[0], max(b[1], a[1]))
             reduced.pop(i0)
         else:
             i0 += 1
@@ -129,7 +123,11 @@ class HWPInterlocks:
         each axis is permitted.  Then the el_range, if provided is
         tested against those ranges.
 
-        The returned structure looks like this::
+        E.g for a call like::
+
+          test_range((40, 40), 'ungripped', 'not_spinning')
+
+        the returned structure looks like this::
 
           {'el': (True, (30, 70), [(30, 70)]),
            'az': (True, (30, 70), [(30, 70)]),
@@ -167,6 +165,12 @@ class HWPInterlocks:
 
 
 class HWPSupervisorClient:
+    """OCSClient wrapper to query and interpret the state of the
+    HWPSupervisor.  Instantiate with the instance_id of the
+    HWPSupervisor to be monitored.
+
+    """
+
     def __init__(self, instance_id):
         self.instance_id = instance_id
         self.cclient = site_config.get_control_client(instance_id)

--- a/socs/agents/acu/hwp_iface.py
+++ b/socs/agents/acu/hwp_iface.py
@@ -1,0 +1,248 @@
+"""
+Interface to HWPSupervisor.
+
+"""
+
+import time
+from dataclasses import asdict, dataclass, field
+
+from ocs import client_http, ocs_client, site_config
+
+# Helper functions for dealing with el ranges.
+
+
+def _range_contains(a, b):
+    # true if "a contains b" i.e. if b is a subset of a
+    return a[0] <= b[0] and a[1] >= b[1]
+
+
+def _simplify_ranges(*a):
+    """Combine and order a set of intervals, to form an ordered,
+    non-abutting list of intevals.
+
+    """
+    def _merge(a, b):
+        if a[0] > b[0]:
+            return _merge(b, a)
+        if a[1] >= b[0]:
+            return [(a[0], max(b[1], a[1]))]
+        return [a, b]
+    reduced = sorted([tuple(_a) for _a in a])
+    i0 = 1
+    while i0 < len(reduced):
+        j = _merge(reduced[i0 - 1], reduced[i0])
+        if len(j) == 1:
+            reduced[i0 - 1] = j[0]
+            reduced.pop(i0)
+        else:
+            i0 += 1
+    return reduced
+
+
+AXIS_NAMES = ['el', 'az', 'third']
+
+
+@dataclass
+class MotionRule:
+    #: Tuple giving the elevation range to which this rule applies.
+    el_range: tuple
+
+    #: List of grip_state values to which this rule applies. Note "*"
+    #: matches any grip_state.
+    grip_states: list
+
+    #: List of spin_state values to which this rule applies. Note "*"
+    #: matches any spin_state.
+    spin_states: list
+
+    #: Dict mapping each axis to a bool that indicates whether moves in
+    #: that axis are permitted.
+    allow_moves: dict
+
+    def test_hwp(self, grip_state, spin_state):
+        """Returns True only if grip_state and spin_state args are
+        matched by this rule.
+
+        """
+        if grip_state not in self.grip_states and '*' not in self.grip_states:
+            return False
+        if spin_state not in self.spin_states and '*' not in self.spin_states:
+            return False
+        return True
+
+
+@dataclass
+class HWPInterlocks:
+    #: bool indicating whether the config is valid (and thus eligible
+    #: to be enabled).
+    configured: bool = False
+
+    #: bool indicating whether to bother with HWP interlocks.
+    enabled: bool = False
+
+    #: instance_id of HWPSupervisor agent to query.
+    instance_id: str = 'hwp-supervisor'
+
+    #: amount of leeway in el (deg) to grant when checking rules.
+    tolerance: float = 0.1
+
+    #: whether HWP state-based elevation limits should be applied to
+    #: Sun avoidance escape movements
+    limit_sun_avoidance: bool = True
+
+    #: rules: list of MotionRule objects, each of which grants move
+    #: privs on some axis based on elevation range and HWP state.
+    rules: list = field(default_factory=list)
+
+    @classmethod
+    def from_dict(cls, cfg):
+        if cfg is None:
+            return cls()
+        self = cls(configured=True, **cfg)
+        self.rules = [MotionRule(**rule) for rule in self.rules]
+        return self
+
+    def encoded(self, basic=False):
+        d = asdict(self)
+        if basic:
+            d.pop('rules')
+        return d
+
+    def get_client(self):
+        return HWPSupervisorClient(self.instance_id)
+
+    def test_range(self, el_range, grip_state, spin_state):
+        """Determine what motion types are permitted, given the
+        current HWP state and the elevation (range) of the planned
+        motion.
+
+        Args:
+          el_range (tuple[float] or None):
+            The starting and ending elevations of the move.
+          grip_state (str):
+            The HWP gripper state.
+          spin_state (str):
+            The HWP spinning state.
+
+        The rules are evaluated in the context of grip_state and
+        spin_state, to obtain the ranges of els over which moves in
+        each axis is permitted.  Then the el_range, if provided is
+        tested against those ranges.
+
+        The returned structure looks like this::
+
+          {'el': (True, (30, 70), [(30, 70)]),
+           'az': (True, (30, 70), [(30, 70)]),
+           'third': (False, None, [(30, 50), (60, 70)]),
+          }
+
+        I.e. for each axis, a tuple is returned where the third value
+        is the full list of permitted elevation ranges for this state;
+        the first value is whether the requested el_range,
+        specifically, overlaps with the elevation ranges, and the
+        second value is the particular range that overlaps with
+        requested el_range (or None if not the case).
+
+        """
+        allow_moves = {k: [None, None, []] for k in AXIS_NAMES}
+        for rule in self.rules:
+            if not rule.test_hwp(grip_state, spin_state):
+                continue
+            # For each axis move that is allowed, add the el range
+            # into the allow_moves entry.
+            for k, (_, _, el_ranges) in allow_moves.items():
+                if rule.allow_moves[k]:
+                    el_ranges.append(rule.el_range)
+        for k in allow_moves:
+            allow_moves[k][2] = _simplify_ranges(*allow_moves[k][2])
+        if el_range is not None:
+            el_range = [min(el_range), max(el_range)]
+            for k in allow_moves.keys():
+                allow_moves[k][0] = False
+                for _e in allow_moves[k][2]:
+                    if _range_contains(_e, el_range):
+                        allow_moves[k][0] = True
+                        allow_moves[k][1] = _e
+        return {k: tuple(v) for k, v in allow_moves.items()}
+
+
+class HWPSupervisorClient:
+    def __init__(self, instance_id):
+        self.instance_id = instance_id
+        self.cclient = site_config.get_control_client(instance_id)
+
+    def update(self):
+        """Analyze HWPSupervisor state info and make determinations
+        about hwp state.  Returns a dict with the results.
+
+        When everything works well, the useful results in the dict are:
+
+        - ``timestamp``: current time
+        - ``ok``: True if state determination went reasonably well
+        - ``err_msg``: populated if not ok.
+        - ``grip_state``: one of "unknown", "cold", "warm", "ungripped"
+        - ``spin_state``: one of "unknown", "spinning", "not_spinning"
+
+        The following raw data from monitor process are copied into
+        the output dict::
+
+          hwp_state:
+            is_spinning       -> _is_spinning
+            pid_target_freq   -> _target_freq
+            gripper:
+              grip_state      -> _grip_state
+              brake           -> _grip_brakes
+          acu:
+            request_block_motion             -> request_block_motion
+            request_block_motion_timestamp   -> request_block_motion_timestamp
+
+        """
+        ok, err_msg = False, ''
+        hs, acu = {}, {}
+        try:
+            _, _, session = ocs_client.OCSReply(*self.cclient.request('status', 'monitor'))
+            if session is not None:
+                hs = session['data'].get('hwp_state', {})
+                acu = session['data'].get('acu', {})
+                ok = True
+        except client_http.ControlClientError as e:
+            err_msg = f'Error getting status: {e}'
+        except Exception as e:
+            err_msg = f'Surprising error: {e}'
+
+        # Enhanced spin state logic...
+        is_spinning = hs.get('is_spinning')  # bool or None
+        target_freq = hs.get('pid_target_freq')  # float or None I guess
+        if is_spinning or target_freq not in [None, 0]:
+            spin_state = 'spinning'
+        elif is_spinning is False and target_freq in [0.]:
+            spin_state = 'not_spinning'
+        else:
+            spin_state = 'unknown'
+
+        # Enhanced gripper state logic...
+        _grip_state = hs.get('gripper', {}).get('grip_state')
+        brakes = hs.get('gripper', {}).get('brake')  # 1 1 1 when stable
+        brakes_on = False
+        try:
+            brakes_on = len(brakes) and all(brakes)
+        except BaseException:
+            pass
+        if _grip_state is not None and brakes_on:
+            grip_state = _grip_state
+        else:
+            grip_state = 'unknown'
+
+        return {
+            'timestamp': time.time(),
+            'ok': ok,
+            'err_msg': err_msg,
+            'grip_state': grip_state,
+            'spin_state': spin_state,
+            '_grip_brakes': brakes,
+            '_grip_state': _grip_state,
+            '_is_spinning': is_spinning,
+            '_target_freq': target_freq,
+            'request_block_motion': acu.get('request_block_motion'),
+            'request_block_motion_timestamp': acu.get('request_block_motion_timestamp'),
+        }

--- a/tests/agents/test_acu_agent.py
+++ b/tests/agents/test_acu_agent.py
@@ -5,6 +5,8 @@ from socs.agents.acu.agent import ACUAgent  # noqa: F401
 HWP_IFACE_TEST_CONFIG = {
     'enabled': True,
     'tolerance': 0.1,
+    'instance_id': 'hwp-super1',
+    'limit_sun_avoidance': False,
     'rules': [
         {
             'el_range': [18, 90],
@@ -155,9 +157,11 @@ def _gen_rules(*args):
 
 
 def test_hwp_iface():
+    # Test parsing of a full config dict ...
     cfg = HWP_IFACE_TEST_CONFIG
     mo_rules = hwp_iface.HWPInterlocks.from_dict(cfg)
 
+    # Test range combination rules.
     def ex(d, item=0):
         return tuple([d[k][item] for k in ['el', 'az', 'third']])
 

--- a/tests/agents/test_acu_agent.py
+++ b/tests/agents/test_acu_agent.py
@@ -156,11 +156,12 @@ def _gen_rules(*args):
             'rules': rules}
 
 
-def test_hwp_iface():
+def test_hwp_iface_parse_config():
     # Test parsing of a full config dict ...
-    cfg = HWP_IFACE_TEST_CONFIG
-    mo_rules = hwp_iface.HWPInterlocks.from_dict(cfg)
+    hwp_iface.HWPInterlocks.from_dict(HWP_IFACE_TEST_CONFIG)
 
+
+def test_hwp_iface_rule_eval():
     # Test range combination rules.
     def ex(d, item=0):
         return tuple([d[k][item] for k in ['el', 'az', 'third']])

--- a/tests/agents/test_acu_agent.py
+++ b/tests/agents/test_acu_agent.py
@@ -1,6 +1,53 @@
 from socs.agents.acu import avoidance as av
-from socs.agents.acu import drivers
+from socs.agents.acu import drivers, hwp_iface
 from socs.agents.acu.agent import ACUAgent  # noqa: F401
+
+HWP_IFACE_TEST_CONFIG = {
+    'enabled': True,
+    'tolerance': 0.1,
+    'rules': [
+        {
+            'el_range': [18, 90],
+            'grip_states': ['cold', 'warm'],
+            'spin_states': ['*'],
+            'allow_moves': {
+                'el': True,
+                'az': True,
+                'third': False,
+            },
+        },
+        {
+            'el_range': [40, 90],
+            'grip_states': ['ungripped'],
+            'spin_states': ['not_spinning'],
+            'allow_moves': {
+                'el': True,
+                'az': True,
+                'third': False,
+            },
+        },
+        {
+            'el_range': [48, 60],
+            'grip_states': ['ungripped'],
+            'spin_states': ['not_spinning'],
+            'allow_moves': {
+                'el': True,
+                'az': True,
+                'third': True,
+            },
+        },
+        {
+            'el_range': [48, 60],
+            'grip_states': ['ungripped'],
+            'spin_states': ['spinning'],
+            'allow_moves': {
+                'el': True,
+                'az': True,
+                'third': False,
+            },
+        },
+    ]
+}
 
 
 def test_avoidance():
@@ -72,3 +119,71 @@ def test_tracks():
     points = next(iter(g))
     drivers.get_track_points_text(points, text_block=True,
                                   timestamp_offset=3)
+
+
+def test_hwp_iface_ranges_math():
+    misc = [
+        (10, 20), (30, 40), (20, 25), (-10, 11)
+    ]
+    assert hwp_iface._simplify_ranges(*misc) == [(-10, 25), (30, 40)]
+    for a, b, result in [
+            ((0, 10), (11, 20), False),
+            ((0, 10), (1, 1), True),
+            ((0, 10), (2, 10), True),
+            ((0, 10), (-1, 4), False),
+            ((0, 10), (8, 11), False),
+    ]:
+        assert hwp_iface._range_contains(a, b) == result
+
+
+def _gen_rules(*args):
+    def listify(x):
+        return [x] if isinstance(x, str) else x
+    rules = []
+    for el0, el1, grip, spin, el, az, th in args:
+        rules.append({
+            'el_range': [el0, el1],
+            'grip_states': listify(grip),
+            'spin_states': listify(spin),
+            'allow_moves': {
+                'el': el,
+                'az': az,
+                'third': th,
+            }})
+    return {'tolerance': .1,
+            'rules': rules}
+
+
+def test_hwp_iface():
+    cfg = HWP_IFACE_TEST_CONFIG
+    mo_rules = hwp_iface.HWPInterlocks.from_dict(cfg)
+
+    def ex(d, item=0):
+        return tuple([d[k][item] for k in ['el', 'az', 'third']])
+
+    mo_rules = hwp_iface.HWPInterlocks.from_dict(_gen_rules(
+        (40, 70, 'gripped', 'not_spinning', True, False, False),
+        (50, 60, 'ungripped', 'not_spinning', False, True, True),
+        (55, 62, 'ungripped', 'spinning', True, True, False),
+    ))
+
+    ruling = mo_rules.test_range(None, 'gripped', 'not_spinning')
+    assert ex(ruling, 2) == ([(40, 70)], [], [])
+
+    ruling = mo_rules.test_range([40, 50], 'gripped', 'not_spinning')
+    assert ex(ruling) == (True, False, False)
+
+    ruling = mo_rules.test_range([45, 51], 'gripped', 'not_spinning')
+    assert ex(ruling) == (True, False, False)
+
+    ruling = mo_rules.test_range([45, 51], 'ungripped', 'not_spinning')
+    assert ex(ruling) == (False, False, False)
+
+    ruling = mo_rules.test_range([51, 45], 'ungripped', 'not_spinning')
+    assert ex(ruling) == (False, False, False)
+
+    ruling = mo_rules.test_range([51, 52], 'ungripped', 'not_spinning')
+    assert ex(ruling) == (False, True, True)
+
+    ruling = mo_rules.test_range([30, 41], 'gripped', 'not_spinning')
+    assert ex(ruling) == (False, False, False)


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Using the ``hwp_interlocks`` configuration block, the Agent can be asked to monitor state in an HWPSupervisor agent, and use that information to restrict motion in specific axes.

When configured, the Agent's `monitor_hwp` process queries a particular HWPSupervisor instance, to learn the grip and spin state of the HWP.  It combines that information with the current elevation (or range of elevations required for some move) to determine whether a requested motion should be permitted.

## Motivation and Context

These changes complement the HWPSupervisor's interlocks that prevent HWP grip and spin state changes, based on platform position. 

## How Has This Been Tested?

This has been tested extensively with ACU simulator and a dummy HWPSupervisor agent.  Two development versions were tested briefly on real platform, along the way.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
