### PR TITLE
wiregrid_encoder: Fix potential race condition

### DIFF
--- a/socs/agents/wiregrid_encoder/agent.py
+++ b/socs/agents/wiregrid_encoder/agent.py
@@ -175,7 +175,7 @@ class WiregridEncoderAgent:
                             'error': [],
                         }
                     }
-                
+
                 # Check current time
                 current_time = time.time()
 

--- a/socs/agents/wiregrid_encoder/agent.py
+++ b/socs/agents/wiregrid_encoder/agent.py
@@ -115,39 +115,11 @@ class WiregridEncoderAgent:
                 return False, 'Could not acquire lock.'
 
             self.take_data = True
-            # Initialize data containers
+            # Initialize data containers and update times
             session.data = {'fields': {'irig_data': {}, 'encoder_data': {},
                             'timestamp': 0}}
-            irig_rdata = {'timestamp': 0,
-                          'block_name': 'wgencoder_irig',
-                          'data': {
-                              'irig_time': 0,
-                              'rising_edge_count': 0,
-                              'edge_diff': 0,
-                              'irig_sec': 0,
-                              'irig_min': 0,
-                              'irig_hour': 0,
-                              'irig_day': 0,
-                              'irig_year': 0,
-                          }
-                          }
             irig_last_updated = 0
-            irig_fdata = {'timestamps': [],
-                          'block_name': 'wgencoder_irig_raw',
-                          'data': {}
-                          }
-            enc_rdata = {
-                'timestamps': [],
-                'block_name': 'wgencoder_rough',
-                'data': {}
-            }
             enc_last_updated = 0
-            enc_fdata = {
-                'timestamps': [],
-                'block_name': 'wgencoder_full',
-                'data': {}
-            }
-
             # Loop
             while self.take_data:
 
@@ -159,6 +131,51 @@ class WiregridEncoderAgent:
                     with open('parse_error.log', 'a') as f:
                         traceback.print_exc(file=f)
 
+                # Data container initialization in while loop
+                irig_rdata = {'timestamp': 0,
+                        'block_name': 'wgencoder_irig',
+                        'data': {
+                            'irig_time': 0,
+                            'rising_edge_count': 0,
+                            'edge_diff': 0,
+                            'irig_sec': 0,
+                            'irig_min': 0,
+                            'irig_hour': 0,
+                            'irig_day': 0,
+                            'irig_year': 0,
+                            'bbb_clock_freq': 0,
+                        }
+                    }
+                irig_fdata = {'timestamps': [],
+                        'block_name': 'wgencoder_irig_raw',
+                        'data': {
+                            'irig_synch_pulse_clock_time']: [],
+                            'irig_synch_pulse_clock_counts']: [],
+                            'irig_info': []
+                        }
+                    }
+                enc_rdata = {
+                        'timestamps': [],
+                        'block_name': 'wgencoder_rough',
+                        'data': {
+                            'quadrature': [],
+                            'pru_clock': [],
+                            'reference_degree': []
+                            'error': [],
+                            'rotation_speed': [],
+                        }
+                    }
+                enc_fdata = {
+                        'timestamps': [],
+                        'block_name': 'wgencoder_full',
+                        'data': {
+                            'quadrature': [],
+                            'pru_clock': [],
+                            'reference_count': [],
+                            'error': [],
+                        }
+                    }
+                
                 # Check current time
                 current_time = time.time()
 
@@ -172,7 +189,6 @@ class WiregridEncoderAgent:
                     irig_info = irig_data[2]
                     synch_pulse_clock_counts = irig_data[3]
                     sys_time = irig_data[4]
-
                     irig_rdata['timestamp'] = sys_time
                     irig_rdata['data']['irig_time'] = irig_time
                     irig_rdata['data']['rising_edge_count'] = rising_edge_count
@@ -250,10 +266,6 @@ class WiregridEncoderAgent:
                         or (len(pru_clock)
                             and (current_time - time_encoder_published)
                             > SEC_ENCODER_TO_PUBLISH):
-                        enc_rdata = {
-                            'block_name': 'wgencoder_rough',
-                            'data': {}
-                        }
                         enc_rdata['timestamps'] = received_time_list
                         enc_rdata['data']['quadrature'] =\
                             quad_data[::COUNTER_INFO_LENGTH]
