### PR TITLE
ACU Agent: fix bug that prevents go_to

### DIFF
--- a/socs/agents/acu/agent.py
+++ b/socs/agents/acu/agent.py
@@ -69,6 +69,13 @@ INIT_SUN_CONFIGS = {
 SUN_MAP_REFRESH = 6 * avoidance.HOUR
 
 
+#: Things the ACU might say when you've done things properly
+OK_RESPONSES = [
+    b'OK, Command executed.',
+    b'OK, Command send.',
+]
+
+
 class ACUAgent:
     """Agent to acquire data from an ACU and control telescope pointing with the
     ACU.
@@ -1121,9 +1128,6 @@ class ACUAgent:
         # platform moving around.
         UNREASONABLE_VEL = 0.1
 
-        # Positive acknowledgment of AcuControl.go_to
-        OK_RESPONSE = b'OK, Command executed.'
-
         # Enum for the motion states
         State = Enum(f'{axis}State',
                      ['INIT', 'WAIT_MOVING', 'WAIT_STILL', 'FAIL', 'DONE'])
@@ -1279,7 +1283,7 @@ class ACUAgent:
             if state == State.INIT:
                 # Set target position and change mode to Preset.
                 result = yield ctrl.goto(target)
-                if result == OK_RESPONSE:
+                if result in OK_RESPONSES:
                     state = State.WAIT_MOVING
                 else:
                     self.log.error(f'ACU rejected go_to with message: {result}')
@@ -3027,8 +3031,6 @@ class ACUAgent:
             dset_cmd = 'ShutterClose'
             desired_key, undesired_key = 'Shutter_closed', 'Shutter_open'
 
-        OK_RESPONSE = b'OK, Command executed.'
-
         # This just needs to be longer than 1 loop time.
         STATE_WAIT = 5.
 
@@ -3060,7 +3062,7 @@ class ACUAgent:
             elif state == 'init':
                 # Issue the command
                 result = yield self.acu_control.Command(self.datasets['shutter'], dset_cmd)
-                if result == OK_RESPONSE:
+                if result in OK_RESPONSES:
                     state = 'wait-moving'
                     timeout = time.time() + STATE_WAIT
                 else:


### PR DESCRIPTION
## Description

In cases where we check the ACU reply text to see if it indicates success, check against a short list of known "OK_responses".

This corrects a bug that makes the ACU Agent from #880 totally unusable at the site.

## Motivation and Context

Most ACU commands return the success text "OK, Command executed."  But some say "OK, Command send."  Recent evolutions in soaculib and socs ended up using one of those latter commands, which prevented the agent from believing it had commanded successfully.

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?

Tested moves and scans on the ACU simulator, after updating it to return the second OK response, like a real ACU.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
