### PR TITLE
fix: publish cold junction temperature to feed

### DIFF
--- a/socs/agents/stimulator_thermometer/agent.py
+++ b/socs/agents/stimulator_thermometer/agent.py
@@ -95,7 +95,6 @@ class StimThermometerAgent:
 
                     temp = dev.get_temp()
                     data['data'][chan_string + '_T'] = temp
-                    self.agent.publish_to_feed('temperatures', data)
 
                     if isinstance(dev, Max31856):
                         cjtemp = dev.get_temp_ambient()
@@ -104,6 +103,7 @@ class StimThermometerAgent:
                     else:
                         field_dict = {chan_string: {'T': temp}}
 
+                    self.agent.publish_to_feed('temperatures', data)
                     session.data.update(field_dict)
 
                 session.data.update({'timestamp': current_time})


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Changed the position of `publish_to_feed` so that `acq` can also publish cold-junction temperatures of thermocouple amplifier.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Previously cold-junction temperatures were not published to feed because of a mistake in the location of the `publish_to_feed`.
This PR fixes the problem.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
Not tested yet.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