@@ -264,14 +276,10 @@ class WiregridEncoderAgent:
                              * 360 / COUNTS_ON_BELT).tolist()
                         enc_rdata['data']['error'] =\
                             error_flag[::COUNTER_INFO_LENGTH]
-
                         enc_rdata['data']['rotation_speed'] = rot_speed  # Hz
                         self.agent.publish_to_feed(
                             'wgencoder_rough', enc_rdata)
-                        enc_fdata = {
-                            'block_name': 'wgencoder_full',
-                            'data': {}
-                        }
+
                         enc_fdata['timestamps'] =\
                             count2time(pru_clock, received_time_list[0])
                         enc_fdata['data']['quadrature'] = quad_data

--- a/socs/agents/wiregrid_encoder/agent.py
+++ b/socs/agents/wiregrid_encoder/agent.py
@@ -120,6 +120,26 @@ class WiregridEncoderAgent:
                             'timestamp': 0}}
             irig_last_updated = 0
             enc_last_updated = 0
+
+            # Initialize data container for session.data
+            irig_field_dict = {
+                    'last_updated': 0,
+                    'irig_time': 0,
+                    'rising_edge_count': 0,
+                    'edge_diff': 0,
+                    'irig_sec': 0,
+                    'irig_min': 0,
+                    'irig_hour': 0,
+                    'irig_day': 0,
+                    'irig_year': 0
+                }
+                enc_field_dict = {
+                    'last_updated': [],
+                    'quadrature': [],
+                    'pru_clock': [],
+                    'reference_degree': [],
+                    'error': []
+                }
             # Loop
             while self.take_data:
 
@@ -131,29 +151,31 @@ class WiregridEncoderAgent:
                     with open('parse_error.log', 'a') as f:
                         traceback.print_exc(file=f)
 
-                # Data container initialization in while loop
-                irig_rdata = {'timestamp': 0,
-                              'block_name': 'wgencoder_irig',
-                              'data': {
-                                  'irig_time': 0,
-                                  'rising_edge_count': 0,
-                                  'edge_diff': 0,
-                                  'irig_sec': 0,
-                                  'irig_min': 0,
-                                  'irig_hour': 0,
-                                  'irig_day': 0,
-                                  'irig_year': 0,
-                                  'bbb_clock_freq': 0,
-                              }
-                              }
-                irig_fdata = {'timestamps': [],
-                              'block_name': 'wgencoder_irig_raw',
-                              'data': {
-                    'irig_synch_pulse_clock_time': [],
-                    'irig_synch_pulse_clock_counts': [],
-                    'irig_info': []
-                }
-                }
+                # Data container initialization
+                irig_rdata = {
+                    'timestamp': 0,
+                    'block_name': 'wgencoder_irig',
+                    'data': {
+                        'irig_time': 0,
+                        'rising_edge_count': 0,
+                        'edge_diff': 0,
+                        'irig_sec': 0,
+                        'irig_min': 0,
+                        'irig_hour': 0,
+                        'irig_day': 0,
+                        'irig_year': 0,
+                        'bbb_clock_freq': 0,
+                        }
+                    }
+                irig_fdata = {
+                    'timestamps': [],
+                    'block_name': 'wgencoder_irig_raw',
+                    'data': {
+                        'irig_synch_pulse_clock_time': [],
+                        'irig_synch_pulse_clock_counts': [],
+                        'irig_info': []
+                        }
+                    }
                 enc_rdata = {
                     'timestamps': [],
                     'block_name': 'wgencoder_rough',
@@ -163,8 +185,8 @@ class WiregridEncoderAgent:
                         'reference_degree': [],
                         'error': [],
                         'rotation_speed': []
+                        }
                     }
-                }
                 enc_fdata = {
                     'timestamps': [],
                     'block_name': 'wgencoder_full',
@@ -173,8 +195,8 @@ class WiregridEncoderAgent:
                         'pru_clock': [],
                         'reference_count': [],
                         'error': [],
+                        }
                     }
-                }
 
                 # Check current time
                 current_time = time.time()
@@ -232,6 +254,20 @@ class WiregridEncoderAgent:
                         synch_pulse_clock_counts
                     irig_fdata['data']['irig_info'] = list(irig_info)
                     self.agent.publish_to_feed('wgencoder_full', irig_fdata)
