### PR TITLE
Acu agent update line timestamp check

### DIFF
--- a/socs/agents/acu/agent.py
+++ b/socs/agents/acu/agent.py
@@ -2440,7 +2440,7 @@ class ACUAgent:
         # (The cost is that stopping a scan may take a little longer.)
         MIN_STACK_ADVANCE_TIME = 3.
 
-        # Minimum nuber of points to keep in the stack.
+        # Minimum number of points to keep in the stack.
         _pbc = max(MIN_STACK_POP, MIN_STACK_ADVANCE_TIME / step_time)
         if point_batch_count is None or _pbc > point_batch_count:
             point_batch_count = _pbc
@@ -2597,13 +2597,13 @@ class ACUAgent:
                     while len(lines) and len(upload_lines) and upload_lines[-1].group_flag != 0:
                         upload_lines.append(lines.pop(0))
 
-                    # If there are any upcoming points left with timestamps < 3 step_times, transfer them in.
+                    # If there are any upcoming points left with timestamps the MIN_STACK_ADVANCE_TIME transfer them in.
                     # This prevents the update_line from running out of points
                     # if points are generated faster than the step_time.
                     # This mainly happens with the new turnaround functions that need to generate points
                     # with step_times << 1.0s.
                     first_upload_timestamp = upload_lines[0].timestamp
-                    while len(lines) and (lines[0].timestamp - first_upload_timestamp) < 3 * step_time:
+                    while len(lines) and (lines[0].timestamp - first_upload_timestamp) < MIN_STACK_ADVANCE_TIME:
                         upload_lines.append(lines.pop(0))
 
                     if len(upload_lines):

--- a/socs/agents/acu/agent.py
+++ b/socs/agents/acu/agent.py
@@ -2598,9 +2598,10 @@ class ACUAgent:
                         upload_lines.append(lines.pop(0))
 
                     # If there are any upcoming points left with timestamps < 3 step_times, transfer them in.
-                    # This prevents the update_line from running out of points 
+                    # This prevents the update_line from running out of points
                     # if points are generated faster than the step_time.
-                    # 
+                    # This mainly happens with the new turnaround functions that need to generate points
+                    # with step_times << 1.0s.
                     first_upload_timestamp = upload_lines[0].timestamp
                     while len(lines) and (lines[0].timestamp - first_upload_timestamp) < 3 * step_time:
                         upload_lines.append(lines.pop(0))

--- a/socs/agents/acu/agent.py
+++ b/socs/agents/acu/agent.py
@@ -2597,6 +2597,14 @@ class ACUAgent:
                     while len(lines) and len(upload_lines) and upload_lines[-1].group_flag != 0:
                         upload_lines.append(lines.pop(0))
 
+                    # If there are any upcoming points left with timestamps < 3 step_times, transfer them in.
+                    # This prevents the update_line from running out of points 
+                    # if points are generated faster than the step_time.
+                    # 
+                    first_upload_timestamp = upload_lines[0].timestamp
+                    while len(lines) and (lines[0].timestamp - first_upload_timestamp) < 3 * step_time:
+                        upload_lines.append(lines.pop(0))
+
                     if len(upload_lines):
                         # Discard the group flag and upload all.
                         text = sh.get_track_points_text(

--- a/socs/agents/acu/agent.py
+++ b/socs/agents/acu/agent.py
@@ -2565,8 +2565,16 @@ class ACUAgent:
                 if mode == 'abort':
                     lines = []
 
+                last_upload_size = 0
                 # Is it time to upload more lines?
-                if free_positions >= STACK_REFILL_THRESHOLD:
+                # STACK_REFILL_THRESHOLD is the absolute minimum number of points that can be in the stack
+                # based on the constant_velocity step_time.
+                # FULL_STACK - int(last_upload_size/2) is the minimum number of points that we should
+                # try to reupload based on the number of points in the last upload in case we uploaded
+                # points with a lower dt. We always add at least 2xMIN_STACK_ADVANCE_TIME worth of points,
+                # so this should attempt to always keep MIN_STACK_ADVANCE_TIME worth of points in the
+                # upload.
+                if free_positions >= min(STACK_REFILL_THRESHOLD, FULL_STACK - int(last_upload_size / 2)):
                     new_line_target = max(int(free_positions - STACK_TARGET), 1)
 
                     # Make sure that you get one more line than you
@@ -2603,8 +2611,11 @@ class ACUAgent:
                     # This mainly happens with the new turnaround functions that need to generate points
                     # with step_times << 1.0s.
                     first_upload_timestamp = upload_lines[0].timestamp
-                    while len(lines) and (lines[0].timestamp - first_upload_timestamp) < MIN_STACK_ADVANCE_TIME:
+                    while len(lines) and (lines[0].timestamp - first_upload_timestamp) < 2 * MIN_STACK_ADVANCE_TIME:
                         upload_lines.append(lines.pop(0))
+
+                    # The total number of points we just uploaded is at least 2x the number of points we want.
+                    last_upload_size = len(upload_lines)
 
                     if len(upload_lines):
                         # Discard the group flag and upload all.


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Added in a check for Point timestamps to add to update_lines in `_run_track` function in ACU agent.
This should added code should make sure that the update_lines list always contains at least ~3 * step_times worth of points.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
We were seeing that the ACU agent `_run_track` function was running out of points during `generate_scan` calls when using non-standard (two_leg, standard_gen, three_leg) turnaround methods. This is because the `turnaround_gen` function generates PointTrack points at a step_time (currently 0.05s) that is much lower than the `_run_track` step_time (1.0s). The `_run_track` function tries to pull ~6 points per loop (which should be ~3 seconds worth of points). Because the `turnaround_gen` uses a much lower step_time, the `_run_track` function was struggling to keep up with the number of points needed per second. This change should make sure each loop of `_run_track` should always grab at least 3*step_time worth of points.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
Needs to be tested! We should test this on one of the platforms with the two_leg or standard_gen turnaround and watch the # free_position_points during turnarounds.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
