### PR TITLE
suprsync: Change default chmod to set world-readable

### DIFF
--- a/socs/agents/suprsync/agent.py
+++ b/socs/agents/suprsync/agent.py
@@ -270,7 +270,7 @@ def make_parser(parser=None):
     )
     pgroup.add_argument('--chmod', type=str, default="g+rwX,o+rX",
                         help="Comma-separated chmod strings to apply to file permissions "
-                             "on transfer. Defauls to making sure files are group-writeable "
+                             "on transfer. Defaults to making sure files are group-writeable "
                              "and world-readable.")
     return parser
 

--- a/socs/agents/suprsync/agent.py
+++ b/socs/agents/suprsync/agent.py
@@ -268,9 +268,10 @@ def make_parser(parser=None):
         '--db-pool-max-overflow', type=int, default=10,
         help="Number of connections to allow in the overflow pool."
     )
-    pgroup.add_argument('--chmod', type=str, default="g+rwX",
+    pgroup.add_argument('--chmod', type=str, default="g+rwX,o+rX",
                         help="Comma-separated chmod strings to apply to file permissions "
-                             "on transfer. Defauls to making sure files are group-writeable.")
+                             "on transfer. Defauls to making sure files are group-writeable "
+                             "and world-readable.")
     return parser
 
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
This PR changes the default `--chmod` argument passed to rsync within the suprsync agent to 'g+rwX,o+rX', which ensures files are group writable and world readable.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Resolves #871.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
I tested setting this argument via the SCF on the LAT SMuRF servers. It resulted in changing the top level directory permissions from `drwxrwx---` to `drwxrwxr-x`, which is what we want.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
