### PR TITLE
Add extra fields to tc400 drivers/agent acq function

### DIFF
--- a/socs/agents/pfeiffer_tc400/agent.py
+++ b/socs/agents/pfeiffer_tc400/agent.py
@@ -96,8 +96,16 @@ class PfeifferTC400Agent:
                 'timestamp': 1598626144.5365012,
                 'block_name': 'turbo_output',
                 'data': {
-                    "Turbo_Motor_Temp": 40.054,
-                    "Rotation_Speed": 823.655,
+                    "Drive_Voltage": 46.65,
+                    "Drive_Current": 3.02,
+                    "Drive_Power": 139.95,
+                    "Turbo_Power_Stage_Temp": 42,
+                    "Turbo_Electronics_Temp": 38,
+                    "Turbo_Pump_Bottom_Temp": 26,
+                    "Turbo_Bearing_Temp": 28,
+                    "Turbo_Motor_Temp": 32,
+                    "Rotation_Speed": 819,
+                    "Acceleration": 60,
                     "Error_Code": "Err001",
                 }
             }
@@ -120,9 +128,18 @@ class PfeifferTC400Agent:
                     }
 
                     try:
+                        data['data']["Drive_Voltage"] = self.turbo.get_turbo_drive_voltage()
+                        data['data']["Drive_Current"] = self.turbo.get_turbo_drive_current()
+                        data['data']["Drive_Power"] = self.turbo.get_turbo_drive_power()
+                        data['data']["Turbo_Power_Stage_Temp"] = self.turbo.get_turbo_power_stage_temperature()
+                        data['data']["Turbo_Electronics_Temp"] = self.turbo.get_turbo_electronic_temperature()
+                        data['data']["Turbo_Pump_Bottom_Temp"] = self.turbo.get_turbo_pump_bottom_temperature()
+                        data['data']["Turbo_Bearing_Temp"] = self.turbo.get_turbo_bearing_temperature()
                         data['data']["Turbo_Motor_Temp"] = self.turbo.get_turbo_motor_temperature()
                         data['data']["Rotation_Speed"] = self.turbo.get_turbo_actual_rotation_speed()
+                        data['data']["Acceleration"] = self.turbo.get_turbo_acceleration()
                         data['data']['Error_Code'] = self.turbo.get_turbo_error_code()
+
                     except ValueError as e:
                         self.log.error(f"Error in collecting data: {e}")
                         continue

--- a/socs/agents/pfeiffer_tc400/drivers.py
+++ b/socs/agents/pfeiffer_tc400/drivers.py
@@ -51,6 +51,110 @@ class PfeifferTC400:
 
         self.turbo_address = turbo_address
 
