### PR TITLE
Add missing params to SMuRF file emulator tasks

### DIFF
--- a/socs/agents/smurf_file_emulator/agent.py
+++ b/socs/agents/smurf_file_emulator/agent.py
@@ -558,6 +558,7 @@ class SmurfFileEmulator:
         return True, "Wrote tune files"
 
     @ocs_agent.param('wait', default=True)
+    @ocs_agent.param('kwargs', default=None)
     @ocs_agent.param('tag', default=None)
     def take_iv(self, session, params=None):
         """take_iv(wait=True, tag=None)
@@ -568,6 +569,9 @@ class SmurfFileEmulator:
             wait (bool, optional):
                 If true, will wait for the 5 seconds where fake IV data is
                 generated
+            kwargs : dict
+                Additional kwargs to pass to the ``take_iv`` function.
+                Ignored in the emulator.
             tag (str, optional):
                 User tag to add to the g3 stream.
         """
@@ -662,8 +666,10 @@ class SmurfFileEmulator:
         return True, 'Wrote det biasing files'
 
     @ocs_agent.param('duration', default=None)
+    @ocs_agent.param('kwargs', default=None)
     @ocs_agent.param('use_stream_between', default=False, type=bool)
     @ocs_agent.param('start_offset', default=0, type=float)
+    @ocs_agent.param('subtype', default=None)
     @ocs_agent.param('tag', default=None)
     def stream(self, session, params):
         """stream(duration=None, use_stream_between=False, start_offset=0, tag=None)
@@ -678,6 +684,9 @@ class SmurfFileEmulator:
         Parameters:
             duration (float, optional):
                 If set, will stop stream after specified amount of time (sec).
+            kwargs : dict
+                A dictionary containing additional keyword arguments to pass.
+                Ignored by the emulator.
             use_stream_between (bool, optional):
                 If True, will use the DataStreamer's `stream_between` function
                 instead of writing frames one at a time. This allows you to write
@@ -686,6 +695,8 @@ class SmurfFileEmulator:
                 If set, this will add an offset to the start time passed to the
                 `stream_between` function, allowing you to create offsets between
                 streams taken at the same time.
+            subtype : string, optional
+                Operation subtype used to tag the stream. Ignored by the emulator.
             tag (str, optional):
                 User tag to add to the g3 stream.
         """


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
This adds a few missing parameters to the SMuRF File Emulator which have been added to the pysmurf-controller agent since this was last updated. We accept the parameters, but don't do anything with them. This may not be totally valid, but it at least lets me run a schedule without error to test functionality unrelated to the actual emulated data.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
I was trying to test error handling in sorunlib and was running copies of real schedules run at site and needed these parameters added to do that.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
A copy of a real schedule was run on a local instance with two SMuRF File Emulators and an ACU simulator, as described in https://github.com/simonsobs/sorunlib/pull/232.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
