### PR TITLE
Fix wiregrid tiltsensor recursion error / Update tiltsensor agent to reconnect to the sensor automatically

### DIFF
--- a/socs/agents/wiregrid_tiltsensor/drivers/dwl.py
+++ b/socs/agents/wiregrid_tiltsensor/drivers/dwl.py
@@ -27,7 +27,7 @@ class DWL:
 
     def __del__(self):
         print(f"Disconnecting from TCP IP {self.tcp_ip} at port {self.tcp_port}")
-        self.ser.close()
+        self.ser.sock.close()
         return
 
     def get_angle(self):
@@ -57,7 +57,7 @@ class DWL:
             if self.isSingle:
                 val = (-999)
             else:
-                val = (-999, 999)
+                val = (-999, -999)
             return msg, val
 
         # check header matching and calculate the angles

--- a/socs/agents/wiregrid_tiltsensor/drivers/sherborne.py
+++ b/socs/agents/wiregrid_tiltsensor/drivers/sherborne.py
@@ -35,7 +35,7 @@ class Sherborne:
 
     def __del__(self):
         print(f"Disconnecting from TCP IP {self.tcp_ip} at port {self.tcp_port}")
-        self.ser.close()
+        self.ser.sock.close()
         return
 
     def get_angle(self):

--- a/socs/common/moxa_serial.py
+++ b/socs/common/moxa_serial.py
@@ -1,3 +1,5 @@
+# 9/2025 Shun
+# Change all BaseExeption --> TimeoutError
 # 4/2009 BAS
 #  read() replicates behavior of pyserial
 #  readexactly() added, which is probably more useful
@@ -87,7 +89,7 @@ class Serial_TCPServer(object):
             self.settimeout(newtimeout)
             try:
                 msg = self.sock.recv(n, socket.MSG_PEEK)
-            except BaseException:
+            except (TimeoutError, BlockingIOError):
                 pass
         # Flush the message out if you got everything
         if len(msg) == n:
@@ -114,7 +116,7 @@ class Serial_TCPServer(object):
         try:
             for i in range(n):
                 msg += self.sock.recv(1)
-        except BaseException:
+        except (TimeoutError, BlockingIOError):
             pass
         self.sock.setblocking(1)  # belt and suspenders
         self.settimeout(self.__timeout)
@@ -132,9 +134,9 @@ class Serial_TCPServer(object):
             return ''
         try:
             msg = self.sock.recv(n)
-        except BaseException:
+        except (TimeoutError, BlockingIOError):
             msg = ''
-        n2 = min(n - len(msg), n / 2)
+        n2 = min(n - len(msg), (int)(n / 2))
         return msg + self.readbuf(n2)
 
     def readpacket(self, n):
@@ -147,7 +149,7 @@ class Serial_TCPServer(object):
         """
         try:
             msg = self.sock.recv(n)
-        except BaseException:
+        except (TimeoutError, BlockingIOError):
             msg = ''
         return msg
 
@@ -221,7 +223,7 @@ class Serial_TCPServer(object):
         try:
             while len(self.sock.recv(1)) > 0:
                 pass
-        except BaseException:
+        except (TimeoutError, BlockingIOError):
             pass
         self.sock.setblocking(1)
         self.sock.settimeout(self.__timeout)


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
- Change the `socs/common/moxa_serial.py` to have better error handle
- Change the wiregrid tilt-sensor agent to reconnect to the sensor automatically if the read data is wrong.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
The change to the `moxa_serial.py` is related to the issue: #891 
The change to the tilt-sensor agent is useful to recover from network disconnection automatically.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
I ran the updated agent in SATp1 on 10th Sept.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
