### PR TITLE
Add three_leg_turnaround to ACU agent

### DIFF
--- a/socs/agents/acu/agent.py
+++ b/socs/agents/acu/agent.py
@@ -2031,6 +2031,8 @@ class ACUAgent:
     @ocs_agent.param('az_drift', type=float, default=None)
     @ocs_agent.param('az_only', type=bool, default=True)
     @ocs_agent.param('type', default=1, choices=[1, 2, 3])
+    @ocs_agent.param('turnaround_method', default=None,
+                     choices=[None, 'three_leg'])
     @ocs_agent.param('az_vel_ref', type=float, default=1)
     @ocs_agent.param('scan_upload_length', type=float, default=None)
     @inlineCallbacks
@@ -2098,6 +2100,12 @@ class ACUAgent:
                 of uploaded points. If this is not specified, the
                 track manager will try to use as short a time as is
                 reasonable.
+            turnaround_method (str): The method used for generating turnaround.
+                Default (None) generates the baseline minimal jerk trajectory.
+                'three_leg' generates a three-leg turnaround which attempts to
+                minimize the acceleration at the midpoint of the turnaround.
+                Type 2 and 3 scans will ALWAYS use the baseline turnaround method
+                regardless of selection.
 
         Notes:
           Note that all parameters are optional except for

--- a/socs/agents/acu/drivers.py
+++ b/socs/agents/acu/drivers.py
@@ -6,6 +6,7 @@ import time
 from dataclasses import dataclass, replace
 
 import numpy as np
+import socs.agent.acu.three_leg_turnaround as three_leg_tr
 
 #: The number of seconds in a day.
 DAY = 86400
