### PR TITLE
hwp-supervisor: Remove UPS OID when missing

### DIFF
--- a/socs/agents/hwp_supervisor/agent.py
+++ b/socs/agents/hwp_supervisor/agent.py
@@ -552,7 +552,9 @@ class HWPState:
                 ups_oid = k.split('_')[1]
                 break
         else:
-            raise ValueError('Could not find upsOutputSource OID')
+            for k in ups_keymap:
+                setattr(self, k, None)
+            return
 
         for k, f in ups_keymap.items():
             setattr(self, k, data[f'{f[0]}_{ups_oid}'][f[1]])


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Change update_ups_state not to raise error.

## Motivation and Context

All the hwp-supervisor agents usually crash during the site computing maintenance due to the ValueError in update_ups_state.
This PR mitigates this issue.
```
2026-03-26T15:21:56+0000 monitor:0 Status is now "done".
]
/opt/venv/lib/python3.10/site-packages/socs/agents/hwp_supervisor/agent.py:555:update_ups_state
/opt/venv/lib/python3.10/site-packages/socs/agents/hwp_supervisor/agent.py:625:update
/opt/venv/lib/python3.10/site-packages/socs/agents/hwp_supervisor/agent.py:1656:monitor
/opt/venv/lib/python3.10/site-packages/ocs/ocs_agent.py:1074:_running_wrapper
/opt/venv/lib/python3.10/site-packages/twisted/python/context.py:82:callWithContext
/opt/venv/lib/python3.10/site-packages/twisted/python/context.py:117:callWithContext
/opt/venv/lib/python3.10/site-packages/twisted/python/threadpool.py:285:<lambda>
/opt/venv/lib/python3.10/site-packages/twisted/python/threadpool.py:269:inContext2026-03-26T15:21:56+0000 monitor:0 CRASH: [Failure instance: Traceback: <class 'ValueError'>: Could not find upsOutputSource OID
2026-03-26T15:21:56+0000 Could not connect to client: hwp-pcu
2026-03-26T15:21:56+0000 Error getting status: [0, 0, 0, 0, 'wamp.error.no_such_procedure', ['no callee registered for procedure <satp3.hwp-pid.ops>'], {}]
2026-03-26T15:21:55+0000 Could not connect to client: hwp-pid
2026-03-26T15:21:54+0000 Error getting status: [0, 0, 0, 0, 'wamp.error.no_such_procedure', ['no callee registered for procedure <satp3.hwp-bbb-a1.ops>'], {}]
2026-03-26T15:21:52+0000 Error getting status: [0, 0, 0, 0, 'wamp.error.no_such_procedure', ['no callee registered for procedure <satp3.cryo-ls240-lsa2k4g.ops>'], {}]2026-03-26T15:21:52+0000 Could not connect to client: hwp-bbb-a1
```

## How Has This Been Tested?
This has not been tested but hopefully straightforward.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
