### PR TITLE
ACU: read out the LAT tiltmeter

### DIFF
--- a/socs/agents/acu/agent.py
+++ b/socs/agents/acu/agent.py
@@ -26,9 +26,6 @@ from socs.agents.acu import exercisor, hwp_iface
 FULL_STACK = 10000
 
 
-#: Maximum update time (in s) for "monitor" process data, even with no changes
-MONITOR_MAX_TIME_DELTA = 2.
-
 #: Initial default scan params by platform type.
 INIT_DEFAULT_SCAN_PARAMS = {
     'ccat': {
@@ -74,6 +71,46 @@ OK_RESPONSES = [
     b'OK, Command executed.',
     b'OK, Command send.',
 ]
+
+
+# The data structure below defines how data fields are organized in
+# the "status" readout of the "monitor" process.  Each entry in the
+# list is a tuple:
+#
+#   (block_name, fields_key, policy)
+#
+# The "block_name" is the block name in the sense of housekeeping data
+# format. The "fields_key" corresponds a labeled group of ACU fields,
+# as defined in soaculib.status_keys.  The "policy" is a description,
+# for the monitor process, of how to store the data.  The values for
+# policy are:
+#
+#   - None: publish the data at least every X seconds (see
+#     MONITOR_MAX_TIME_DELTA), or if any of the values have changed.
+#   - 'tick': publish every sample (as a reference tick).
+#
+
+#: Block names and update policy for status fields in monitor process.
+MONITOR_STRUCTURE = [
+    ('ACU_summary_output', 'summary', 'tick'),
+    ('ACU_axis_faults', 'axis_faults_errors_overages', None),
+    ('ACU_position_errors', 'position_errors', None),
+    ('ACU_axis_limits', 'axis_limits', None),
+    ('ACU_axis_warnings', 'axis_warnings', None),
+    ('ACU_axis_failures', 'axis_failures', None),
+    ('ACU_axis_state', 'axis_state', None),
+    ('ACU_oscillation_alarm', 'osc_alarms', None),
+    ('ACU_command_status', 'commands', None),
+    ('ACU_general_errors', 'ACU_failures_errors', None),
+    ('ACU_platform_status', 'platform_status', None),
+    ('ACU_emergency', 'ACU_emergency', None),
+    ('ACU_corotator', 'corotator', None),
+    ('ACU_shutter', 'shutter', None),
+]
+
+
+#: Maximum update time (in s) for "monitor" process data, even with no changes
+MONITOR_MAX_TIME_DELTA = 2.
 
 
 class ACUAgent:
@@ -226,27 +263,15 @@ class ACUAgent:
         # self.data provides a place to reference data from the monitors.
         # 'status' is populated by the monitor operation
         # 'broadcast' is populated by the udp_monitor operation
+        # 'hwp' is populated by the monitor_hwp operation
 
         self.data = {
-            'status': {
-                'summary': {},
-                'position_errors': {},
-                'axis_limits': {},
-                'axis_faults_errors_overages': {},
-                'axis_warnings': {},
-                'axis_failures': {},
-                'axis_state': {},
-                'osc_alarms': {},
-                'commands': {},
-                'ACU_failures_errors': {},
-                'platform_status': {},
-                'ACU_emergency': {},
-                'corotator': {},
-                'shutter': {},
-            },
-            'hwp': {},
+            'status': {},
             'broadcast': {},
+            'hwp': {},
         }
+        for _, k, _ in MONITOR_STRUCTURE:
+            self.data['status'][k] = {}
 
         # Structure for the broadcast process to communicate state to
         # the monitor process, for a data quality feed.
@@ -594,7 +619,8 @@ class ACUAgent:
             for short, collection in [
                     ('status', 'StatusDetailed'),
                     ('third', 'Status3rdAxis'),
-                    ('shutter', 'StatusShutter')]:
+                    ('shutter', 'StatusShutter'),
+            ]:
                 if self.datasets[short]:
                     output[collection] = (
                         yield self.acu_read.Values(self.datasets[short]))
@@ -760,9 +786,9 @@ class ACUAgent:
                 if k not in influx_blocks:
                     continue
                 B, N = influx_blocks[k], new_influx_blocks[k]
-                if N['timestamp'] - B['timestamp'] > MONITOR_MAX_TIME_DELTA:
-                    continue
-                if any([B['data'][_k] != _v for _k, _v in N['data'].items()]):
+                overdue = (N['timestamp'] - B['timestamp'] > MONITOR_MAX_TIME_DELTA)
+                changes = any([B['data'][_k] != _v for _k, _v in N['data'].items()])
+                if overdue or changes:
                     continue
                 del new_influx_blocks[k]
 
@@ -774,22 +800,7 @@ class ACUAgent:
 
             # Assemble data for aggregator ...
             new_blocks = {}
-            for block_name, data_key in [
-                    ('ACU_summary_output', 'summary'),
-                    ('ACU_axis_faults', 'axis_faults_errors_overages'),
-                    ('ACU_position_errors', 'position_errors'),
-                    ('ACU_axis_limits', 'axis_limits'),
-                    ('ACU_axis_warnings', 'axis_warnings'),
-                    ('ACU_axis_failures', 'axis_failures'),
-                    ('ACU_axis_state', 'axis_state'),
-                    ('ACU_oscillation_alarm', 'osc_alarms'),
-                    ('ACU_command_status', 'commands'),
-                    ('ACU_general_errors', 'ACU_failures_errors'),
-                    ('ACU_platform_status', 'platform_status'),
-                    ('ACU_emergency', 'ACU_emergency'),
-                    ('ACU_corotator', 'corotator'),
-                    ('ACU_shutter', 'shutter'),
-            ]:
+            for block_name, data_key, policy in MONITOR_STRUCTURE:
                 new_blocks[block_name] = {
                     'timestamp': self.data['status']['summary']['ctime'],
                     'block_name': block_name,
@@ -797,16 +808,17 @@ class ACUAgent:
                 }
 
             # Only keep blocks that have changed or have new data.
-            block_keys = list(new_blocks.keys())
-            for k in block_keys:
-                if k == 'summary':  # always store these, as a sort of reference tick.
+            for k, _, policy in MONITOR_STRUCTURE:
+                if policy is None:
+                    policy = 'default'
+                if policy == 'tick':  # always store.
                     continue
                 if k not in data_blocks:
                     continue
                 B, N = data_blocks[k], new_blocks[k]
-                if N['timestamp'] - B['timestamp'] > MONITOR_MAX_TIME_DELTA:
-                    continue
-                if any([B['data'][_k] != _v for _k, _v in N['data'].items()]):
+                overdue = (N['timestamp'] - B['timestamp'] > MONITOR_MAX_TIME_DELTA)
+                changes = any([B['data'][_k] != _v for _k, _v in N['data'].items()])
+                if overdue or changes:
                     continue
                 del new_blocks[k]
 


### PR DESCRIPTION
## Description

Read out the built-in tiltmeter.  This requires a bunch of new code because the tiltmeter reports stale (repeated) data when the platform is moving.

## Motivation and Context

LAT team wants these fields recorded to help understand LAT pointing behavior.

## How Has This Been Tested?

Tested on simulator.  Ran it at site today.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
