### PR TITLE
device_emulator: Add docstring for socket_port attribute and explain port 0

### DIFF
--- a/socs/testing/device_emulator.py
+++ b/socs/testing/device_emulator.py
@@ -25,7 +25,8 @@ def create_device_emulator(responses, relay_type, port=9001, encoding='utf-8',
             values. See :class:`.DeviceEmulator` for details.
         relay_type (str): Communication relay type. Either 'serial' or 'tcp'.
         port (int): Port for the TCP relay to listen for connections on.
-            Defaults to 9001. Only used if relay_type is 'tcp'.
+            Defaults to 9001. Using port 0 will randomly select an available
+            port. Only used if relay_type is 'tcp'.
         encoding (str): Encoding for the messages and responses. See
             :func:`socs.testing.device_emulator.DeviceEmulator` for more
             details.
@@ -82,6 +83,8 @@ class DeviceEmulator:
             Defaults to None.
         encoding (str): Encoding for the messages and responses, set by the
             encoding argument.
+        socket_port (int): Port that the DeviceEmulator is listening on if
+            using the 'tcp' relay.
         _type (str): Relay type, either 'serial' or 'tcp'.
         _read (bool): Used to stop the background reading of data recieved on
             the relay.


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
This PR adds a missing docstring for the `socket_port` attribute, and explains the port 0 behavior.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
This was mostly the difference from #643 after #802, which implemented similar functionality.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
No tests, just a docstring change.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
