### PR TITLE
ACU Agent: new LAT datasets

### DIFF
--- a/docs/agents/acu_agent.rst
+++ b/docs/agents/acu_agent.rst
@@ -76,9 +76,6 @@ Here is an example of a device definition for a SATP::
                 'active': False,
             },
         },
-        'status': {
-            'status_name': 'Datasets.StatusSATPDetailed8100',
-            },
 
         'platform': 'satp',
         'motion_limits': {

--- a/socs/agents/acu/agent.py
+++ b/socs/agents/acu/agent.py
@@ -94,8 +94,10 @@ OK_RESPONSES = [
 # The sample_period is the minimum spacing between samples, even if
 # values have changed.
 #
-# To drop a block of data (as defined by fields_key) from the output
-# data, set the block_name to None.
+# Note that *all groups found in soaculib.status_keys* must be listed
+# here -- or an error will be raised on startup.  To drop a block of
+# data (as defined by fields_key) from the output data, set the
+# block_name to None.
 
 #: Block names and update policy for status fields in monitor process.
 MONITOR_STRUCTURE = [
@@ -115,6 +117,8 @@ MONITOR_STRUCTURE = [
     ('ACU_shutter', 'shutter', None, None),
     ('ACU_tilt', 'tilt_slow', 'changed', 0.5),
     (None, 'tilt_fast', None, None),
+    ('ACU_sun_avoidance', 'sun_avoidance', 'changed', 1.),
+    ('ACU_corrections', 'corrections', 'changed', 10.),
 ]
 
 
@@ -206,7 +210,7 @@ class ACUAgent:
                 if block_group == group:
                     break
             else:
-                raise ValueError("status_key block '{group}' not configured for monitoring.")
+                raise ValueError(f"status_key block '{group}' not configured for monitoring.")
             for acu_key, block_key in group_fields.items():
                 self.status_field_map[acu_key] = (group, block_name, block_key)
 

--- a/socs/agents/acu/agent.py
+++ b/socs/agents/acu/agent.py
@@ -210,7 +210,7 @@ class ACUAgent:
                 if block_group == group:
                     break
             else:
-                raise ValueError(f"status_key block '{group}' not configured for monitoring.")
+                raise ValueError(f"status_key block '{group}' not found in MONITOR_STRUCTURE.")
             for acu_key, block_key in group_fields.items():
                 self.status_field_map[acu_key] = (group, block_name, block_key)
 

--- a/socs/agents/acu/agent.py
+++ b/socs/agents/acu/agent.py
@@ -117,8 +117,8 @@ MONITOR_STRUCTURE = [
     ('ACU_shutter', 'shutter', None, None),
     ('ACU_tilt', 'tilt_slow', 'changed', 0.5),
     (None, 'tilt_fast', None, None),
-    ('ACU_sun_avoidance', 'sun_avoidance', 'changed', 1.),
-    ('ACU_corrections', 'corrections', 'changed', 10.),
+    ('ACU_sun_avoidance', 'sun_avoidance', None, 1.),
+    ('ACU_corrections', 'corrections', None, 10.),
 ]
 
 
@@ -869,9 +869,10 @@ class ACUAgent:
                     continue
                 if policy == 'tick':  # always store.
                     continue
-                overdue = (N['timestamp'] - B['timestamp'] > MONITOR_MAX_TIME_DELTA)
                 underdue = delta is not None and \
                     (N['timestamp'] - B['timestamp'] < delta)
+                overdue = (N['timestamp'] - B['timestamp'] > MONITOR_MAX_TIME_DELTA) \
+                    and not underdue
                 changes = any([B['data'][_k] != _v for _k, _v in N['data'].items()])
                 if (overdue and policy != 'changed') or changes and not underdue:
                     continue

--- a/socs/agents/acu/agent.py
+++ b/socs/agents/acu/agent.py
@@ -93,6 +93,9 @@ OK_RESPONSES = [
 #
 # The sample_period is the minimum spacing between samples, even if
 # values have changed.
+#
+# To drop a block of data (as defined by fields_key) from the output
+# data, set the block_name to None.
 
 #: Block names and update policy for status fields in monitor process.
 MONITOR_STRUCTURE = [
@@ -111,6 +114,7 @@ MONITOR_STRUCTURE = [
     ('ACU_corotator', 'corotator', None, None),
     ('ACU_shutter', 'shutter', None, None),
     ('ACU_tilt', 'tilt_slow', 'changed', 0.5),
+    (None, 'tilt_fast', None, None),
 ]
 
 
@@ -177,9 +181,11 @@ class ACUAgent:
         self.udp_schema = aculib.get_stream_schema(self.udp['schema'])
         self.udp_ext = self.acu_config['streams']['ext']
 
-        # The 'status' dataset is necessary; the 'third' axis can be
-        # None (in SATP it's all included in default); the 'shutter'
-        # is enabled for LAT.
+        # List of datasets to read as "status".  The 'status' dataset
+        # is necessary; the 'third' axis can be None (in SATP all the
+        # boresight info is included in the status dataset); the
+        # 'shutter' is for LAT shutter and 'pointing' is for LAT
+        # tiltmeter.
         _dsets = self.acu_config['_datasets']
         self.datasets = {
             'status': _dsets.get('default_dataset'),
@@ -191,7 +197,18 @@ class ACUAgent:
             if v is not None:
                 self.datasets[k] = dict(_dsets['datasets'])[v]
 
-        self.monitor_fields = status_keys.status_fields[self.platform_type]['status_fields']
+        # Create a map from each status key (read through the
+        # self.datasets) to the output block and field name.
+        self.status_field_map = {}
+        for group, group_fields in \
+                status_keys.status_fields[self.platform_type]['status_fields'].items():
+            for block_name, block_group, _, _ in MONITOR_STRUCTURE:
+                if block_group == group:
+                    break
+            else:
+                raise ValueError("status_key block '{group}' not configured for monitoring.")
+            for acu_key, block_key in group_fields.items():
+                self.status_field_map[acu_key] = (group, block_name, block_key)
 
         # Config file + overrides processing
 
@@ -276,7 +293,9 @@ class ACUAgent:
             'broadcast': {},
             'hwp': {},
         }
-        for _, k, _, _ in MONITOR_STRUCTURE:
+        for b, k, _, _ in MONITOR_STRUCTURE:
+            if b is None:
+                continue
             self.data['status'][k] = {}
 
         # Structure for the broadcast process to communicate state to
@@ -648,6 +667,7 @@ class ACUAgent:
         last_resp_rate = None
         data_blocks = {}
         influx_blocks = {}
+        unknown_fields = set()
 
         while session.status in ['running']:
 
@@ -703,20 +723,32 @@ class ACUAgent:
                     session.data['connected'] = False
                 yield dsleep(1)
                 continue
+
             for k, v in session.data.items():
                 if k in not_data_keys:
                     continue
                 for (key, value) in v.items():
-                    for category in self.monitor_fields:
-                        if key in self.monitor_fields[category]:
-                            if isinstance(value, bool):
-                                self.data['status'][category][self.monitor_fields[category][key]] = int(value)
-                            elif isinstance(value, int) or isinstance(value, float):
-                                self.data['status'][category][self.monitor_fields[category][key]] = value
-                            elif value is None:
-                                self.data['status'][category][self.monitor_fields[category][key]] = float('nan')
-                            else:
-                                self.data['status'][category][self.monitor_fields[category][key]] = str(value)
+                    try:
+                        group, block, field = self.status_field_map[key]
+                    except KeyError:
+                        if key not in unknown_fields:
+                            self.log.warn(
+                                'unknown status field (ignored hereafter): "%s"' % key)
+                            unknown_fields.add(key)
+                        continue
+                    if block is None:
+                        continue
+                    # Cast value to saveable type.
+                    if isinstance(value, bool):
+                        value = int(value)
+                    elif isinstance(value, int) or isinstance(value, float):
+                        pass
+                    elif value is None:
+                        value = float('nan')
+                    else:
+                        value = str(value)
+                    # Store.
+                    self.data['status'][group][field] = value
 
             self.data['status']['summary']['ctime'] =\
                 sh.timecode(self.data['status']['summary']['Time'])
@@ -813,6 +845,8 @@ class ACUAgent:
             # Assemble data for aggregator ...
             new_blocks = {}
             for block_name, data_key, _, _ in MONITOR_STRUCTURE:
+                if block_name is None:
+                    continue
                 new_blocks[block_name] = {
                     'timestamp': self.data['status']['summary']['ctime'],
                     'block_name': block_name,
@@ -821,6 +855,8 @@ class ACUAgent:
 
             # Only keep blocks that have changed or have new data.
             for k, _, policy, delta in MONITOR_STRUCTURE:
+                if k is None:
+                    continue
                 B, N = data_blocks.get(k), new_blocks[k]
                 if len(N['data']) == 0:
                     del new_blocks[k]


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

- Redoes logic for mapping ACU field names into OCS feed block and field names.  This is clearer and includes some helpful log messages.
- Adds two new status blocks with some missing LAT info (pointing correction status and ACU Sun Avoidance)

## Motivation and Context

The current ACU agent won't run because of a missing entry in MONITOR_STRUCTURE.

Debugging that led to clearer code for navigating the map from ACU field name to OCS block / field name.

While debugging that, realized some missing fields from LAT ACU that we should probably be storing.

## How Has This Been Tested?

This is running at site now -- these changes are necessary since the current published ACU agent has a bug.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
