### PR TITLE
Remove lingering references to versioneer

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -135,4 +135,4 @@ include = [
 ]
 
 [tool.isort]
-skip = ["versioneer.py", "socs/_version.py"]
+skip = ["socs/_version.py"]

--- a/tests/.coveragerc
+++ b/tests/.coveragerc
@@ -3,7 +3,7 @@ source =
     ../socs
 
 omit =
-  # omit versioneer
+  # omit version file
   */_version.py
 
   # omit lab only Agents for now


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
This just drops the old `versioneer.py` file from the isort config, and changes the text in a comment that used to refer to the versioneer file.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Noticed these while looking at socs as an example of switching from setuptools to hatchling.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
Ran pre-commit, which runs isort.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