@@ -295,7 +296,8 @@ def generate_constant_velocity_scan(az_endpoint1, az_endpoint2, az_speed,
                                     batch_size=500,
                                     az_start='mid_inc',
                                     az_first_pos=None,
-                                    az_drift=None):
+                                    az_drift=None,
+                                    turnaround_method=None):
     """Python generator to produce times, azimuth and elevation positions,
     azimuth and elevation velocities, azimuth and elevation flags for
     arbitrarily long constant-velocity azimuth scans.
@@ -337,8 +339,12 @@ def generate_constant_velocity_scan(az_endpoint1, az_endpoint2, az_speed,
             start at this position (but otherwise proceed in the same
             starting direction).
         az_drift (float): The rate (deg / s) at which to shift the
-            scan endpoints in time.  This can be used to better track
+            scan endpoints i n time.  This can be used to better track
             celestial sources in targeted scans.
+        turnaround_method (str): The method used for generating turnaround.
+            Default (None) generates the baseline minimal jerk trajectory.
+            'three_leg' generates a three-leg turnaround which attempts to
+            minimize the acceleration at the midpoint of the turnaround.
 
     Yields:
         points (list): a list of TrackPoint objects.  Raises
@@ -413,10 +419,15 @@ def generate_constant_velocity_scan(az_endpoint1, az_endpoint2, az_speed,
     point_group_batch = 0
 
     i = 0
+    point_queue = []
     while i < stop_iter and check_num_scans():
         i += 1
         point_block = []
         for j in range(batch_size):
+            if len(point_queue):  # Pull from points in the queue first
+                point_block.append(point_queue.pop(0))
+                continue
+
             point_block.append(TrackPoint(
                 timestamp=t + t0,
                 az=az, el=el, az_vel=az_vel, el_vel=el_vel,
@@ -436,6 +447,14 @@ def generate_constant_velocity_scan(az_endpoint1, az_endpoint2, az_speed,
                     el_flag = 0
                 elif az == target_az:
                     # Turn around.
+                    if turnaround_method is not None and turnaround_method == "three_leg":
+                        turnaround_track = three_leg_tr.gen_three_leg_turnaround(t0=t + t0, az0=az, el0=el, v0=az_vel,
+                                                                                 turntime=turntime,
+                                                                                 az_flag=az_flag, el_flag=el_flag,
+                                                                                 point_group_batch=point_group_batch)
+                        for track_point in turnaround_track:
+                            point_queue.append(track_point)  # Add the TrackPoints from the turnaround into the queue.
+
                     t += turntime
                     az_vel = -1 * az_speed
                     el_vel = el_speed
@@ -463,6 +482,14 @@ def generate_constant_velocity_scan(az_endpoint1, az_endpoint2, az_speed,
                     el_flag = 0
                 elif az == target_az:
                     # Turn around.
+                    if turnaround_method is not None and turnaround_method == "three_leg":
+                        turnaround_track = three_leg_tr.gen_three_leg_turnaround(t0=t + t0, az0=az, el0=el, v0=az_vel,
+                                                                                 turntime=turntime,
+                                                                                 az_flag=az_flag, el_flag=el_flag,
+                                                                                 point_group_batch=point_group_batch)
+                        for track_point in turnaround_track:
+                            point_queue.append(track_point)  # Add the TrackPoints from the turnaround into the queue.
+
                     t += turntime
                     az_vel = az_speed
                     el_vel = el_speed

--- a/socs/agents/acu/three_leg_turnaround.py
+++ b/socs/agents/acu/three_leg_turnaround.py
@@ -1,0 +1,234 @@
+import numpy as np
+
+
+def gen_3leg_turnaround(t0, az0, el0, v0, turntime, az_flag, el_flag, point_group_batch,
+                        second_leg_time=None, second_leg_velocity=0, step_time=0.1):
+    from .drivers import TrackPoint
+    """
+    Generates the trajectory of a 3part turnaround given the initial position and velocity of the platform.
+    This function generates a turnaround in three "legs":
+
+        1. The initial deceleration.
+        2. The middle leg with a low velocity/acceleration to gently turn the gears of the motors around so
+           they contact the other face of the bearing with minimal force. The default velocity and acceleration
+           is 0 so the platform comes to a full stop in this leg by a default.
+        3. The final acceleration to the scan velocity in the opposite direction.
+
+    The turnaround time of this function adheres to the same equation as the "baseline" turnaround function:
+
+        turntime = (2.0 * scan_velocity) / scan_acceleration
+
+    Thus, for the same scan velocity and scan acceleration this turnaround will take the same time as the baseline.
+
+    Args:
+        t0 (float): The initial time of the turnaround.
+        az0 (float): The iniital azimuth position of the turnaround. Should be equal to the final azimuth position of the turnaround.
+        el0 (float): The initial elevation of the turnaround. El velocity is forced to 0 here so this is only used for creating TrackPoints.
+        v0 (float): The initial azimuth velocity of the turnaround.
+        turntime (float): The turnaround time given by the above equation.
+        az_flag (int): The az flag used by the ACU. Inherited from the scan generation function and not changed. Used for TrackPoints.
+        el_flag (int): The el flag used by the ACU. Inherited from the scan generation function and not changed. Used for TrackPoints.
+        point_group_batch (int): the point group batch used by the ACU. Inherited from the scan generation function and not changed. Used for TrackPoints.
+        second_leg_time (float): The time used by the second leg of the turnaround. Defaults to 1 second.
+                               This limits the minimum turnaround time to ~2.0 seconds!
+        second_leg_velocity (float): The velocity targeted by the beginning/end of the second leg of the turnaround. Defaults to 0 deg/s.
+                                   second_leg acceleration = 2.0 * second_leg_velocity / second_leg_time.
+        step_time (float): The step time between points in the turnaround. Defaults to 0.1 seconds (10Hz).
+    """
+
+    # Enforce 0 el velocity. Can be changed later if these want to be used with type2 or type3 LAT scans,
+    # but more work is necessary to get to that point. We shouldn't mix the two yet!
+    el_vel = 0.
+
+    if second_leg_time is None:
+        second_leg_time = turntime / 3.0  # Cut the turnaround into equal thirds unless otherwise specified.
+    second_leg_acceleration = 2.0 * second_leg_velocity / second_leg_time
+
+    # Assert we have at least 0.5 seconds for the first and second legs of the turnaround!
+    # This limits the turntime to >= 1.5 seconds
+    assert (turntime - second_leg_time) >= 1.0, \
+           "Time for the second leg of the turnaround is too long! The time remaining for the first and third legs is < 1.0 seconds!"
+
+    # Solve for the first leg of the turnaround
+    t_start_1 = 0  # We have to solve the trajectory around 0 or the linear equations become very large. Add t back on later
+    t_target_1 = t_start_1 + (turntime - second_leg_time) / 2  # The first and third legs share the same portion of the turnaround time.
+    az_start_1 = az0
+    v_start_1 = v0
+    v_target_1 = second_leg_velocity * np.sign(v_start_1)
+    a_start_1 = 0
+    a_target_1 = second_leg_acceleration * -1 * np.sign(v0)
+    j_start_1 = 0  # We always target a jerk of 0 at the beginning and end of turnaround legs.
+    j_target_1 = 0
+    ts_1, azs_1, vs_1 = _gen_trajectory(t_start_1, t_target_1, az_start_1,
+                                        v_start_1, v_target_1, a_start_1,
+                                        a_target_1, j_start_1, j_target_1,
+                                        step_time)
+
+    # Solve for the second leg of the turnaround
+    t_start_2 = t_target_1
+    t_target_2 = t_start_2 + second_leg_time
+    az_start_2 = azs_1[-1]  # The acceleration of the beggining of the next turnaround leg should always match the end of the last leg.
+    v_start_2 = v_target_1
+    v_target_2 = v_start_2 * -1
+    a_start_2 = a_target_1
+    a_target_2 = a_start_2
+    j_start_2 = 0
+    j_target_2 = 0
+    ts_2, azs_2, vs_2 = _gen_trajectory(t_start_2, t_target_2, az_start_2,
+                                        v_start_2, v_target_2, a_start_2,
+                                        a_target_2, j_start_2, j_target_2,
+                                        step_time)
+
+    # Solve for the third leg of the turnaround
+    t_start_3 = t_target_2
+    t_target_3 = t_start_3 + (turntime - second_leg_time) / 2.0
+    az_start_3 = azs_2[-1]
+    v_start_3 = v_target_2
+    v_target_3 = v0 * -1
+    a_start_3 = a_target_2
+    a_target_3 = 0
+    j_start_3 = 0
+    j_target_3 = 0
+    ts_3, azs_3, vs_3 = _gen_trajectory(t_start_3, t_target_3, az_start_3,
+                                        v_start_3, v_target_3, a_start_3,
+                                        a_target_3, j_start_3, j_target_3,
+                                        step_time)
+
+    # Concatenate the times, azimuth positions, and azimuth velocities together.
+    # The first point of each leg is a duplicate of the last so we drop those points.
+    ts = np.concatenate([ts_1[1:], ts_2[1:], ts_3[1:]]) + t0
+    azs = np.concatenate([azs_1[1:], azs_2[1:], azs_3[1:]])
+    vs = np.concatenate([vs_1[1:], vs_2[1:], vs_3[1:]])
+
+    # Turn our turnaround solution into TrackPoint's for the ACU.
+    turnaround_track = []
+    for t, az, v in zip(ts, azs, vs):
+        turnaround_track.append(TrackPoint(timestamp=t,
+                                az=az, el=el0, az_vel=v, el_vel=el_vel,
+                                az_flag=az_flag, el_flag=el_flag,
+                                group_flag=int(point_group_batch > 0)))
+
+    return turnaround_track
+
+
+def _gen_trajectory(t_i, t_f, xn1_i, x0_i, x0_f, x1_i, x1_f, x2_i, x2_f, step_time):
+    """
+    Generally, generates the trajectory that minimizes the third derivative of the parameter defined by x0.
+
+    In the context of this module, this function is used to generate the legs of the 3part turnaround in a way that
+    minimizes the snap of the motion. Because we don't know the final positions of each of the legs we must
+    generate the trajectories using the initial and final velocity, acceleration, and jerk, which minimizes the snap.
+
+    In this context, x0 is the function of velocity, x1 is acceleration, x2 is jerk, and xn1 is position.
+
+    Args:
+        t_i (float): The initial time of the trajectory.
+        t_f (float): The final time of the trajectory.
+        xn1_i (float): The initial position.
+        x0_i (float): The initial velocity.
+        x0_f (float): The final velocity.
+        x1_i (float): The initial acceleration.
+        x1_f (float): The final acceleration.
+        x2_i (float): The initial jerk.
+        x2_f (float): The final jerk.
+
+    Returns:
+        ts (float array): A numpy array of timestamps.
+        xs (float array): A numpy array of azimuth positions.
+        vs (float array): A numpy array of azimuth velocities.
+    """
+
+    # Solve for the polynomial components that fits our initial and final conditions
+    A = solve_fifth_polynomial_lin_eqs(t_i, t_f, x0_i, x0_f, x1_i, x1_f, x2_i, x2_f)
+
+    ts = np.arange(t_i, t_f + step_time, step_time)  # Divide our times into points with step_time spacing
+    vs = x0(ts, *A)  # Solve for the velocity at every time using our solved components
+
+    xs = xn1(ts, 0, *A)
+    xs = xs - xs[0] + xn1_i  # Solve for the positions of each point
+
+    return ts, xs, vs
+
+
+# Linear Algebra Below
+def solve_fifth_polynomial_lin_eqs(t_i, t_f, x0_i, x0_f, x1_i, x1_f, x2_i, x2_f):
+    """
+    Solves for the components of a polynomial equation of order five the form:
+
+        x0 = A0 + A1*x + A2*x^2 + A3*x^3 + A4*x^4 + A5*a^5,
+
+    given the initial/final conditions of the 0th, 1st, and 2nd derivatives.
+
+    This solution minimizes the third derivative over the trajectory between t_i and t_f.
+
+    Args:
+        t_i (float): starting time
+        t_f (float): stop time
+        x0_i (float): initial 0th derivative condition
+        x0_f (float): final 0th derivative condition
+        x1_i (float): initial 1st derivative condition
+        x1_f (float): final 1st derivative condition
+        x2_i (float): initial 2nd derivative condition
+        x2_f (float): initial 2nd derivative condition
+
+    Returns:
+        A0 (float): The solved 0th parameter of the order five polynomial.
+        A1 (float): The solved 1st parameter of the order five polynomial.
+        A2 (float): The solved 2nd parameter of the order five polynomial.
+        A3 (float): The solved 3rd parameter of the order five polynomial.
+        A4 (float): The solved 4th parameter of the order five polynomial.
+        A5 (float): The solved 5th parameter of the order five polynomial.
+    """
+
+    x0 = [1, 1, 1, 1, 1, 1]
+    x1 = [0, 1, 2, 3, 4, 5]
+    x2 = [0, 0, 2, 6, 12, 20]
+
+    A = np.zeros((6, 6))
+    for i, x in enumerate([x0, x1, x2]):
+        for j, y in enumerate(x):
+            if j < i:
+                continue
+
+            A[2 * i, j] = y * t_i**(j - i)
+            A[2 * i + 1, j] = y * t_f**(j - i)
+
+    B = np.zeros(6)
+    B[0] = x0_i
+    B[1] = x0_f
+    B[2] = x1_i
+    B[3] = x1_f
+    B[4] = x2_i
+    B[5] = x2_f
+
+    return np.linalg.solve(A, B)
+
+
+def xn1(t, an1, a0, a1, a2, a3, a4, a5):
+    """
+    Returns the solution to the first anti-derivative of the order five polynomial given its solved parameters and a given time.
+
+    Args:
+        t (float): The time of the desired solution. This should probably stay within the original given time bounds of the solution.
+        an1-a5 (floats): The solved parameters of the order five polynomial from `solve_fifth_polynomial_lin_eqs` and `get_an1`.
+
+    Returns:
+        xn1(t) (float): The solution of the first anti-derivative of the order five polynomial equation calculated at time t.
+    """
+
+    return an1 + a0 * t + (1 / 2) * a1 * t**2 + (1 / 3) * a2 * t**3 + (1 / 4) * a3 * t**4 + (1 / 5) * a4 * t**5 + (1 / 6) * a5 * t**6
+
+
+def x0(t, a0, a1, a2, a3, a4, a5):
+    """
+    Returns the solution to the order five polynomial given its solved parameters and a given time.
+
+    Args:
+        t (float): The time of the desired solution. This should probably stay within the original given time bounds of the solution.
+        a0-a5 (floats): The solved parameters of the order five polynomial from `solve_fifth_polynomial_lin_eqs` and `get_an1`.
+
+    Returns:
+        x0(t) (float): The solution of the order five polynomial equation calculated at time t.
+    """
+
+    return a0 + a1 * t + a2 * t**2 + a3 * t**3 + a4 * t**4 + a5 * t**5


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Starting a new PR and closing #930  because the commit that added in type2 and type3 scans diverged my branch in a way I didn't want to spend the time to figure out how to fix.

I've added in a new python file to generate three leg turnarounds and modified the generate_constant_velocity_scan in the ACU drivers.py to accept the new turnaround function.

## Description
This function is the implementation of the three part turnarounds discussed on last weeks SAT Analysis call.
This turnaround function breaks the turnarounds into three "legs":

The initial deceleration.
The middle portion with a gentle/zero velocity acceleration to allow the motor gears to change direction and come in contact with the opposite azimuth bearing face more gently.
The final acceleration to the scan velocity.
This should hopefully make the turnarounds more gentle for the SATs.

I've written the default behavior of this turnaround to split the time for the three legs evenly now instead of hard coding the second leg to be 1 second. This may change the behavior slightly but that lowers the minimum turnaround time.

## Motivation and Context
This implements the new three leg turnarounds for the SATs that have shown improvements to the FPA temps during turnarounds.

## How Has This Been Tested?
These turnarounds have been tested on SATp1 multiple times. We should probably test that this specific implementation of the constant_velocity_scan generator function works!

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
