### PR TITLE
Add ability to deactivate slot in smurf crate

### DIFF
--- a/socs/agents/smurf_crate_monitor/agent.py
+++ b/socs/agents/smurf_crate_monitor/agent.py
@@ -271,7 +271,7 @@ class SmurfCrateMonitor:
         else:
             return False, 'acq is not currently running'
 
-    @ocs_agent.param('slot', type=int, choices=[1, 2, 3, 4, 5, 6, 7], default=None)
+    @ocs_agent.param('slot', type=int, choices=[1, 2, 3, 4, 5, 6, 7])
     def deactivate_slot(self, session, params=None):
         """
         deactivate_slot()
@@ -284,13 +284,7 @@ class SmurfCrateMonitor:
             slot (int):
                 Slot number to deactivate. Allowed values are 1-7.
         """
-        slot = params.get('slot')
-        if slot is None:
-            session.data = {"result": "ERROR: No slot provided",
-                            "last_updated": time.time()}
-            return False, 'No slot provided.'
-
-        cmd = ['ssh', f'{self.shm_addr}', 'clia', 'deactivate', 'board', str(slot)]
+        cmd = ['ssh', f'{self.shm_addr}', 'clia', 'deactivate', 'board', str(params['slot'])]
         ssh = subprocess.Popen(cmd, shell=False, stdout=subprocess.PIPE,
                                stderr=subprocess.PIPE)
         result = ssh.stdout.readlines()
@@ -308,7 +302,7 @@ class SmurfCrateMonitor:
                             "last_updated": time.time()}
             return True, 'Slot deactivated.'
 
-    @ocs_agent.param('slot', type=int, choices=[1, 2, 3, 4, 5, 6, 7], default=None)
+    @ocs_agent.param('slot', type=int, choices=[1, 2, 3, 4, 5, 6, 7])
     def activate_slot(self, session, params=None):
         """
         activate_slot()
@@ -319,13 +313,7 @@ class SmurfCrateMonitor:
             slot (int):
                 Slot number to activate. Allowed values are 1-7.
         """
-        slot = params.get('slot')
-        if slot is None:
-            session.data = {"result": "ERROR: No slot provided",
-                            "last_updated": time.time()}
-            return False, 'No slot provided.'
-
-        cmd = ['ssh', f'{self.shm_addr}', 'clia', 'activate', 'board', str(slot)]
+        cmd = ['ssh', f'{self.shm_addr}', 'clia', 'activate', 'board', str(params['slot'])]
         ssh = subprocess.Popen(cmd, shell=False, stdout=subprocess.PIPE,
                                stderr=subprocess.PIPE)
         result = ssh.stdout.readlines()

--- a/socs/agents/smurf_crate_monitor/agent.py
+++ b/socs/agents/smurf_crate_monitor/agent.py
@@ -270,8 +270,8 @@ class SmurfCrateMonitor:
             return True, 'requested to stop taking data.'
         else:
             return False, 'acq is not currently running'
-    
-    @ocs_agent.param('slot', type=int, choices=[1,2,3,4,5,6,7], default=None)
+
+    @ocs_agent.param('slot', type=int, choices=[1, 2, 3, 4, 5, 6, 7], default=None)
     def deactivate_slot(self, session, params=None):
         """
         deactivate_slot()
@@ -288,25 +288,26 @@ class SmurfCrateMonitor:
         """
         slot = params.get('slot')
         if slot is None:
