### PR TITLE
SRS CG635 Agent ValueError handling

### DIFF
--- a/socs/agents/srs_cg635/agent.py
+++ b/socs/agents/srs_cg635/agent.py
@@ -148,12 +148,18 @@ class SRSCG635Agent:
                     }
 
                     try:
-                        freq, stdc, runs, timb = self.clock.get_all_status()
-                        data['data']['Frequency'] = freq
-                        data['data']['Standard_CMOS_Output'] = stdc
-                        data['data']['Running_State'] = runs
-                        data['data']['Timebase'] = timb
-
+                        try:
+                            freq, stdc, runs, timb = self.clock.get_all_status().split(';')
+                            data['data']['Frequency'] = float(freq)
+                            data['data']['Standard_CMOS_Output'] = int(stdc)
+                            data['data']['Running_State'] = int(runs)
+                            data['data']['Timebase'] = int(timb)
+                        except ValueError:
+                            self.clock.clear()
+                            data['data']['Frequency'] = self.clock.get_freq()
+                            data['data']['Standard_CMOS_Output'] = self.clock.get_stdc()
+                            data['data']['Running_State'] = self.clock.get_runs()
+                            data['data']['Timebase'] = self.clock.get_timebase()
                     except socket.timeout as e:
                         self.log.error(f"Timeout in retrieving clock data: {e}")
                         self.clock = None

--- a/socs/agents/srs_cg635/agent.py
+++ b/socs/agents/srs_cg635/agent.py
@@ -148,18 +148,11 @@ class SRSCG635Agent:
                     }
 
                     try:
-                        try:
-                            freq, stdc, runs, timb = self.clock.get_all_status().split(';')
-                            data['data']['Frequency'] = float(freq)
-                            data['data']['Standard_CMOS_Output'] = int(stdc)
-                            data['data']['Running_State'] = int(runs)
-                            data['data']['Timebase'] = int(timb)
-                        except ValueError:
-                            self.clock.clear()
-                            data['data']['Frequency'] = self.clock.get_freq()
-                            data['data']['Standard_CMOS_Output'] = self.clock.get_stdc()
-                            data['data']['Running_State'] = self.clock.get_runs()
-                            data['data']['Timebase'] = self.clock.get_timebase()
+                        freq, stdc, runs, timb = self.clock.get_all_status()
+                        data['data']['Frequency'] = freq
+                        data['data']['Standard_CMOS_Output'] = stdc
+                        data['data']['Running_State'] = runs
+                        data['data']['Timebase'] = timb
                     except socket.timeout as e:
                         self.log.error(f"Timeout in retrieving clock data: {e}")
                         self.clock = None

--- a/socs/agents/srs_cg635/drivers.py
+++ b/socs/agents/srs_cg635/drivers.py
@@ -84,7 +84,12 @@ class SRSCG635Interface(PrologixInterface):
         self.write("FREQ?;STDC?;RUNS?;TIMB?")
         output = self.read()
 
-        return output
+        try:
+            freq, stdc, runs, timb = output.split(';')
+            return float(freq), int(stdc), int(runs), int(timb)
+        except ValueError:
+            self.clear()
+            return self.get_freq(), self.get_stdc(), self.get_runs(), self.get_timebase()
 
     def clear(self):
         """Clear all the event registers and error queue."""

--- a/socs/agents/srs_cg635/drivers.py
+++ b/socs/agents/srs_cg635/drivers.py
@@ -82,9 +82,9 @@ class SRSCG635Interface(PrologixInterface):
 
     def get_all_status(self):
         self.write("FREQ?;STDC?;RUNS?;TIMB?")
-        freq, stdc, runs, timb = self.read().split(';')
+        output = self.read()
 
-        return float(freq), int(stdc), int(runs), int(timb)
+        return output
 
     def clear(self):
         """Clear all the event registers and error queue."""


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Add ValueError handling to agent process. Attempts calling the individual driver functions individually if the combined function fails.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Error found when agent deployed to site.
Traceback from Loki logs:
```
2025-08-04 21:32:46.270	
2025-08-04T21:32:46+0000 acq:1 CRASH: [Failure instance: Traceback: <class 'ValueError'>: not enough values to unpack (expected 4, got 3)
2025-08-04 21:32:46.270	
/opt/venv/lib/python3.10/site-packages/twisted/python/threadpool.py:269:inContext
2025-08-04 21:32:46.270	
/opt/venv/lib/python3.10/site-packages/twisted/python/threadpool.py:285:<lambda>
2025-08-04 21:32:46.270	
/opt/venv/lib/python3.10/site-packages/twisted/python/context.py:117:callWithContext
2025-08-04 21:32:46.270	
/opt/venv/lib/python3.10/site-packages/twisted/python/context.py:82:callWithContext
2025-08-04 21:32:46.270	
/opt/venv/lib/python3.10/site-packages/ocs/ocs_agent.py:984:_running_wrapper
2025-08-04 21:32:46.270	
/opt/venv/lib/python3.10/site-packages/socs/agents/srs_cg635/agent.py:151:acq
2025-08-04 21:32:46.270	
/opt/venv/lib/python3.10/site-packages/socs/agents/srs_cg635/drivers.py:85:get_all_status
2025-08-04 21:32:46.270	
]
2025-08-04 21:32:46.270	
2025-08-04T21:32:46+0000 acq:1 Status is now "done".
```
The process had ran fine for about an hour, then this error occurred seemingly randomly. I assume something finicky happened when trying to read 4 registers at the same time, so this fix adds the fallback of reading the 4 registers separately.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
