### PR TITLE
ACU: Support el_mode='stop' in generate_scan

### DIFF
--- a/docs/agents/acu_agent.rst
+++ b/docs/agents/acu_agent.rst
@@ -155,8 +155,8 @@ ignorance:
   :class:`ACUAgent <socs.agents.acu.agent.ACUAgent>`.
 - ``scan_params``: Default scan parameters; currently ``az_speed``
   (float, deg/s) ``az_accel`` (float, deg/s/s), ``el_freq`` (float, Hz),
-  and ``turnaround_method`` (str). If not specfied, these are given
-  default values depending on the platform type.
+  ``turnaround_method`` (str), and ``el_mode`` (str). If not specfied,
+  these are given default values depending on the platform type.
 
 
 Other agent functions


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Main change is that the azonly argument in generate_scan is replaced by el_mode.  Default behavior is the same, which is to leave elevation axis in Preset mode for the (type 1 or type 2) scan.  But now you have the option to request el_mode="stop", which will put that axis in Stop for the scan.

The el_mode is also a "scan_param" whose default value can be set in config file and then updated using `set_scan_params`.

Note although there's an interface change here, the azonly argument does not appear to be used by anyone currently (it's not exposed through ocs-web, even).  And the functionality it advertised was not correctly implemented.

## Motivation and Context

This is a desired interim behavior for SATP2 while some issues with elevation drive are being investigated.

## How Has This Been Tested?

Tested on ACU simulator software.  Confirmed old default behavior is reproduced.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
