### PR TITLE
suprsync: Add debug line for rsync command

### DIFF
--- a/socs/db/suprsync.py
+++ b/socs/db/suprsync.py
@@ -667,6 +667,7 @@ class SupRsyncFileHandler:
                     cmd.extend(['--rsh', f'ssh -i {self.ssh_key}'])
                 cmd.extend([tmp_dir + '/', dest])
 
+                self.log.debug(f"Running: {' '.join(cmd)}")
                 subprocess.run(cmd, check=True, timeout=self.copy_timeout)
 
             for file in files:


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
This adds a debug line for showing what `rsync` command is running to do the sync.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
One of the suprsync agents on satp2 is transferring with incorrect permissions and I'm trying to debug what's going on. This will at least help confirm what command is being run so I can check for any issues there.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
I've run this on the E2E testing system. Here is an example log with the `LOGLEVEL=debug` and the autobahn heartbeats removed:

```
2026-01-21T16-03-49.204589 Copying files:
2026-01-21T16-03-49.204777 - /mnt/nfs/data/ocs3/temp_data/timestreams/17690/emulator1/1769011239_000.g3
2026-01-21T16-03-49.205168 - /mnt/nfs/data/ocs3/temp_data/timestreams/17690/emulator1/1769011228_000.g3
2026-01-21T16-03-49.205507 - /mnt/nfs/data/ocs3/temp_data/timestreams/17690/emulator1/1769011215_000.g3
2026-01-21T16-03-49.205766 Running: rsync -Lrt -p --chmod=g+rwX,o+rX /tmp/tmpjkve57o3/ /mnt/nfs/data/ocs3/timestreams
2026-01-21T16-03-51.939120 Checksumming on remote.
2026-01-21T16-03-51.940139 Running: md5sum /mnt/nfs/data/ocs3/timestreams/emulator1/1769011239_000.g3 /mnt/nfs/data/ocs3/timestreams/emulator1/1769011228_000.g3 /mnt/nfs/data/ocs3/timestreams/emulator1/1769011215_000.g3
2026-01-21T16-03-51.953818 Copy session complete.
```

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
