### PR TITLE
Revert to building wheels on Python 3.8

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -68,10 +68,10 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - name: Set up Python 3.12
+    - name: Set up Python 3.8
       uses: actions/setup-python@v6
       with:
-        python-version: "3.12"
+        python-version: 3.8
 
     - name: clone socs
       uses: actions/checkout@v6

--- a/.github/workflows/develop.yml
+++ b/.github/workflows/develop.yml
@@ -71,10 +71,10 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - name: Set up Python 3.12
+    - name: Set up Python 3.8
       uses: actions/setup-python@v6
       with:
-        python-version: "3.12"
+        python-version: 3.8
 
     - name: clone socs
       uses: actions/checkout@v6


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
This reverts the wheel builds to being done on Python 3.8 instead of 3.12.

This will fix one problem we have with workflows at the moment. The other problem still needs more investigation.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
On 3.12 we run into https://github.com/simonsobs/sotodlib/issues/1030. 

Latest build on `main`: https://github.com/simonsobs/socs/actions/runs/23667833834/job/68956880425

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
I forced a run of the build-wheel job on `push` and verified it built without error.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
