### PR TITLE
Require ocs>=0.10.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,7 +26,7 @@ classifiers = [
 dependencies = [
     "autobahn[serialization]",
     "numpy",
-    "ocs",
+    "ocs>=0.10.0",
     "pyasn1==0.4.8",
     "pyModbusTCP",
     "pyserial",

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 # core dependencies
 autobahn[serialization]
-ocs
+ocs>=0.10.0
 sqlalchemy>=1.4
 twisted
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
This PR forces the installed ocs version to be `>=0.10.0`, when the new plugin system was introduced.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Now that the old plugin system has been removed in [1], we should make sure we have the new plugin system, which was introduced in v0.10.0.

[1] - https://github.com/simonsobs/socs/pull/988

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
I installed locally with the changes.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