+
+                    # Update the data for the session.data
+                    irig_field_dict = {
+                        'last_updated': irig_last_updated,
+                        'irig_time': irig_rdata['data']['irig_time'],
+                        'rising_edge_count':
+                            irig_rdata['data']['rising_edge_count'],
+                        'edge_diff': irig_rdata['data']['edge_diff'],
+                        'irig_sec': irig_rdata['data']['irig_sec'],
+                        'irig_min': irig_rdata['data']['irig_min'],
+                        'irig_hour': irig_rdata['data']['irig_hour'],
+                        'irig_day': irig_rdata['data']['irig_day'],
+                        'irig_year': irig_rdata['data']['irig_year']
+                    }
                     # End of IRIG case
 
                 if len(self.parser.encoder_queue):
@@ -300,30 +336,19 @@ class WiregridEncoderAgent:
 
                         time_encoder_published = current_time
 
+                        # Update encoder data for the session.data
+                        enc_field_dict = {
+                            'last_updated': enc_last_updated,
+                            'quadrature': enc_rdata['data']['quadrature'],
+                            'pru_clock': enc_rdata['data']['pru_clock'],
+                            'reference_degree':
+                                enc_rdata['data']['reference_degree'],
+                            'error': enc_rdata['data']['error']
+                        }
                         # End of filling encoder data
                     # End of encoder case
 
                 # store session.data
-                irig_field_dict = {
-                    'last_updated': irig_last_updated,
-                    'irig_time': irig_rdata['data']['irig_time'],
-                    'rising_edge_count':
-                        irig_rdata['data']['rising_edge_count'],
-                    'edge_diff': irig_rdata['data']['edge_diff'],
-                    'irig_sec': irig_rdata['data']['irig_sec'],
-                    'irig_min': irig_rdata['data']['irig_min'],
-                    'irig_hour': irig_rdata['data']['irig_hour'],
-                    'irig_day': irig_rdata['data']['irig_day'],
-                    'irig_year': irig_rdata['data']['irig_year']
-                }
-                enc_field_dict = {
-                    'last_updated': enc_last_updated,
-                    'quadrature': enc_rdata['data']['quadrature'],
-                    'pru_clock': enc_rdata['data']['pru_clock'],
-                    'reference_degree':
-                        enc_rdata['data']['reference_degree'],
-                    'error': enc_rdata['data']['error']
-                }
                 session.data['timestamp'] = current_time
                 session.data['fields']['irig_data'] = irig_field_dict
                 session.data['fields']['encoder_data'] = enc_field_dict

--- a/socs/agents/wiregrid_encoder/agent.py
+++ b/socs/agents/wiregrid_encoder/agent.py
@@ -118,10 +118,6 @@ class WiregridEncoderAgent:
             # Initialize data containers and update times
             session.data = {'fields': {'irig_data': {}, 'encoder_data': {},
                             'timestamp': 0}}
-            irig_last_updated = 0
-            enc_last_updated = 0
-
-            # Initialize data container for session.data
             irig_field_dict = {
                 'last_updated': 0,
                 'irig_time': 0,
@@ -140,6 +136,9 @@ class WiregridEncoderAgent:
                 'reference_degree': [],
                 'error': []
             }
+            irig_last_updated = 0
+            enc_last_updated = 0
+
             # Loop
             while self.take_data:
 
@@ -151,58 +150,37 @@ class WiregridEncoderAgent:
                     with open('parse_error.log', 'a') as f:
                         traceback.print_exc(file=f)
 
