### PR TITLE
hwp-supervisor: Set longer timeout for grip commands

### DIFF
--- a/socs/agents/hwp_supervisor/agent.py
+++ b/socs/agents/hwp_supervisor/agent.py
@@ -1296,7 +1296,8 @@ class ControlStateMachine:
 
             elif isinstance(state, ControlState.GripHWP):
                 with ensure_grip_safety(hwp_state, self.log):
-                    self.run_and_validate(clients.gripper.grip)
+                    # Grip can take 5-10 minutes to complete
+                    self.run_and_validate(clients.gripper.grip, timeout=720)
                 self.action.set_state(ControlState.Done(success=True))
 
             elif isinstance(state, ControlState.UngripHWP):

--- a/socs/agents/hwp_supervisor/agent.py
+++ b/socs/agents/hwp_supervisor/agent.py
@@ -1302,7 +1302,7 @@ class ControlStateMachine:
 
             elif isinstance(state, ControlState.UngripHWP):
                 with ensure_grip_safety(hwp_state, self.log):
-                    self.run_and_validate(clients.gripper.ungrip)
+                    self.run_and_validate(clients.gripper.ungrip, timeout=60)
                 self.action.set_state(ControlState.Done(success=True))
 
             elif isinstance(state, ControlState.Brake):


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
This sets a longer timeout for the grip and ungrip commands to execute (12 minutes, and 1 minute, respectively) from the supervisor agent.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Resolves #882.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
Not yet tested.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
