### PR TITLE
pysmurf-controller: Add fields to `session.data` to track when stream is enabled

### DIFF
--- a/socs/agents/pysmurf_controller/agent.py
+++ b/socs/agents/pysmurf_controller/agent.py
@@ -448,6 +448,7 @@ class PysmurfController:
 
             session.data['stream_on'] = False
             session.data['last_updated'] = time.time()
+            init_start = time.time()
             S, cfg = self._get_smurf_control(session=session,
                                              load_tune=params['load_tune'])
 
@@ -458,6 +459,10 @@ class PysmurfController:
             session.data['stream_id'] = cfg.stream_id
             session.data['sid'] = sdl.stream_g3_on(S, **params['kwargs'])
             session.data['stream_on'] = True
+            init_end = time.time()
+            init_duration = init_end - init_start
+            self.log.info("Stream initialization took {duration:.2f} seconds",
+                          duration=init_duration)
             while session.status in ['starting', 'running']:
                 session.data['last_updated'] = time.time()
                 if stop_time is not None:


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
This PR adds the 'stream_on' and 'last_updated' fields to `session.data` within the `stream` process. It also adds a log message recording the duration of this initialization process.

### Reviewers
@kmharrington, lemme know if that logging is sufficient for what you want. @msilvafe and @tristpinsm, just wanted to keep you aware of changes.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
This will enable an `OCSClient` to check whether or not the stream is on, and whether 'stream_on' is a recent value. This will be used downstream when addressing https://github.com/simonsobs/sorunlib/issues/215.

The initialization timer will help identify how long this startup is actually taking. We know its ~30 seconds. However, it won't break down which components are slowest. Thoughts related to that are welcome.

Resolves #897.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
This has not been tested, but they are relatively innocuous changes.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
