### PR TITLE
fix: compute az center correctly

### DIFF
--- a/socs/agents/acu/drivers.py
+++ b/socs/agents/acu/drivers.py
@@ -572,7 +572,7 @@ def generate_type3_scan(az_endpoint1, az_endpoint2, az_speed,
 
     # Get center of az range
     if az_vel_ref is None:
-        az_vel_ref = (az_endpoint1 + az_endpoint1) / 2.
+        az_vel_ref = (az_endpoint1 + az_endpoint2) / 2.
     az_cent = az_vel_ref - 90
 
     # Get el throw


### PR DESCRIPTION
Bugfix on type 2/3 scans where the az center was computed wrong

## Description
Compute az center with both endpoints instead of one

## Motivation and Context
Without this you cannot run scans unless you pass an explicit az ref.

## How Has This Been Tested?
Tested with scans last night

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
