### PR TITLE
wg-actuator: Fix limit switch issue at extreme boresight angles

### DIFF
--- a/socs/agents/wiregrid_actuator/agent.py
+++ b/socs/agents/wiregrid_actuator/agent.py
@@ -242,10 +242,11 @@ class WiregridActuatorAgent:
             self.log.error(msg)
             return False, msg
 
-        # Additional small moving to ensure the limit switch ON
-        # No limit switch check during this moving
-        # Only this function reflects pos/neg of <distance>.
-        # Please use +/- distance for insertion/ejection, respectively.
+        # Additional small move to ensure the limit switch ON
+        # No limit switch check during this move
+        # `self.actuator.move()` preserves the sign of `distance`.
+        # In contrast, `move_func()` sets the sign automatically based on `is_insert`.
+        # Pass a positive distance for insertion and a negative distance for ejection.
         ret = self.actuator.move(0.5 * (1. if is_insert else -1.), speedrate=0.2)
         if not ret:
             msg = '_insert_eject(): ERROR!:'\


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
To avoid limit switch issue, modify the `wiregrid_actuator/agent.py` and add additional small (0.5mm) moving after the insertion and ejection.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
There is a known issue that the outside limit switch turns OFF right after ejection, probably due to the gravity force of the wiregrid rotator at boresight=-45deg.
To avoid it, I added an additional small movement (0.5 mm) at the last step of the insertion and ejection to ensure that the limit switch is ON.
The limit switch lever has a 1.1 mm margin in the ON condition. So, the 0.5 mm additional movement is no problem for the limit switch.
(The limit switch: Omron D2JW-01K31-MD)
<img width="456" height="256" alt="image" src="https://github.com/user-attachments/assets/8caaa608-0f65-4977-b080-cf2bce8299bf" />


## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
Need the operation test at the site to check if the insert/eject works as expected.
Run insert/eject several times at SATp1 at boresight = 0, -45, +45, and check the limit switch turns ON as expected.
El should be the nominal elevation (60 deg).

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
