### PR TITLE
Hwp supervisor: Add enc_freq timestamp and tolerance in acu elevation check

### DIFF
--- a/socs/agents/hwp_supervisor/agent.py
+++ b/socs/agents/hwp_supervisor/agent.py
@@ -353,6 +353,7 @@ class HWPState:
     pmx_last_updated: Optional[float] = None
 
     enc_freq: Optional[float] = None
+    encoder_last_updated: Optional[float] = None
     last_quad: Optional[float] = None
     last_quad_time: Optional[float] = None
 
@@ -1539,6 +1540,7 @@ class HWPSupervisor:
                     'driver_iboot': None,
                     'enc_freq': None,
                     'enc_instance_id': 'hwp-enc',
+                    'encoder_last_updated': None,
                     'gripper': {
                         'brake': [0, 0, 0],
                         'emg': [0, 0, 0],

--- a/socs/agents/hwp_supervisor/agent.py
+++ b/socs/agents/hwp_supervisor/agent.py
@@ -405,8 +405,8 @@ class HWPState:
         if not args.no_acu:
             self.acu = ACUState(
                 instance_id=args.acu_instance_id,
-                min_el=args.acu_min_el,
-                max_el=args.acu_max_el,
+                min_el=args.acu_min_el - args.acu_tol_el,
+                max_el=args.acu_max_el + args.acu_tol_el,
                 max_time_since_update=args.acu_max_time_since_update,
                 mount_velocity_grip_thresh=args.mount_velocity_grip_thresh,
                 grip_max_boresight_angle=args.grip_max_boresight_angle,
@@ -2061,6 +2061,10 @@ def make_parser(parser=None):
     pgroup.add_argument(
         '--acu-max-el', type=float, default=90.0,
         help="Max elevation that HWP spin up is allowed",
+    )
+    pgroup.add_argument(
+        '--acu-tol-el', type=float, default=0.1,
+        help="Amount of tolerance in elevation allowed when HWP spin up",
     )
     pgroup.add_argument(
         '--acu-max-time-since-update', type=float, default=30.0,


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Add enc_freq timestamp to resolve the issue in ocs-web.
Add tolerance in acu elevation check so that we don't need to manually add tolerance in config.

## Motivation and Context
This resolves https://github.com/simonsobs/socs/issues/788 and https://github.com/simonsobs/socs/issues/789

## How Has This Been Tested?
Tested at daq-satp3.
![image png](https://github.com/user-attachments/assets/8c4e77ed-153e-4aba-82e9-63917aa3ab2f)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
