### PR TITLE
ACU: Make end_stop=True the default

### DIFF
--- a/socs/agents/acu/agent.py
+++ b/socs/agents/acu/agent.py
@@ -1603,10 +1603,10 @@ class ACUAgent:
 
     @ocs_agent.param('az', type=float, default=None)
     @ocs_agent.param('el', type=float, default=None)
-    @ocs_agent.param('end_stop', default=False, type=bool)
+    @ocs_agent.param('end_stop', default=True, type=bool)
     @inlineCallbacks
     def go_to(self, session, params):
-        """go_to(az, el, end_stop=False)
+        """go_to(az, el, end_stop=True)
 
         **Task** - Move the telescope to a particular point (azimuth,
         elevation) in Preset mode. When motion has ended and the telescope
@@ -1687,16 +1687,16 @@ class ACUAgent:
         return all_ok, msg
 
     @ocs_agent.param('target', type=float)
-    @ocs_agent.param('end_stop', default=False, type=bool)
+    @ocs_agent.param('end_stop', default=True, type=bool)
     @inlineCallbacks
     def set_boresight(self, session, params):
-        """set_boresight(target, end_stop=False)
+        """set_boresight(target, end_stop=True)
 
         **Task** - Move the telescope to a particular third-axis angle.
 
         Parameters:
             target (float): destination angle for boresight rotation
-            end_stop (bool): put axes in Stop mode after motion
+            end_stop (bool): put axis in Stop mode after motion
 
         """
         with self.boresight_lock.acquire_timeout(0, job='set_boresight') as acquired:


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Make end_stop=True the default, for go_to and set_boresight tasks.

Technically this is an interface change, in that default behavior is affected, and default behavior is actively used in our running schedules.  But it was agreed on DAQ call that this will be seen, by any who notices, as an improvement.

## Motivation and Context

After each move, it is sensible to put on the brakes.  We rarely care about servoing actively on any fixed position, because we only observe while scanning.  This change does not affect behavior when scanning -- elevation axis will remain in Preset mode in that case (which may or may not be what is wanted; cf #964).

## How Has This Been Tested?

Tested on simulator, but this is quite a minor change in any case.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
