### PR TITLE
Fix recursion error in moxa_serial module

### DIFF
--- a/socs/common/moxa_serial.py
+++ b/socs/common/moxa_serial.py
@@ -89,6 +89,9 @@ class Serial_TCPServer(object):
                 msg = self.sock.recv(n, socket.MSG_PEEK)
             except (TimeoutError, BlockingIOError):
                 pass
+            except Exception as e:
+                print(f"Caught unexpected {type(e).__name__} exception:")
+                print(f"  {e}")
         # Flush the message out if you got everything
         if len(msg) == n:
             if self.encoded:
@@ -116,6 +119,9 @@ class Serial_TCPServer(object):
                 msg += self.sock.recv(1)
         except (TimeoutError, BlockingIOError):
             pass
+        except Exception as e:
+            print(f"Caught unexpected {type(e).__name__} exception:")
+            print(f"  {e}")
         self.sock.setblocking(1)  # belt and suspenders
         self.settimeout(self.__timeout)
         return msg
@@ -137,6 +143,10 @@ class Serial_TCPServer(object):
                 msg_current = self.sock.recv(n)
             except (TimeoutError, BlockingIOError):
                 msg_current = b''
+            except Exception as e:
+                print(f"Caught unexpected {type(e).__name__} exception:")
+                print(f"  {e}")
+                msg_current = b''
             msg += msg_current
             n_current -= len(msg_current)
 
@@ -153,6 +163,10 @@ class Serial_TCPServer(object):
         try:
             msg = self.sock.recv(n)
         except (TimeoutError, BlockingIOError):
+            msg = ''
+        except Exception as e:
+            print(f"Caught unexpected {type(e).__name__} exception:")
+            print(f"  {e}")
             msg = ''
         return msg
 
@@ -228,6 +242,9 @@ class Serial_TCPServer(object):
                 pass
         except (TimeoutError, BlockingIOError):
             pass
+        except Exception as e:
+            print(f"Caught unexpected {type(e).__name__} exception:")
+            print(f"  {e}")
         self.sock.setblocking(1)
         self.sock.settimeout(self.__timeout)
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
This PR contains the relevant changes originally from #924 to the issue described in #891.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Resolves #891.

Split since this has potential impact on more than just the wiregrid agents and I'd like to keep it separated from the reconnection handling work in #924.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
This, along with the changes in #924, was run with the wiregrid tiltsensor agent. Tests have not been done on other agents that use the `moxa_serial` module, such as the PMX agents.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
