### PR TITLE
Updated default step_time in gen_turnaround

### DIFF
--- a/socs/agents/acu/turnarounds.py
+++ b/socs/agents/acu/turnarounds.py
@@ -3,7 +3,7 @@ import numpy as np
 
 def gen_turnaround(turnaround_method, t0, az0, el0, v0, turntime, az_flag, el_flag,
                    point_group_batch, second_leg_time=None, second_leg_velocity=0,
-                   step_time=0.05):
+                   step_time=0.1):
     from .drivers import TrackPoint
     """
     Generates the trajectory of a turnaround given the initial position and velocity of the platform.


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Updated the default step_time in `gen_turnaround` in `turnarounds.py` to `step_time=0.1`

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
This really should have been the default before probably. I think the ACU maxes out at 0.1s step time.
I think I had set this higher when I was testing very high accelerations.
This might be the cause of the az position errors seen on satp1, but that's uncertain until tested.
The high frequency may over constrain the turnaround or cause very strange ACU behavior if we're sending too many points.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
This has been tested before. 

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