-                # Data container initialization
-                irig_rdata = {
-                    'timestamp': 0,
-                    'block_name': 'wgencoder_irig',
-                    'data': {
-                        'irig_time': 0,
-                        'rising_edge_count': 0,
-                        'edge_diff': 0,
-                        'irig_sec': 0,
-                        'irig_min': 0,
-                        'irig_hour': 0,
-                        'irig_day': 0,
-                        'irig_year': 0,
-                        'bbb_clock_freq': 0,
-                    }
-                }
-                irig_fdata = {
-                    'timestamps': [],
-                    'block_name': 'wgencoder_irig_raw',
-                    'data': {
-                        'irig_synch_pulse_clock_time': [],
-                        'irig_synch_pulse_clock_counts': [],
-                        'irig_info': []
-                    }
-                }
-                enc_rdata = {
-                    'timestamps': [],
-                    'block_name': 'wgencoder_rough',
-                    'data': {
-                        'quadrature': [],
-                        'pru_clock': [],
-                        'reference_degree': [],
-                        'error': [],
-                        'rotation_speed': []
-                    }
-                }
-                enc_fdata = {
-                    'timestamps': [],
-                    'block_name': 'wgencoder_full',
-                    'data': {
-                        'quadrature': [],
-                        'pru_clock': [],
-                        'reference_count': [],
-                        'error': [],
-                    }
-                }
-
                 # Check current time
                 current_time = time.time()
 
                 # IRIG part mainly takes over CHWP scripts by H.Nishino
                 if len(self.parser.irig_queue):
+                    # IRIG data container initialization
+                    irig_rdata = {
+                        'timestamp': 0,
+                        'block_name': 'wgencoder_irig',
+                        'data': {
+                            'irig_time': 0,
+                            'rising_edge_count': 0,
+                            'edge_diff': 0,
+                            'irig_sec': 0,
+                            'irig_min': 0,
+                            'irig_hour': 0,
+                            'irig_day': 0,
+                            'irig_year': 0,
+                            'bbb_clock_freq': 0,
+                        }
+                    }
+                    irig_fdata = {
+                        'timestamps': [],
+                        'block_name': 'wgencoder_irig_raw',
+                        'data': {
+                            'irig_synch_pulse_clock_time': [],
+                            'irig_synch_pulse_clock_counts': [],
+                            'irig_info': []
+                        }
+                    }
+
                     irig_last_updated = current_time
                     irig_data = self.parser.irig_queue.popleft()
 
@@ -268,6 +246,7 @@ class WiregridEncoderAgent:
                         'irig_day': irig_rdata['data']['irig_day'],
                         'irig_year': irig_rdata['data']['irig_year']
                     }
+
                     # End of IRIG case
 
                 if len(self.parser.encoder_queue):
@@ -302,6 +281,29 @@ class WiregridEncoderAgent:
                         or (len(pru_clock)
                             and (current_time - time_encoder_published)
                             > SEC_ENCODER_TO_PUBLISH):
+                        # Encoder data container initialization
+                        enc_rdata = {
+                            'timestamps': [],
+                            'block_name': 'wgencoder_rough',
+                            'data': {
+                                'quadrature': [],
+                                'pru_clock': [],
+                                'reference_degree': [],
+                                'error': [],
+                                'rotation_speed': []
+                            }
+                        }
+                        enc_fdata = {
+                            'timestamps': [],
+                            'block_name': 'wgencoder_full',
+                            'data': {
+                                'quadrature': [],
+                                'pru_clock': [],
+                                'reference_count': [],
+                                'error': [],
+                            }
+                        }
+
                         enc_rdata['timestamps'] = received_time_list
                         enc_rdata['data']['quadrature'] =\
                             quad_data[::COUNTER_INFO_LENGTH]
@@ -345,6 +347,7 @@ class WiregridEncoderAgent:
                                 enc_rdata['data']['reference_degree'],
                             'error': enc_rdata['data']['error']
                         }
+
                         # End of filling encoder data
                     # End of encoder case
 