+    def get_turbo_drive_voltage(self):
+        """Gets the drive voltage supplied to the turbo controller.
+
+        Returns
+        -------
+        int
+            The drive voltage supplied to the turbo controller in Volts.
+        """
+
+        send_data_request(self.ser, self.turbo_address, 313)
+        addr, rw, param_num, drive_voltage = read_gauge_response(self.ser)
+
+        # The turbo response should be interpreted as having two decimal points
+        return float(drive_voltage) * 0.01
+
+    def get_turbo_drive_current(self):
+        """Gets the drive current supplied to the turbo controller.
+
+        Returns
+        -------
+        int
+            The drive current supplied to the turbo controller in Amps.
+        """
+
+        send_data_request(self.ser, self.turbo_address, 310)
+        addr, rw, param_num, drive_current = read_gauge_response(self.ser)
+
+        # The turbo response should be interpreted as having two decimal points
+        return float(drive_current) * 0.01
+
+    def get_turbo_drive_power(self):
+        """Gets the drive power supplied to the turbo controller.
+
+        Returns
+        -------
+        int
+            The drive power supplied to the turbo controller in Watts.
+        """
+
+        send_data_request(self.ser, self.turbo_address, 316)
+
+        addr, rw, param_num, drive_power = read_gauge_response(self.ser)
+
+        return float(drive_power)
+
+    def get_turbo_power_stage_temperature(self):
+        """Gets the temperatures of the turbo power stage from the turbo controller.
+
+        Returns
+        -------
+        int
+            The power temperature of the turbo in Celsius.
+        """
+
+        send_data_request(self.ser, self.turbo_address, 324)
+
+        addr, rw, param_num, power_stage_temp = read_gauge_response(self.ser)
+
+        return int(power_stage_temp)
+
+    def get_turbo_electronic_temperature(self):
+        """Gets the temperatures of the turbo electronics from the turbo controller.
+
+        Returns
+        -------
+        int
+            The electronics temperature of the turbo in Celsius.
+        """
+
+        send_data_request(self.ser, self.turbo_address, 326)
+
+        addr, rw, param_num, electronic_temp = read_gauge_response(self.ser)
+
+        return int(electronic_temp)
+
+    def get_turbo_pump_bottom_temperature(self):
+        """Gets the temperatures of the turbo pump bottom from the turbo controller.
+
+        Returns
+        -------
+        int
+            The pump bottom temperature of the turbo in Celsius.
+        """
+
+        send_data_request(self.ser, self.turbo_address, 330)
+
+        addr, rw, param_num, pump_bottom_temp = read_gauge_response(self.ser)
+
+        return int(pump_bottom_temp)
+
+    def get_turbo_bearing_temperature(self):
+        """Gets the temperatures of the turbo bearing from the turbo controller.
+
+        Returns
+        -------
+        int
+            The bearing temperature of the turbo in Celsius.
+        """
+
+        send_data_request(self.ser, self.turbo_address, 342)
+        addr, rw, param_num, bearing_temp = read_gauge_response(self.ser)
+
+        return int(bearing_temp)
+
     def get_turbo_motor_temperature(self):
         """Gets the temperatures of the turbo rotor from the turbo controller.
 
@@ -95,6 +199,21 @@ class PfeifferTC400:
         addr, rw, param_num, set_rotation_speed = read_gauge_response(self.ser)
 
         return int(set_rotation_speed)
+
+    def get_turbo_acceleration(self):
+        """Gets the current acceleration of the turbo from the turbo controller.
+
+        Returns
+        -------
+        int
+            The current acceleration of the turbo in rpm/s.
+        """
+
+        send_data_request(self.ser, self.turbo_address, 336)
+
+        addr, rw, param_num, acceleration = read_gauge_response(self.ser)
+
+        return int(acceleration)
 
     def get_turbo_error_code(self):
         """Gets the current error code of the turbo from the turbo controller.

--- a/socs/agents/pfeiffer_tc400/drivers.py
+++ b/socs/agents/pfeiffer_tc400/drivers.py
@@ -170,7 +170,7 @@ class PfeifferTC400:
         Returns
         -------
         bool
-            True for successful, False for failure.
+            False for successful, True for failure.
         """
 
         send_control_command(self.ser, self.turbo_address, 23, "000000")
@@ -180,7 +180,7 @@ class PfeifferTC400:
         if turbo_response not in PFEIFFER_BOOL:
             raise ValueError(f"Unrecognized response from turbo: {turbo_response}")
         else:
-            return turbo_response == "111111"
+            return turbo_response == "000000"
 
     def acknowledge_turbo_errors(self):
         """Acknowledges the turbo errors. This is analagous to clearing the errors.

--- a/socs/agents/pfeiffer_tc400/drivers.py
+++ b/socs/agents/pfeiffer_tc400/drivers.py
@@ -170,7 +170,7 @@ class PfeifferTC400:
         Returns
         -------
         bool
-            False for successful, True for failure.
+            True for successful, False for failure.
         """
 
         send_control_command(self.ser, self.turbo_address, 23, "000000")


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Added in query functions and fields for the tc400 turbo pump bearing, electronics, pump bottom, and power stage temperatures.
Added in query functions and fields for the tc400 drive voltage, current, and power.
Added in query functions and fields for the tc400 acceleration.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
This change adds in extra data fields that will help debug the TC400 temperatures as well as drive voltage+current+power in the future.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
I ran this agent on daq-dev and was able to read all fields with the correct data type and values for both the SATp1 and LAT turbo controllers.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
I've updated the doc strings for the agent acq function. (Is there extra documentation somewhere else that needs to be updated?)
