### PR TITLE
fix(pysmurf_controller): Bypass smurf instance for RSSI restart.

### DIFF
--- a/socs/agents/pysmurf_controller/agent.py
+++ b/socs/agents/pysmurf_controller/agent.py
@@ -1148,8 +1148,8 @@ class PysmurfController:
             if not acquired:
                 return False, f"Operation failed: {self.lock.job} is running."
 
-            S, cfg = self._get_smurf_control(session=session)
-            S._caput(S.epics_root + ":AMCc:RestartRssi", 1)
+            # if the system is locked up, spawning a SmurfControl instance will hang
+            epics.caput(f"smurf_server_s{self.slot}:AMCc:RestartRssi", 1)
 
             return True, "RestartRssi sent"
 


### PR DESCRIPTION
## Description
We found that the `restart_rssi` action fails on a slot that is actually locked-up because this prevents it from instantiating a pysmurf instance, which we had overlooked. This fix bypasses that interface by sending the command directly via EPICS.

## How Has This Been Tested?
Tested on a locked up slot on the LAT.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
