### PR TITLE
ibootbar: publish current and voltage to a feed and session.data

### DIFF
--- a/socs/agents/ibootbar/agent.py
+++ b/socs/agents/ibootbar/agent.py
@@ -94,7 +94,8 @@ def _build_message(get_result, names, time):
             continue
 
         message['data'][field_name] = oid_value
-        message['data'][field_name + "_name"] = names[int(field_name[-1])]
+        if 'outlet' in field_name:
+            message['data'][field_name + "_name"] = names[int(field_name[-1])]
         message['data'][field_name + "_description"] = oid_description
 
     return message
@@ -143,8 +144,9 @@ def update_cache(get_result, names, outlet_locked, timestamp):
 
         # Update OID Cache for session.data
         oid_cache[field_name] = {"status": oid_value}
-        oid_cache[field_name]["name"] = names[int(field_name[-1])]
-        oid_cache[field_name]["locked"] = outlet_locked[int(field_name[-1])]
+        if 'outlet' in field_name:
+            oid_cache[field_name]["name"] = names[int(field_name[-1])]
+            oid_cache[field_name]["locked"] = outlet_locked[int(field_name[-1])]
         oid_cache[field_name]["description"] = oid_description
         oid_cache['ibootbar_connection'] = {'last_attempt': time.time(),
                                             'connected': True}
@@ -233,11 +235,17 @@ class ibootbarAgent:
             {'outletStatus_0':
                 {'status': 1,
                  'name': 'Outlet-1',
+                 'locked': True,
                  'description': 'on'},
              'outletStatus_1':
                 {'status': 0,
                  'name': 'Outlet-2',
+                 'locked': False,
                  'description': 'off'},
+             ...
+             'currentLC1_0':
+                {'status': 0,
+                 'description': '0'},
              ...
              'ibootbar_connection':
                 {'last_attempt': 1656085022.680916,
@@ -271,6 +279,11 @@ class ibootbarAgent:
             for i in range(8):
                 get_list.append((self.ibootbar_type + '-MIB', 'outletStatus', i))
                 name_list.append((self.ibootbar_type + '-MIB', 'outletName', i))
+            get_list.append((self.ibootbar_type + '-MIB', 'currentLC1', 0))
+            get_list.append((self.ibootbar_type + '-MIB', 'currentLC2', 0))
+            if self.ibootbar_type == 'IBOOTPDU':
+                get_list.append((self.ibootbar_type + '-MIB', 'voltageLC1', 0))
+                get_list.append((self.ibootbar_type + '-MIB', 'voltageLC2', 0))
 
             # Issue SNMP GET commands
             get_result = yield self.snmp.get(get_list, self.version)


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Add current and voltage to a feed and session.data of ibootbar agent.

## Motivation and Context
Even though the ibootbar outlet is on, a device on the ibootbar can fail and stop. To detect the failure of air compressor which do not have its agent, we would like to monitor the current draw of ibootbar to detect failure of device.

Voltage can only be monitored by IBOOTPDU.

## How Has This Been Tested?
Tested at daq-dev for both IBOOTBAR and IBOOTPDU.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
