### PR TITLE
Galil3 - Added limit switch query task to agent.py and drivers.py

### DIFF
--- a/socs/agents/galil_axis/agent.py
+++ b/socs/agents/galil_axis/agent.py
@@ -1102,15 +1102,15 @@ class GalilAxisAgent:
                 return False, "Could not acquire lock."
 
             state, human_state = self.stage.get_forward_limitswitch(axis)
-        
+
         # store data
         session.data = {
-                'axis': axis,
-                'raw_state': state,
-                'human_state': human_state,
-                'timestamp': time.time(),
+            'axis': axis,
+            'raw_state': state,
+            'human_state': human_state,
+            'timestamp': time.time(),
         }
-        
+
         return True, f"Axis {axis} forward limit: {human_state} (raw={state})"
 
     @ocs_agent.param('axis', type=str)
@@ -1118,7 +1118,7 @@ class GalilAxisAgent:
         """get_reverse_limitswitch(axis)
 
         **Task** - Returns reverse limit switch state for a given axis. 1 means not triggered, 0 means triggered.
-        
+
         Parameters:
             axis (str): Axis to query (e.g. 'A')
         """
@@ -1133,14 +1133,14 @@ class GalilAxisAgent:
 
         # store data
         session.data = {
-                'axis': axis,
-                'raw_state': state,
-                'human_state': human_state,
-                'timestamp': time.time(),
+            'axis': axis,
+            'raw_state': state,
+            'human_state': human_state,
+            'timestamp': time.time(),
         }
 
         return True, f"Axis {axis} reverse limit: {human_state} (raw={state})"
-    
+
     @ocs_agent.param('axis', type=str)
     def stop_axis_motion(self, session, params):
         """stop_axis_motion(axis)

--- a/socs/agents/galil_axis/drivers.py
+++ b/socs/agents/galil_axis/drivers.py
@@ -488,7 +488,7 @@ class GalilAxis(TCPInterface):
 
         # --- Interpret raw
         human_state = "not triggered" if state == 1 else "triggered" if state == 0 else f"unknown ({state})"
-        
+
         return state, human_state
 
     def get_reverse_limitswitch(self, axis):


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Added two new tasks to query the forward and reverse limits to see if they're triggered or not.

## Description
Added two new tasks to query the forward and reverse limits to see if they're triggered or not. The argument can be any axis. (e.g. Axis "A" for motor A).

## Motivation and Context
We ran into a new issue at site with the limit switches bouncing where they were flickering. We added capacitors in the electronics to try and debounce the limit switches, but were not able to check the state of the limits without the new tasks. Now we can query those forward and reverse limits to see if they're triggered or not.

## How Has This Been Tested?
Tested the limits for the lead axes "A" and "C" in a script and they worked.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
I think the documentation would need to be updated if a new task is added, but I'm unsure, but I can add that later if that's needed.