--- a/socs/agents/wiregrid_encoder/agent.py
+++ b/socs/agents/wiregrid_encoder/agent.py
@@ -133,48 +133,48 @@ class WiregridEncoderAgent:
 
                 # Data container initialization in while loop
                 irig_rdata = {'timestamp': 0,
-                        'block_name': 'wgencoder_irig',
-                        'data': {
-                            'irig_time': 0,
-                            'rising_edge_count': 0,
-                            'edge_diff': 0,
-                            'irig_sec': 0,
-                            'irig_min': 0,
-                            'irig_hour': 0,
-                            'irig_day': 0,
-                            'irig_year': 0,
-                            'bbb_clock_freq': 0,
-                        }
-                    }
+                              'block_name': 'wgencoder_irig',
+                              'data': {
+                                  'irig_time': 0,
+                                  'rising_edge_count': 0,
+                                  'edge_diff': 0,
+                                  'irig_sec': 0,
+                                  'irig_min': 0,
+                                  'irig_hour': 0,
+                                  'irig_day': 0,
+                                  'irig_year': 0,
+                                  'bbb_clock_freq': 0,
+                              }
+                              }
                 irig_fdata = {'timestamps': [],
-                        'block_name': 'wgencoder_irig_raw',
-                        'data': {
-                            'irig_synch_pulse_clock_time': [],
-                            'irig_synch_pulse_clock_counts': [],
-                            'irig_info': []
-                        }
-                    }
+                              'block_name': 'wgencoder_irig_raw',
+                              'data': {
+                    'irig_synch_pulse_clock_time': [],
+                    'irig_synch_pulse_clock_counts': [],
+                    'irig_info': []
+                }
+                }
                 enc_rdata = {
-                        'timestamps': [],
-                        'block_name': 'wgencoder_rough',
-                        'data': {
-                            'quadrature': [],
-                            'pru_clock': [],
-                            'reference_degree':　[],
-                            'error': [],
-                            'rotation_speed': []
-                        }
+                    'timestamps': [],
+                    'block_name': 'wgencoder_rough',
+                    'data': {
+                        'quadrature': [],
+                        'pru_clock': [],
+                        'reference_degree': [],
+                        'error': [],
+                        'rotation_speed': []
                     }
+                }
                 enc_fdata = {
-                        'timestamps': [],
-                        'block_name': 'wgencoder_full',
-                        'data': {
-                            'quadrature': [],
-                            'pru_clock': [],
-                            'reference_count': [],
-                            'error': [],
-                        }
+                    'timestamps': [],
+                    'block_name': 'wgencoder_full',
+                    'data': {
+                        'quadrature': [],
+                        'pru_clock': [],
+                        'reference_count': [],
+                        'error': [],
                     }
+                }
 
                 # Check current time
                 current_time = time.time()

--- a/socs/agents/wiregrid_encoder/agent.py
+++ b/socs/agents/wiregrid_encoder/agent.py
@@ -149,8 +149,8 @@ class WiregridEncoderAgent:
                 irig_fdata = {'timestamps': [],
                         'block_name': 'wgencoder_irig_raw',
                         'data': {
-                            'irig_synch_pulse_clock_time']: [],
-                            'irig_synch_pulse_clock_counts']: [],
+                            'irig_synch_pulse_clock_time': [],
+                            'irig_synch_pulse_clock_counts': [],
                             'irig_info': []
                         }
                     }
@@ -160,9 +160,9 @@ class WiregridEncoderAgent:
                         'data': {
                             'quadrature': [],
                             'pru_clock': [],
-                            'reference_degree': []
+                            'reference_degree':　[],
                             'error': [],
-                            'rotation_speed': [],
+                            'rotation_speed': []
                         }
                     }
                 enc_fdata = {

--- a/socs/agents/wiregrid_encoder/agent.py
+++ b/socs/agents/wiregrid_encoder/agent.py
@@ -123,23 +123,23 @@ class WiregridEncoderAgent:
 
             # Initialize data container for session.data
             irig_field_dict = {
-                    'last_updated': 0,
-                    'irig_time': 0,
-                    'rising_edge_count': 0,
-                    'edge_diff': 0,
-                    'irig_sec': 0,
-                    'irig_min': 0,
-                    'irig_hour': 0,
-                    'irig_day': 0,
-                    'irig_year': 0
-                }
-                enc_field_dict = {
-                    'last_updated': [],
-                    'quadrature': [],
-                    'pru_clock': [],
-                    'reference_degree': [],
-                    'error': []
-                }
+                'last_updated': 0,
+                'irig_time': 0,
+                'rising_edge_count': 0,
+                'edge_diff': 0,
+                'irig_sec': 0,
+                'irig_min': 0,
+                'irig_hour': 0,
+                'irig_day': 0,
+                'irig_year': 0
+            }
+            enc_field_dict = {
+                'last_updated': [],
+                'quadrature': [],
+                'pru_clock': [],
+                'reference_degree': [],
+                'error': []
+            }
             # Loop
             while self.take_data:
 
@@ -165,8 +165,8 @@ class WiregridEncoderAgent:
                         'irig_day': 0,
                         'irig_year': 0,
                         'bbb_clock_freq': 0,
