### PR TITLE
hwp-gripper: fix alarm message handling

### DIFF
--- a/socs/agents/hwp_gripper/agent.py
+++ b/socs/agents/hwp_gripper/agent.py
@@ -789,7 +789,7 @@ class HWPGripperAgent:
             if bool(state['jxc']['alarm']):
                 out_value = int(state['jxc']['out']) % 16
                 if out_value in alarm_group_mapping.keys():
-                    alarm_message = self.decoded_alarm_group[alarm_group_mapping]
+                    alarm_message = self.decoded_alarm_group[alarm_group_mapping[out_value]]
                 else:
                     alarm_message = self.decoded_alarm_group['A']
             else:


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
There was an error of alarm message handing of hwp-gripper. 
This was crashing agent by `<class 'TypeError'>: unhashable type: 'dict'`

## Motivation and Context
This resolves https://github.com/simonsobs/socs/issues/841

## How Has This Been Tested?
Tested daq-dev. Introduced general controller error by turning off the power for gripper controller and confirmed this resolves the issue.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