-            session.data.update({"fields":{"result": "ERROR: No slot provided"},
+            session.data.update({"fields": {"result": "ERROR: No slot provided"},
                                  "last_updated": time.time()})
             return False, 'No slot provided.'
-        
+
         cmd = ['ssh', f'{self.shm_addr}', 'clia', 'deactivate', 'board', str(slot)]
         ssh = subprocess.Popen(cmd, shell=False, stdout=subprocess.PIPE,
                                stderr=subprocess.PIPE)
         result = ssh.stdout.readlines()
         if result == []:
             error = ssh.stderr.readlines()
-            session_data = {"fields":{"result": "ERROR: %s" % error},
+            session_data = {"fields": {"result": "ERROR: %s" % error},
                             "last_updated": time.time()}
             session.data.update(session_data)
             return False, 'Crate failed to respond.'
         else:
-            session_data = {"fields":{"result": result},
+            session_data = {"fields": {"result": result},
                             "last_updated": time.time()}
             session.data.update(session_data)
             return True, 'Slot deactivated.'
+
 
 def make_parser(parser=None):
     """

--- a/socs/agents/smurf_crate_monitor/agent.py
+++ b/socs/agents/smurf_crate_monitor/agent.py
@@ -277,6 +277,7 @@ class SmurfCrateMonitor:
         deactivate_slot(slot)
 
         **Task** - Deactivates a specific slot in the crate.
+
         This is used to ensure that the boards are not active
         when the boards are being worked on or air cooling is blocked.
 

--- a/socs/agents/smurf_crate_monitor/agent.py
+++ b/socs/agents/smurf_crate_monitor/agent.py
@@ -274,7 +274,7 @@ class SmurfCrateMonitor:
     @ocs_agent.param('slot', type=int, choices=[1, 2, 3, 4, 5, 6, 7])
     def deactivate_slot(self, session, params=None):
         """
-        deactivate_slot()
+        deactivate_slot(slot)
 
         **Task** - Deactivates a specific slot in the crate.
         This is used to ensure that the boards are not active
@@ -305,7 +305,7 @@ class SmurfCrateMonitor:
     @ocs_agent.param('slot', type=int, choices=[1, 2, 3, 4, 5, 6, 7])
     def activate_slot(self, session, params=None):
         """
-        activate_slot()
+        activate_slot(slot)
 
         **Task** - Activates a specific slot in the crate.
 

--- a/socs/agents/smurf_crate_monitor/agent.py
+++ b/socs/agents/smurf_crate_monitor/agent.py
@@ -271,7 +271,6 @@ class SmurfCrateMonitor:
         else:
             return False, 'acq is not currently running'
 
-
     @ocs_agent.param('slot', type=int, choices=[1, 2, 3, 4, 5, 6, 7], default=None)
     def deactivate_slot(self, session, params=None):
         """
@@ -308,7 +307,6 @@ class SmurfCrateMonitor:
             session.data = {"result": result,
                             "last_updated": time.time()}
             return True, 'Slot deactivated.'
-
 
     @ocs_agent.param('slot', type=int, choices=[1, 2, 3, 4, 5, 6, 7], default=None)
     def activate_slot(self, session, params=None):

--- a/socs/agents/smurf_crate_monitor/agent.py
+++ b/socs/agents/smurf_crate_monitor/agent.py
@@ -270,7 +270,43 @@ class SmurfCrateMonitor:
             return True, 'requested to stop taking data.'
         else:
             return False, 'acq is not currently running'
+    
+    @ocs_agent.param('slot', type=int, choices=[1,2,3,4,5,6,7], default=None)
+    def deactivate_slot(self, session, params=None):
+        """
+        deactivate_slot()
 
+        **Task** - Deactivates a specific slot in the crate.
+        This is used to ensure that the boards are not active
+        when the boards are being worked on or air cooling is blocked.
+
+        Args:
+            shm_addr (str):
+                Address used to connect to shelf manager.
+            slot (int):
+                Slot number to deactivate. Allowed values are 1-7.
+        """
+        slot = params.get('slot')
+        if slot is None:
+            session.data.update({"fields":{"result": "ERROR: No slot provided"},
+                                 "last_updated": time.time()})
+            return False, 'No slot provided.'
+        
+        cmd = ['ssh', f'{self.shm_addr}', 'clia', 'deactivate', 'board', str(slot)]
+        ssh = subprocess.Popen(cmd, shell=False, stdout=subprocess.PIPE,
+                               stderr=subprocess.PIPE)
+        result = ssh.stdout.readlines()
+        if result == []:
+            error = ssh.stderr.readlines()
+            session_data = {"fields":{"result": "ERROR: %s" % error},
+                            "last_updated": time.time()}
+            session.data.update(session_data)
+            return False, 'Crate failed to respond.'
+        else:
+            session_data = {"fields":{"result": result},
+                            "last_updated": time.time()}
+            session.data.update(session_data)
+            return True, 'Slot deactivated.'
 
 def make_parser(parser=None):
     """
@@ -302,6 +338,7 @@ def main(args=None):
 
     agent.register_task('init_crate', smurfcrate.init_crate,
                         startup=startup)
+    agent.register_task('deactivate_slot', smurfcrate.deactivate_slot)
     agent.register_process('acq', smurfcrate.acq,
                            smurfcrate._stop_acq)
 


### PR DESCRIPTION
Add a task to disable a smurf slot.

## Description
This adds a task to the `smurf_crate_monitor` agent called `deactivate_slot` which allows turning off a specific slot within the smurf crate.

## Motivation and Context
SATp3 weather stow procedure involves closing their air hatch to their ATCA crates. Current the signals are shutoff but the boards are not powered off before the hatch is closed. To prevent thermal issues its better to power off the slots before closing the hatch which this task allows.

## How Has This Been Tested?
I haven't tested this yet, I would like to test it on one of the site crates.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.

Tagging @samdayweiss, and @tpsatt to let them know I'm adding this in.