### PR TITLE
Fix PyPI wheel uploads

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -100,6 +100,7 @@ jobs:
     - name: upload dist
       uses: actions/upload-artifact@v7
       with:
+        name: wheels
         path: ./dist/
 
   pypi-publish:
@@ -115,6 +116,7 @@ jobs:
     - name: download dist
       uses: actions/download-artifact@v8
       with:
+        name: wheels
         path: dist
 
     - name: publish package distributions to PyPI


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
This PR names the wheel artifact upload/download in the deploy workflow. This prevents all artifacts from being downloaded and a directory structure being created that prevents the `pypa/gh-action-pypi-publish` action from finding the wheels.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

While @tristpinsm has been testing the new Rogue6 based pysmurf-controllers he's been tagging release candidates, which generate a build of the docker images and the wheels. The wheel builds fail to publish like in the run below:
https://github.com/simonsobs/socs/actions/runs/24865173924/job/72800578579

I realized that this was going to be true even for official releases.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
I ran workflow on push with just the build wheel and upload/download artifact bits: https://github.com/simonsobs/socs/actions/runs/24892528248/job/72888756641

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
