### PR TITLE
pysmurf-controller: Update sodetlib version to v0.6.2

### DIFF
--- a/docker/pysmurf_controller/Dockerfile
+++ b/docker/pysmurf_controller/Dockerfile
@@ -10,7 +10,8 @@ USER cryo
 RUN git config --global --add safe.directory /sodetlib
 USER root
 WORKDIR /sodetlib
-RUN pip3 install .
+RUN pip3 install -U pip
+RUN pip3 install -e .
 RUN pip3 install -r requirements.txt
 
 ENV OCS_CONFIG_DIR /config


### PR DESCRIPTION
New sodetlib version fixes bug in time constant analysis for detectors near saturation, and provides additional configuration parameters to control amplifier biasing.

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
fit_tmin is again available as a parameter that can be specified. If left as None, dynamic tmin calculation is used.
Dynamic tmin calculation rewritten to rely on the stored polarity of a detector's response, rather than abs(signal)

For amplifier bias parameters, `amp_{amp}_gate_volt_{min/max}` are added to the dev cfg and referenced in the amplifier biasing routines.


## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Issues with time constant fitting of near-saturated detectors shown here:
https://docs.google.com/presentation/d/1oGefvf0J7R-OqJHX4xY_ArVm5rNWToZq-wb7sOqg1t8/edit?slide=id.g3b710008148_0_20#slide=id.g3b710008148_0_20
## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
Kyohei and Daniel have re-run bias step analyses and saw the spuriously-low time constants disappear, with results similar to the old fixed tmin=1.5 ms results.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
