### PR TITLE
Fix to IRIG timing bug

### DIFF
--- a/socs/agents/hwp_encoder/agent.py
+++ b/socs/agents/hwp_encoder/agent.py
@@ -96,12 +96,12 @@ def de_irig(val, base_shift=0):
     val : int
        raw IRIG bit info of each 100msec chunk
     base_shift : int, optional
-       number of bit shifts. This should be 0 except for seccods
+       number of bit shifts. This should be 0 except for seconds
 
     Returns
     -------
     int
-       Either of sec/min/hourds/day/year
+       Either of sec/min/hours/day/year
 
     """
     return (((val >> (0 + base_shift)) & 1)
@@ -111,7 +111,7 @@ def de_irig(val, base_shift=0):
             + ((val >> (5 + base_shift)) & 1) * 10
             + ((val >> (6 + base_shift)) & 1) * 20
             + ((val >> (7 + base_shift)) & 1) * 40
-            + ((val >> (8 + base_shift)) & 1) * 80)
+            + ((val >> (8 + base_shift)) & 1) * 80 * (base_shift == 0))
 
 
 def count2time(counts, t_offset=0.):


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Fixes a bug in which the IRIG second value is wrong every other value by 80 seconds

## Description
<!--- Describe your changes in detail -->
There is a specific decoding function used to read the individual bits in the raw IRIG data. For the "seconds" value specifically, there is a bit shift which causes the decode function to look at a bit which is never explicitly set to a value. This bit can sometimes get stuck as a 1 when it is normally a 0, causing the second reading to be off by 80. The fix adds logic so that this bit should not contribute to the returned value in the "seconds" case only.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
When this issue occurs the HWP timing data is unusable without a correction. For some reason SATp2 has this bug occur fairly frequently, but it has been observed on the other SATs as well

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
I implemented this change on one of the two encoders for SATp2 and then waited for the bug to happen. On the encoder with this update the IRIG time remained at it's expected value.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