-                        }
                     }
+                }
                 irig_fdata = {
                     'timestamps': [],
                     'block_name': 'wgencoder_irig_raw',
@@ -174,8 +174,8 @@ class WiregridEncoderAgent:
                         'irig_synch_pulse_clock_time': [],
                         'irig_synch_pulse_clock_counts': [],
                         'irig_info': []
-                        }
                     }
+                }
                 enc_rdata = {
                     'timestamps': [],
                     'block_name': 'wgencoder_rough',
@@ -185,8 +185,8 @@ class WiregridEncoderAgent:
                         'reference_degree': [],
                         'error': [],
                         'rotation_speed': []
-                        }
                     }
+                }
                 enc_fdata = {
                     'timestamps': [],
                     'block_name': 'wgencoder_full',
@@ -195,8 +195,8 @@ class WiregridEncoderAgent:
                         'pru_clock': [],
                         'reference_count': [],
                         'error': [],
-                        }
                     }
+                }
 
                 # Check current time
                 current_time = time.time()

--- a/socs/agents/wiregrid_encoder/agent.py
+++ b/socs/agents/wiregrid_encoder/agent.py
@@ -250,6 +250,10 @@ class WiregridEncoderAgent:
                         or (len(pru_clock)
                             and (current_time - time_encoder_published)
                             > SEC_ENCODER_TO_PUBLISH):
+                        enc_rdata = {
+                            'block_name': 'wgencoder_rough',
+                            'data': {}
+                        }
                         enc_rdata['timestamps'] = received_time_list
                         enc_rdata['data']['quadrature'] =\
                             quad_data[::COUNTER_INFO_LENGTH]
@@ -264,6 +268,10 @@ class WiregridEncoderAgent:
                         enc_rdata['data']['rotation_speed'] = rot_speed  # Hz
                         self.agent.publish_to_feed(
                             'wgencoder_rough', enc_rdata)
+                        enc_fdata = {
+                            'block_name': 'wgencoder_full',
+                            'data': {}
+                        }
                         enc_fdata['timestamps'] =\
                             count2time(pru_clock, received_time_list[0])
                         enc_fdata['data']['quadrature'] = quad_data


### PR DESCRIPTION


## Description

Creates a new container structure for each bundle of data published to feeds

Prior to this change, the dicts were re-used for multiple calls to publish_to_feed.  Since the acq process runs in a thread, the data will be consumed in the reactor, asynchronous to the thread, and thus is vulnerable to corruption.

This is a general problem with publishing data from threads -- it should always be assembled into a unique container instance, published, and then never modified again (other than to delete it or replace it in the thread namespace). Although ocs/ocs_feed tries to "copy" the message and pass the copy to the reactor, it's not a deepcopy so that's actually pretty pointless for our standard Block way of publishing data to a feed.


## Motivation and Context

Memory leaks have been observed for this agent, and are associated with rapid logging of message:
```
2026-04-23T07:28:33+0000 while calling from thread
2026-04-23T07:28:34+0000 Recieved IRIG timeout packet.
2026-04-23T07:28:34+0000 while calling from thread
2026-04-23T07:28:34+0000 while calling from thread
2026-04-23T07:28:34+0000 while calling from thread
2026-04-23T07:28:34+0000 while calling from thread
2026-04-23T07:28:35+0000 while calling from thread
2026-04-23T07:28:35+0000 while calling from thread		
2026-04-23T07:28:36+0000 while calling from thread
```

I theorize that these messages come from the feed data publishing, which runs in the reactor but initiated from the acq thread, and are ultimately due to inconsistent data getting into a Block.  Specifically vectors of different lengths, in the block, are not checked on "append" (when the acq process calls publish) but _are_ checked and will raise an error just prior to encoding and publishing to crossbar.  That latter thing happens in the reactor.

Note that this:
```
        def A():
            assert 1 == 2
        def B():
            reactor.callFromThread(A)
        d = threads.deferToThread(B)
```
called from inside an OCS Agent reactor, will produce the exact "while calling from thread" error message that we are seeing, strongly suggesting it's originating from the reactor -> thread -> reactor arrangement, which is only really used in the ocs_agent.publish code.

## How Has This Been Tested?

This has not been tested! This is draft pending discussion with agent devs and possibly testing at site.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
