### PR TITLE
Reduce verbose syncbox logging by changing info to debug

### DIFF
--- a/socs/agents/meinberg_syncbox/agent.py
+++ b/socs/agents/meinberg_syncbox/agent.py
@@ -468,12 +468,12 @@ class MeinbergSyncboxAgent:
                 oid_cache = update_cache(get_result, read_time)
                 oid_cache['address'] = self.address
                 session.data = oid_cache
-                self.log.info("{data}", data=session.data)
+                self.log.debug("{data}", data=session.data)
 
                 self.lastGet = time.time()
                 # Publish to feed
                 message = _build_message(get_result, read_time)
-                self.log.info("{msg}", msg=message)
+                self.log.debug("{msg}", msg=message)
                 session.app.publish_to_feed('syncbox', message)
             except Exception as e:
                 self.log.error(f'{e}')


### PR DESCRIPTION
## Description
Reduce excessive logging from the Meinberg Syncbox agent by changing two verbose `self.log.info` calls to `self.log.debug`.

## Motivation and Context
The agent was logging session data and feed messages at the `info` level, which produced very noisy logs and made it difficult to see important events such as disconnects or errors.

This change moves those logs to the `debug` level so they are only shown when debugging is enabled.

Fixes #1005