### PR TITLE
tcp: Catch exceptions on recv

### DIFF
--- a/socs/tcp.py
+++ b/socs/tcp.py
@@ -148,7 +148,15 @@ class TCPInterface:
 
         """
         self._check_ready()
-        data = self.comm.recv(bufsize)
+        try:
+            data = self.comm.recv(bufsize)
+        except OSError as e:
+            print(f"Connection error: {e}")
+            raise ConnectionError
+        except Exception as e:
+            print(f"Caught unexpected {type(e).__name__} during recv:")
+            print(f"  {e}")
+            raise ConnectionError
         return data
 
     def __del__(self):


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
This PR introduces error handling in the `TPCInterface.recv` method to handle any connection errors that occur during the `socket.socket.recv` call.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Resolves #996.

This only occurs if the network disconnection happens during `recv`, which was tricky to catch when testing this manually. We're now seeing this in practice and this will enable agents to handle the error and retry.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
This has not been tested and likely won't until it's deployed on site.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
