### PR TITLE
pysmurf-controller: Update sodetlib version to v0.6.4

### DIFF
--- a/docker/pysmurf_controller/Dockerfile
+++ b/docker/pysmurf_controller/Dockerfile
@@ -4,7 +4,7 @@ FROM simonsobs/so_smurf_base:v0.0.6
 # sodetlib Install
 #################################################################
 WORKDIR /
-RUN git clone --branch v0.6.2 --depth 1 https://github.com/simonsobs/sodetlib.git
+RUN git clone --branch v0.6.4 --depth 1 https://github.com/simonsobs/sodetlib.git
 # allow versioneer to determine sodetlib version safely
 USER cryo
 RUN git config --global --add safe.directory /sodetlib


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Bump version of sodetlib in the pysmurf-controller.
New version required to automatically bias the ASU 4K HEMT amplifiers in the LAT.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
ASU 4K amps should operate with fixed gate_voltage=0, and instead scan over drain_voltage to get desired drain current.
Previous attempt of using a fiducial drain_voltage value and expanded drain_current_tolerance did not work.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
Successfully tested the new amplifier biasing code on a cold system on the LAT

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
