### PR TITLE
pysmurf-controller: Allow versioneer to determine sodetlib version safely

### DIFF
--- a/docker/pysmurf_controller/Dockerfile
+++ b/docker/pysmurf_controller/Dockerfile
@@ -5,6 +5,10 @@ FROM simonsobs/so_smurf_base:v0.0.6
 #################################################################
 WORKDIR /
 RUN git clone --branch v0.5.6 --depth 1 https://github.com/simonsobs/sodetlib.git
+# allow versioneer to determine sodetlib version safely
+USER cryo
+RUN git config --global --add safe.directory /sodetlib
+USER root
 WORKDIR /sodetlib
 RUN pip3 install -e .
 RUN pip3 install -r requirements.txt


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
This fixes the determination of `sodetlib` version installed within the pysmurf-controller Docker image. The fix is the same one applied [here](https://github.com/simonsobs/smurf_dockers/blob/3bb520cca801d46981af063309ab1d5f94503b83/pysmurf/Dockerfile#L27-L30) for `pysmurf` in one of the base images.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
The permissions were preventing the determination of the sodetlib version due to dubious ownership of the sodetlib repo checkout. This prevented the actual version being used from showing up in [this metadata](https://github.com/simonsobs/sodetlib/blob/45ffaf57dae7d0ec1bb23424ef84b3b4cd1dc0b0/sodetlib/util.py#L213C38-L213C49).

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
Before this patch if you run as the `cryo:smurf` user within the container, `git status` does not work and if you try to determine the `sodetlib` version you would get `0+unknown`:
```
$ docker run --rm -u 1000:1001 -it --entrypoint=/bin/bash pysmurf-controller:test
cryo@9aa8e89c2b5d:/sodetlib$ git status
fatal: detected dubious ownership in repository at '/sodetlib'
To add an exception for this directory, call:

	git config --global --add safe.directory /sodetlib
cryo@9aa8e89c2b5d:/sodetlib$ cd
cryo@9aa8e89c2b5d:~$ python
Python 3.8.10 (default, Mar 18 2025, 20:04:55)
[GCC 9.4.0] on linux
Type "help", "copyright", "credits" or "license" for more information.
>>> import sodetlib
>>> sodetlib.__version__
'0+unknown'
```

After this patch `git status` works and the version can be determined.
```
$ docker run --rm -u 1000:1001 -it --entrypoint=/bin/bash pysmurf-controller:patch
cryo@c714628d7683:/sodetlib$ git status
Not currently on any branch.
nothing to commit, working tree clean
cryo@c714628d7683:/sodetlib$ cd
cryo@c714628d7683:~$ python
Python 3.8.10 (default, Mar 18 2025, 20:04:55)
[GCC 9.4.0] on linux
Type "help", "copyright", "credits" or "license" for more information.
>>> import sodetlib
>>> sodetlib.__version__
'0.5.6'
```

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
