### PR TITLE
hwp-supervisor: Add missing shutdown procedure

### DIFF
--- a/socs/agents/hwp_supervisor/agent.py
+++ b/socs/agents/hwp_supervisor/agent.py
@@ -1597,7 +1597,7 @@ class HWPSupervisor:
         """
         pm = Pacemaker(1. / self.sleep_time)
         test_mode = params.get('test_mode', False)
-        last_ok_time = time.time()
+        last_okay_time = time.time()
 
         session.data = {
             'timestamp': time.time(),
@@ -1625,9 +1625,9 @@ class HWPSupervisor:
 
             action = self.hwp_state.pmx_action
             if action == 'ok':
-                last_ok_time = time.time()
+                last_okay_time = time.time()
             elif action == 'no_data' and self.shutdown_no_data_timeout >= 0:
-                if (time.time - last_okay_time) > self.shutdown_no_data_timeout:
+                if (time.time() - last_okay_time) > self.shutdown_no_data_timeout:
                     if not self.shutdown_mode:
                         self.agent.start('disable_driver_board', params={})
                         self.shutdown_mode = True
@@ -2117,7 +2117,7 @@ def make_parser(parser=None):
              "cw or ccw is defined when hwp is viewed from the sky side."
     )
     pgroup.add_argument(
-        '--shutdown-no-data-timeout', type=float, default=15 * 60
+        '--shutdown-no-data-timeout', type=float, default=15 * 60,
         help="Time(sec) after which a 'no_data' action should trigger a shutdown"
     )
     return parser


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
This PR adds functionality to the hwp-supervisor agent to shut off bias power to the driver board during a triggered shutdown

## Description
<!--- Describe your changes in detail -->
Currently, when a HWP shutdown is triggered the only actions taken is to lock out user controls and shut off the drive power. These actions alone are not enough to fully stop the HWP as the driver board bias power needs to be disabled as well (we should be doing this anyways because the electronics shouldn't be biased if there is expected to be large swings in the cryostat temperature). This PR adds to the hwp-supervisor's monitor process additional logic which shuts off the bias power once a shutdown is triggered.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
See above

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
This was tested successfully on satp2 by simulating a communication failure to initiate the shutdown

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
