### PR TITLE
acu: Upload ProgramTrack points based on time

### DIFF
--- a/socs/agents/acu/agent.py
+++ b/socs/agents/acu/agent.py
@@ -2563,7 +2563,8 @@ class ACUAgent:
                 # (Meaning we have less than the minimum time worth of points uploaded).
                 # Or if the total number of free positions is higher than the MAX_ALLOWABLE_FREE_POSITIONS.
                 # (Meaning we haven't uploaded at least the minimum number of points)
-                if ((last_uploaded_timestamp - time.time()) <= MIN_STACK_ADVANCE_TIME) or (free_positions > MAX_ALLOWABLE_FREE_POSITIONS):
+                if ((last_uploaded_timestamp - time.time()) <= MIN_STACK_ADVANCE_TIME) \
+                   or (free_positions > MAX_ALLOWABLE_FREE_POSITIONS):
 
                     upload_lines = []
                     # Grab points from point_prov until our last point is at least
@@ -2580,7 +2581,7 @@ class ACUAgent:
                     while not point_prov.is_empty() and len(upload_lines) and upload_lines[-1].group_flag != 0:
                         upload_lines.append(point_prov.pop())
 
-                    if point_prov.is_empty():
+                    if point_prov.is_empty() and mode == 'go':
                         mode = 'stop'
                         stop_message = 'Stop due to end of the planned track.'
 

--- a/socs/agents/acu/agent.py
+++ b/socs/agents/acu/agent.py
@@ -2565,24 +2565,20 @@ class ACUAgent:
                 if mode == 'abort':
                     lines = []
 
-                last_upload_size = 0
+                upload_lines = []
                 # Is it time to upload more lines?
-                # STACK_REFILL_THRESHOLD is the absolute minimum number of points that can be in the stack
-                # based on the constant_velocity step_time.
-                # FULL_STACK - int(last_upload_size/2) is the minimum number of points that we should
-                # try to reupload based on the number of points in the last upload in case we uploaded
-                # points with a lower dt. We always add at least 2xMIN_STACK_ADVANCE_TIME worth of points,
-                # so this should attempt to always keep MIN_STACK_ADVANCE_TIME worth of points in the
-                # upload.
-                if free_positions >= min(STACK_REFILL_THRESHOLD, FULL_STACK - int(last_upload_size / 2)):
-                    new_line_target = max(int(free_positions - STACK_TARGET), 1)
+                # This happens when we initiate (len(upload_lines) == 0) or when our last uploaded points
+                # is less than MIN_STACK_ADVANCE_TIME worth of time away.
+                if len(upload_lines) == 0 or (time.time() + MIN_STACK_ADVANCE_TIME >= upload_lines[-1].timestamp()):
 
-                    # Make sure that you get one more line than you
-                    # need (len(lines) > new_line_target), so that
-                    # after "grabbing the minimum batch", below, there
-                    # is still >= 1 line left.  The lines-is-empty
+                    # Make sure that we have at least 1 MIN_STACK_ADVANCE_TIME
+                    # worth of lines more than we need so that 
+                    # after "grabbing 2 * MIN_STACK_ADVANCE_TIME worth of lines", below, there
+                    # is still >= 1 MIN_STACK_ADVANCE_TIME worth of lines left. The lines-is-empty
                     # check is used to decide we're done.
-                    while mode == 'go' and (len(lines) <= new_line_target or lines[-1].group_flag != 0):
+                    while mode == 'go' and (len(lines) == 0 or (time.time() + 4 * MIN_STACK_ADVANCE_TIME >= lines[-1].timestamp()) \
+                        or lines[-1].group_flag != 0):
+                        
                         try:
                             lines.extend(next(point_gen))
                         except StopIteration:
@@ -2598,24 +2594,14 @@ class ACUAgent:
                             # processed.
                             break
 
-                    # Grab the minimum batch
-                    upload_lines, lines = lines[:new_line_target], lines[new_line_target:]
-
-                    # If the last line has a "group" flag, keep transferring lines.
-                    while len(lines) and len(upload_lines) and upload_lines[-1].group_flag != 0:
-                        upload_lines.append(lines.pop(0))
-
-                    # If there are any upcoming points left with timestamps the MIN_STACK_ADVANCE_TIME transfer them in.
-                    # This prevents the update_line from running out of points
-                    # if points are generated faster than the step_time.
-                    # This mainly happens with the new turnaround functions that need to generate points
-                    # with step_times << 1.0s.
+                    # Grab the minimum batch which is 2 * MIN_STACK_ADVANCE_TIME worth of lines.
                     first_upload_timestamp = upload_lines[0].timestamp
                     while len(lines) and (lines[0].timestamp - first_upload_timestamp) < 2 * MIN_STACK_ADVANCE_TIME:
                         upload_lines.append(lines.pop(0))
 
-                    # The total number of points we just uploaded is at least 2x the number of points we want.
-                    last_upload_size = len(upload_lines)
+                    # If the last line has a "group" flag, keep transferring lines.
+                    while len(lines) and len(upload_lines) and upload_lines[-1].group_flag != 0:
+                        upload_lines.append(lines.pop(0))
 
                     if len(upload_lines):
                         # Discard the group flag and upload all.

--- a/socs/agents/acu/agent.py
+++ b/socs/agents/acu/agent.py
@@ -2440,7 +2440,7 @@ class ACUAgent:
         # (The cost is that stopping a scan may take a little longer.)
         MIN_STACK_ADVANCE_TIME = 3.
 
-        # Minimum nuber of points to keep in the stack.
+        # Minimum number of points to keep in the stack.
         _pbc = max(MIN_STACK_POP, MIN_STACK_ADVANCE_TIME / step_time)
         if point_batch_count is None or _pbc > point_batch_count:
             point_batch_count = _pbc
@@ -2597,13 +2597,13 @@ class ACUAgent:
                     while len(lines) and len(upload_lines) and upload_lines[-1].group_flag != 0:
                         upload_lines.append(lines.pop(0))
 
-                    # If there are any upcoming points left with timestamps < 3 step_times, transfer them in.
+                    # If there are any upcoming points left with timestamps the MIN_STACK_ADVANCE_TIME transfer them in.
                     # This prevents the update_line from running out of points
                     # if points are generated faster than the step_time.
                     # This mainly happens with the new turnaround functions that need to generate points
                     # with step_times << 1.0s.
                     first_upload_timestamp = upload_lines[0].timestamp
-                    while len(lines) and (lines[0].timestamp - first_upload_timestamp) < 3 * step_time:
+                    while len(lines) and (lines[0].timestamp - first_upload_timestamp) < MIN_STACK_ADVANCE_TIME:
                         upload_lines.append(lines.pop(0))
 
                     if len(upload_lines):

--- a/socs/agents/acu/agent.py
+++ b/socs/agents/acu/agent.py
@@ -2598,9 +2598,10 @@ class ACUAgent:
                         upload_lines.append(lines.pop(0))
 
                     # If there are any upcoming points left with timestamps < 3 step_times, transfer them in.
-                    # This prevents the update_line from running out of points 
+                    # This prevents the update_line from running out of points
                     # if points are generated faster than the step_time.
-                    # 
+                    # This mainly happens with the new turnaround functions that need to generate points
+                    # with step_times << 1.0s.
                     first_upload_timestamp = upload_lines[0].timestamp
                     while len(lines) and (lines[0].timestamp - first_upload_timestamp) < 3 * step_time:
                         upload_lines.append(lines.pop(0))

--- a/socs/agents/acu/agent.py
+++ b/socs/agents/acu/agent.py
@@ -2597,6 +2597,14 @@ class ACUAgent:
                     while len(lines) and len(upload_lines) and upload_lines[-1].group_flag != 0:
                         upload_lines.append(lines.pop(0))
 
+                    # If there are any upcoming points left with timestamps < 3 step_times, transfer them in.
+                    # This prevents the update_line from running out of points 
+                    # if points are generated faster than the step_time.
+                    # 
+                    first_upload_timestamp = upload_lines[0].timestamp
+                    while len(lines) and (lines[0].timestamp - first_upload_timestamp) < 3 * step_time:
+                        upload_lines.append(lines.pop(0))
+
                     if len(upload_lines):
                         # Discard the group flag and upload all.
                         text = sh.get_track_points_text(

--- a/socs/agents/acu/agent.py
+++ b/socs/agents/acu/agent.py
@@ -2445,11 +2445,6 @@ class ACUAgent:
         if point_batch_count is None or _pbc > point_batch_count:
             point_batch_count = _pbc
 
-        STACK_REFILL_THRESHOLD = \
-            FULL_STACK - point_batch_count - LOOP_STEP / step_time
-        STACK_TARGET = \
-            FULL_STACK - point_batch_count * 2 - LOOP_STEP / step_time
-
         # Special error bits to watch here
         PTRACK_FAULT_KEYS = [
             'ProgramTrack_position_failure',
@@ -2509,6 +2504,9 @@ class ACUAgent:
             faults = {}
             got_points_in = False
             first_upload_time = None
+            t0 = time.time()
+            last_upload_length = 0
+            current_uploaded = 0
             wait_stop_timeout = None
 
             prog_track_err = False
@@ -2565,21 +2563,26 @@ class ACUAgent:
                 if mode == 'abort':
                     lines = []
 
+                if first_upload_time is not None:
+                    dt = time.time() - t0
+                    current_uploaded -= dt
+                    t0 += dt
+
                 # Is it time to upload more lines?
                 # This happens when we initiate (len(upload_lines) == 0) or when our last uploaded points
                 # is less than MIN_STACK_ADVANCE_TIME worth of time away.
-                last_upload_time = time.time()
-                last_upload_length = 0
-                upload_lines = []
-                if len(upload_lines) == 0 or (time.time() - last_upload_time) <= max(MIN_STACK_ADVANCE_TIME, last_upload_length):
+                if (current_uploaded <= MIN_STACK_ADVANCE_TIME - step_time):
+
                     # Make sure that we have at least 1 MIN_STACK_ADVANCE_TIME
                     # worth of lines more than we need so that
                     # after "grabbing 2 * MIN_STACK_ADVANCE_TIME worth of lines", below, there
                     # is still >= 1 MIN_STACK_ADVANCE_TIME worth of lines left. The lines-is-empty
                     # check is used to decide we're done.
-                    while mode == 'go' and (len(lines) == 0 or (lines[-1].timestamp - lines[0].timestamp <= 4 * MIN_STACK_ADVANCE_TIME) or lines[-1].group_flag != 0):
+                    while mode == 'go' and (len(lines) == 0 or ((lines[-1].timestamp - lines[0].timestamp) <= (4 * MIN_STACK_ADVANCE_TIME)) or lines[-1].group_flag != 0):
+                        self.log.info("Filling lines!")
                         try:
                             lines.extend(next(point_gen))
+
                         except StopIteration:
                             mode = 'stop'
                             stop_message = 'Stop due to end of the planned track.'
@@ -2593,8 +2596,9 @@ class ACUAgent:
                             # processed.
                             break
 
+                    upload_lines = []
                     # Grab the minimum batch which is 2 * MIN_STACK_ADVANCE_TIME worth of lines.
-                    while len(lines) and (len(upload_lines) == 0 or (upload_lines[-1].timestamp - upload_lines[0].timestamp) < 2 * MIN_STACK_ADVANCE_TIME):
+                    while len(lines) and (len(upload_lines) == 0 or (upload_lines[-1].timestamp - upload_lines[0].timestamp) < (2 * MIN_STACK_ADVANCE_TIME) - current_uploaded - step_time):
                         upload_lines.append(lines.pop(0))
 
                     # If the last line has a "group" flag, keep transferring lines.
@@ -2602,9 +2606,8 @@ class ACUAgent:
                         upload_lines.append(lines.pop(0))
 
                     if len(upload_lines):
-                        last_upload_time = time.time()
-                        last_upload_length = upload_lines[-1].timestamp - upload_lines[0].timestamp
-
+                        self.log.info(f"Filled upload_lines to {len(upload_lines)}")
+                        self.log.info(f"Last Point {upload_lines[-1].timestamp}, First Point {upload_lines[0].timestamp}")
                         # Discard the group flag and upload all.
                         text = sh.get_track_points_text(
                             upload_lines, timestamp_offset=3, text_block=True)
@@ -2624,6 +2627,8 @@ class ACUAgent:
                         if first_upload_time is None:
                             first_upload_time = time.time()
                         last_upload_az = upload_lines[-1].az
+                        last_upload_length = upload_lines[-1].timestamp - upload_lines[0].timestamp
+                        current_uploaded += last_upload_length
 
                 if len(lines) == 0 and free_positions >= FULL_STACK - 1:
                     if mode == 'stop':

--- a/socs/agents/acu/agent.py
+++ b/socs/agents/acu/agent.py
@@ -2506,6 +2506,7 @@ class ACUAgent:
             first_upload_time = None
             t0 = time.time()
             last_upload_length = 0
+            last_uploaded_timestamp = None
             current_uploaded = 0
             wait_stop_timeout = None
 
@@ -2563,15 +2564,21 @@ class ACUAgent:
                 if mode == 'abort':
                     lines = []
 
+                # Each loop we'll subtract the time since last loop from the current_uplaod
+                # time. This tracks the amount of time advanced since last upload.
+                # We have no absolute reference between the uploaded points and when
+                # those points are consumed by the ACU, so we have to use a relative
+                # reference since we created the points.
                 if first_upload_time is not None:
                     dt = time.time() - t0
                     current_uploaded -= dt
                     t0 += dt
 
                 # Is it time to upload more lines?
-                # This happens when we initiate (len(upload_lines) == 0) or when our last uploaded points
-                # is less than MIN_STACK_ADVANCE_TIME worth of time away.
-                if (current_uploaded <= MIN_STACK_ADVANCE_TIME - step_time):
+                # This happens when the current time of uploaded points is less
+                # than the MIN_STACK_ADVANCE_TIME.
+                # (Meaning we have less than the minimum amount of points uploaded).
+                if (current_uploaded <= MIN_STACK_ADVANCE_TIME):
 
                     # Make sure that we have at least 1 MIN_STACK_ADVANCE_TIME
                     # worth of lines more than we need so that
@@ -2597,8 +2604,9 @@ class ACUAgent:
                             break
 
                     upload_lines = []
-                    # Grab the minimum batch which is 2 * MIN_STACK_ADVANCE_TIME worth of lines.
-                    while len(lines) and (len(upload_lines) == 0 or (upload_lines[-1].timestamp - upload_lines[0].timestamp) < (2 * MIN_STACK_ADVANCE_TIME) - current_uploaded - step_time):
+                    # Grab points to upload until we'll have a total of 2 * MIN_STACK_ADVANCE_TIME uploaded.
+                    # We subtract the current_uploaded here to make sure we upload UP TO 2 * MIN_STACK_ADVANCE_TIME.
+                    while len(lines) and (len(upload_lines) == 0 or (upload_lines[-1].timestamp - upload_lines[0].timestamp) < (2 * MIN_STACK_ADVANCE_TIME) - current_uploaded):
                         upload_lines.append(lines.pop(0))
 
                     # If the last line has a "group" flag, keep transferring lines.
@@ -2627,7 +2635,19 @@ class ACUAgent:
                         if first_upload_time is None:
                             first_upload_time = time.time()
                         last_upload_az = upload_lines[-1].az
-                        last_upload_length = upload_lines[-1].timestamp - upload_lines[0].timestamp
+
+                        # The amount we just uploaded is equal to the time between the last timestamp
+                        # of the last upload and the last timestamp of the current uplaod.
+                        # If this is the first upload, we'll just estimate it as the total time of the current upload.
+                        # This will underestimate the total upload length of the first upload, but thats OK.
+                        if last_uploaded_timestamp is None:
+                            last_upload_length = upload_lines[-1].timestamp - upload_lines[0].timestamp
+                        else:
+                            last_upload_length = upload_lines[-1].timestamp - last_uploaded_timestamp
+
+                        # Track the timestamp of the current upload.
+                        # Update the current_uploaded time.
+                        last_uploaded_timestamp = upload_lines[-1].timestamp
                         current_uploaded += last_upload_length
 
                 if len(lines) == 0 and free_positions >= FULL_STACK - 1:

--- a/socs/agents/acu/agent.py
+++ b/socs/agents/acu/agent.py
@@ -2496,7 +2496,7 @@ class ACUAgent:
             #   a few seconds and clear the stack.
             mode = 'go'
 
-            lines = []
+            point_prov = sh.PointProvider(point_gen)
             last_mode = None
             last_upload_az = None
             start_time = time.time()
@@ -2528,7 +2528,7 @@ class ACUAgent:
                     or (got_progtrack and free_positions < FULL_STACK)
 
                 if last_mode != mode:
-                    self.log.info(f'scan mode={mode}, line_buffer={len(lines)}, track_free={free_positions}')
+                    self.log.info(f'scan mode={mode}, line_buffer={len(point_prov)}, track_free={free_positions}')
                     last_mode = mode
 
                 for k in PTRACK_FAULT_KEYS:
@@ -2559,10 +2559,10 @@ class ACUAgent:
                     if session.status == 'stopping' and mode not in ['stop', 'abort']:
                         mode = 'stop'
                         stop_message = 'User-requested stop.'
-                        lines = []
+                        point_prov.stop()
 
                 if mode == 'abort':
-                    lines = []
+                    point_prov.stop()
 
                 # Each loop we'll subtract the time since last loop from the current_uplaod
                 # time. This tracks the amount of time advanced since last upload.
@@ -2580,38 +2580,21 @@ class ACUAgent:
                 # (Meaning we have less than the minimum amount of points uploaded).
                 if (current_uploaded <= MIN_STACK_ADVANCE_TIME):
 
-                    # Make sure that we have at least 1 MIN_STACK_ADVANCE_TIME
-                    # worth of lines more than we need so that
-                    # after "grabbing 2 * MIN_STACK_ADVANCE_TIME worth of lines", below, there
-                    # is still >= 1 MIN_STACK_ADVANCE_TIME worth of lines left. The lines-is-empty
-                    # check is used to decide we're done.
-                    while mode == 'go' and (len(lines) == 0 or ((lines[-1].timestamp - lines[0].timestamp) <= (4 * MIN_STACK_ADVANCE_TIME)) or lines[-1].group_flag != 0):
-                        self.log.info("Filling lines!")
-                        try:
-                            lines.extend(next(point_gen))
-
-                        except StopIteration:
-                            mode = 'stop'
-                            stop_message = 'Stop due to end of the planned track.'
-
-                        if len(lines) > FULL_STACK / 2:
-                            # This is used to raise an error and
-                            # abort; but it is more likely to occur in
-                            # the case where bad group_flag handling,
-                            # above, is messing things up.  So we just
-                            # break out and let some points get
-                            # processed.
-                            break
-
                     upload_lines = []
                     # Grab points to upload until we'll have a total of 2 * MIN_STACK_ADVANCE_TIME uploaded.
                     # We subtract the current_uploaded here to make sure we upload UP TO 2 * MIN_STACK_ADVANCE_TIME.
-                    while len(lines) and (len(upload_lines) == 0 or (upload_lines[-1].timestamp - upload_lines[0].timestamp) < (2 * MIN_STACK_ADVANCE_TIME) - current_uploaded):
-                        upload_lines.append(lines.pop(0))
+                    while not point_prov.is_empty() and (
+                            len(upload_lines) == 0
+                            or (upload_lines[-1].timestamp - upload_lines[0].timestamp) < (2 * MIN_STACK_ADVANCE_TIME) - current_uploaded):
+                        upload_lines.append(point_prov.pop())
 
                     # If the last line has a "group" flag, keep transferring lines.
-                    while len(lines) and len(upload_lines) and upload_lines[-1].group_flag != 0:
-                        upload_lines.append(lines.pop(0))
+                    while not point_prov.is_empty() and len(upload_lines) and upload_lines[-1].group_flag != 0:
+                        upload_lines.append(point_prov.pop())
+
+                    if point_prov.is_empty():
+                        mode = 'stop'
+                        stop_message = 'Stop due to end of the planned track.'
 
                     if len(upload_lines):
                         self.log.info(f"Filled upload_lines to {len(upload_lines)}")
@@ -2650,7 +2633,7 @@ class ACUAgent:
                         last_uploaded_timestamp = upload_lines[-1].timestamp
                         current_uploaded += last_upload_length
 
-                if len(lines) == 0 and free_positions >= FULL_STACK - 1:
+                if point_prov.is_empty() and free_positions >= FULL_STACK - 1:
                     if mode == 'stop':
                         if wait_stop_timeout is None:
                             self.log.info('Stack is empty; waiting for settling...')

--- a/socs/agents/acu/agent.py
+++ b/socs/agents/acu/agent.py
@@ -2433,17 +2433,13 @@ class ACUAgent:
         # more than that to allow for rounding when we are setting the
         # refill threshold.
         MIN_STACK_POP = 6  # points
+        MAX_ALLOWABLE_FREE_POSITIONS = FULL_STACK - MIN_STACK_POP
 
         # Minimum amount of time (seconds), in advance, to populate
         # the trajectory.  In cases where step_time is short, this
         # creates a longer track window to survive agent outages.
         # (The cost is that stopping a scan may take a little longer.)
         MIN_STACK_ADVANCE_TIME = 3.
-
-        # Minimum number of points to keep in the stack.
-        _pbc = max(MIN_STACK_POP, MIN_STACK_ADVANCE_TIME / step_time)
-        if point_batch_count is None or _pbc > point_batch_count:
-            point_batch_count = _pbc
 
         # Special error bits to watch here
         PTRACK_FAULT_KEYS = [
@@ -2504,10 +2500,7 @@ class ACUAgent:
             faults = {}
             got_points_in = False
             first_upload_time = None
-            t0 = time.time()
-            last_upload_length = 0
-            last_uploaded_timestamp = None
-            current_uploaded = 0
+            last_uploaded_timestamp = 0
             wait_stop_timeout = None
 
             prog_track_err = False
@@ -2564,28 +2557,23 @@ class ACUAgent:
                 if mode == 'abort':
                     point_prov.stop()
 
-                # Each loop we'll subtract the time since last loop from the current_uplaod
-                # time. This tracks the amount of time advanced since last upload.
-                # We have no absolute reference between the uploaded points and when
-                # those points are consumed by the ACU, so we have to use a relative
-                # reference since we created the points.
-                if first_upload_time is not None:
-                    dt = time.time() - t0
-                    current_uploaded -= dt
-                    t0 += dt
-
                 # Is it time to upload more lines?
                 # This happens when the current time of uploaded points is less
                 # than the MIN_STACK_ADVANCE_TIME.
-                # (Meaning we have less than the minimum amount of points uploaded).
-                if (current_uploaded <= MIN_STACK_ADVANCE_TIME):
+                # (Meaning we have less than the minimum time worth of points uploaded).
+                # Or if the total number of free positions is higher than the MAX_ALLOWABLE_FREE_POSITIONS.
+                # (Meaning we haven't uploaded at least the minimum number of points)
+                if ((last_uploaded_timestamp - time.time()) <= MIN_STACK_ADVANCE_TIME) or (free_positions > MAX_ALLOWABLE_FREE_POSITIONS):
 
                     upload_lines = []
-                    # Grab points to upload until we'll have a total of 2 * MIN_STACK_ADVANCE_TIME uploaded.
-                    # We subtract the current_uploaded here to make sure we upload UP TO 2 * MIN_STACK_ADVANCE_TIME.
-                    while not point_prov.is_empty() and (
-                            len(upload_lines) == 0
-                            or (upload_lines[-1].timestamp - upload_lines[0].timestamp) < (2 * MIN_STACK_ADVANCE_TIME) - current_uploaded):
+                    # Grab points from point_prov until our last point is at least
+                    # 2 * MIN_STACK_ADVANCE_TIME seconds from now.
+                    # If that isn't enough points to have MIN_STACK_POP_TIME amount of points uploaded,
+                    # Keep grabbing points until we have enough.
+                    while not point_prov.is_empty() and (len(upload_lines) == 0
+                                                         or upload_lines[-1].timestamp - time.time() < (2 * MIN_STACK_ADVANCE_TIME)
+                                                         or (free_positions - len(upload_lines) > MAX_ALLOWABLE_FREE_POSITIONS)):
+
                         upload_lines.append(point_prov.pop())
 
                     # If the last line has a "group" flag, keep transferring lines.
@@ -2597,8 +2585,6 @@ class ACUAgent:
                         stop_message = 'Stop due to end of the planned track.'
 
                     if len(upload_lines):
-                        self.log.info(f"Filled upload_lines to {len(upload_lines)}")
-                        self.log.info(f"Last Point {upload_lines[-1].timestamp}, First Point {upload_lines[0].timestamp}")
                         # Discard the group flag and upload all.
                         text = sh.get_track_points_text(
                             upload_lines, timestamp_offset=3, text_block=True)
@@ -2619,19 +2605,8 @@ class ACUAgent:
                             first_upload_time = time.time()
                         last_upload_az = upload_lines[-1].az
 
-                        # The amount we just uploaded is equal to the time between the last timestamp
-                        # of the last upload and the last timestamp of the current uplaod.
-                        # If this is the first upload, we'll just estimate it as the total time of the current upload.
-                        # This will underestimate the total upload length of the first upload, but thats OK.
-                        if last_uploaded_timestamp is None:
-                            last_upload_length = upload_lines[-1].timestamp - upload_lines[0].timestamp
-                        else:
-                            last_upload_length = upload_lines[-1].timestamp - last_uploaded_timestamp
-
                         # Track the timestamp of the current upload.
-                        # Update the current_uploaded time.
                         last_uploaded_timestamp = upload_lines[-1].timestamp
-                        current_uploaded += last_upload_length
 
                 if point_prov.is_empty() and free_positions >= FULL_STACK - 1:
                     if mode == 'stop':

--- a/socs/agents/acu/agent.py
+++ b/socs/agents/acu/agent.py
@@ -2565,21 +2565,23 @@ class ACUAgent:
                 if mode == 'abort':
                     lines = []
 
-                upload_lines = []
                 # Is it time to upload more lines?
                 # This happens when we initiate (len(upload_lines) == 0) or when our last uploaded points
                 # is less than MIN_STACK_ADVANCE_TIME worth of time away.
-                if len(upload_lines) == 0 or (time.time() + MIN_STACK_ADVANCE_TIME >= upload_lines[-1].timestamp()):
-
+                last_upload_time = time.time()
+                last_upload_length = 0
+                if len(upload_lines) == 0 or (time.time() - last_upload_time) <= max(MIN_STACK_ADVANCE_TIME, last_upload_length):
+                    self.log.info("Uploading Points!")
                     # Make sure that we have at least 1 MIN_STACK_ADVANCE_TIME
                     # worth of lines more than we need so that 
                     # after "grabbing 2 * MIN_STACK_ADVANCE_TIME worth of lines", below, there
                     # is still >= 1 MIN_STACK_ADVANCE_TIME worth of lines left. The lines-is-empty
                     # check is used to decide we're done.
-                    while mode == 'go' and (len(lines) == 0 or (time.time() + 4 * MIN_STACK_ADVANCE_TIME >= lines[-1].timestamp()) \
+                    while mode == 'go' and (len(lines) == 0 or (time.time() + 4 * MIN_STACK_ADVANCE_TIME >= lines[-1].timestamp) \
                         or lines[-1].group_flag != 0):
                         
                         try:
+                            self.log.info("Restocking Lines")
                             lines.extend(next(point_gen))
                         except StopIteration:
                             mode = 'stop'
@@ -2593,17 +2595,23 @@ class ACUAgent:
                             # break out and let some points get
                             # processed.
                             break
+                    self.log.info(f"Lines restocked to {len(lines)}")
 
                     # Grab the minimum batch which is 2 * MIN_STACK_ADVANCE_TIME worth of lines.
-                    first_upload_timestamp = upload_lines[0].timestamp
-                    while len(lines) and (lines[0].timestamp - first_upload_timestamp) < 2 * MIN_STACK_ADVANCE_TIME:
+                    self.log.info("Filling Upload Lines")
+                    while len(lines) and (len(upload_lines) == 0 or (upload_lines[-1].timestamp - upload_lines[0].timestamp) < 2 * MIN_STACK_ADVANCE_TIME):
                         upload_lines.append(lines.pop(0))
-
+                        
                     # If the last line has a "group" flag, keep transferring lines.
                     while len(lines) and len(upload_lines) and upload_lines[-1].group_flag != 0:
                         upload_lines.append(lines.pop(0))
-
+                    
+                    
+                    self.log.info(f"Filled Upload lines to {len(upload_lines)}")
                     if len(upload_lines):
+                        last_upload_time = time.time()
+                        last_upload_length = upload_lines[-1].timestamp - upload_lines[0].timestamp
+
                         # Discard the group flag and upload all.
                         text = sh.get_track_points_text(
                             upload_lines, timestamp_offset=3, text_block=True)

--- a/socs/agents/acu/agent.py
+++ b/socs/agents/acu/agent.py
@@ -2570,18 +2570,15 @@ class ACUAgent:
                 # is less than MIN_STACK_ADVANCE_TIME worth of time away.
                 last_upload_time = time.time()
                 last_upload_length = 0
+                upload_lines = []
                 if len(upload_lines) == 0 or (time.time() - last_upload_time) <= max(MIN_STACK_ADVANCE_TIME, last_upload_length):
-                    self.log.info("Uploading Points!")
                     # Make sure that we have at least 1 MIN_STACK_ADVANCE_TIME
-                    # worth of lines more than we need so that 
+                    # worth of lines more than we need so that
                     # after "grabbing 2 * MIN_STACK_ADVANCE_TIME worth of lines", below, there
                     # is still >= 1 MIN_STACK_ADVANCE_TIME worth of lines left. The lines-is-empty
                     # check is used to decide we're done.
-                    while mode == 'go' and (len(lines) == 0 or (time.time() + 4 * MIN_STACK_ADVANCE_TIME >= lines[-1].timestamp) \
-                        or lines[-1].group_flag != 0):
-                        
+                    while mode == 'go' and (len(lines) == 0 or (lines[-1].timestamp - lines[0].timestamp <= 4 * MIN_STACK_ADVANCE_TIME) or lines[-1].group_flag != 0):
                         try:
-                            self.log.info("Restocking Lines")
                             lines.extend(next(point_gen))
                         except StopIteration:
                             mode = 'stop'
@@ -2595,19 +2592,15 @@ class ACUAgent:
                             # break out and let some points get
                             # processed.
                             break
-                    self.log.info(f"Lines restocked to {len(lines)}")
 
                     # Grab the minimum batch which is 2 * MIN_STACK_ADVANCE_TIME worth of lines.
-                    self.log.info("Filling Upload Lines")
                     while len(lines) and (len(upload_lines) == 0 or (upload_lines[-1].timestamp - upload_lines[0].timestamp) < 2 * MIN_STACK_ADVANCE_TIME):
                         upload_lines.append(lines.pop(0))
-                        
+
                     # If the last line has a "group" flag, keep transferring lines.
                     while len(lines) and len(upload_lines) and upload_lines[-1].group_flag != 0:
                         upload_lines.append(lines.pop(0))
-                    
-                    
-                    self.log.info(f"Filled Upload lines to {len(upload_lines)}")
+
                     if len(upload_lines):
                         last_upload_time = time.time()
                         last_upload_length = upload_lines[-1].timestamp - upload_lines[0].timestamp

--- a/socs/agents/acu/agent.py
+++ b/socs/agents/acu/agent.py
@@ -2565,8 +2565,16 @@ class ACUAgent:
                 if mode == 'abort':
                     lines = []
 
+                last_upload_size = 0
                 # Is it time to upload more lines?
-                if free_positions >= STACK_REFILL_THRESHOLD:
+                # STACK_REFILL_THRESHOLD is the absolute minimum number of points that can be in the stack
+                # based on the constant_velocity step_time.
+                # FULL_STACK - int(last_upload_size/2) is the minimum number of points that we should
+                # try to reupload based on the number of points in the last upload in case we uploaded
+                # points with a lower dt. We always add at least 2xMIN_STACK_ADVANCE_TIME worth of points,
+                # so this should attempt to always keep MIN_STACK_ADVANCE_TIME worth of points in the
+                # upload.
+                if free_positions >= min(STACK_REFILL_THRESHOLD, FULL_STACK - int(last_upload_size / 2)):
                     new_line_target = max(int(free_positions - STACK_TARGET), 1)
 
                     # Make sure that you get one more line than you
@@ -2603,8 +2611,11 @@ class ACUAgent:
                     # This mainly happens with the new turnaround functions that need to generate points
                     # with step_times << 1.0s.
                     first_upload_timestamp = upload_lines[0].timestamp
-                    while len(lines) and (lines[0].timestamp - first_upload_timestamp) < MIN_STACK_ADVANCE_TIME:
+                    while len(lines) and (lines[0].timestamp - first_upload_timestamp) < 2 * MIN_STACK_ADVANCE_TIME:
                         upload_lines.append(lines.pop(0))
+
+                    # The total number of points we just uploaded is at least 2x the number of points we want.
+                    last_upload_size = len(upload_lines)
 
                     if len(upload_lines):
                         # Discard the group flag and upload all.

--- a/socs/agents/acu/drivers.py
+++ b/socs/agents/acu/drivers.py
@@ -105,6 +105,40 @@ def get_track_points_text(tpl, timestamp_offset=None, with_group_flag=False,
     return all_lines
 
 
+class PointProvider:
+    """Wraps a generator that yields lists of points, but then
+    provides them one by one via the pop method, and can tell the
+    caller when the source is empty.
+
+    """
+
+    def __init__(self, gen):
+        self._gen = gen
+        self._stash = []
+
+    def __len__(self):
+        return len(self._stash)
+
+    def is_empty(self):
+        self._request(1)
+        return len(self._stash) == 0
+
+    def _request(self, n):
+        while self._gen is not None and len(self._stash) < n:
+            try:
+                self._stash.extend(next(self._gen))
+            except StopIteration:
+                self._gen = None
+
+    def pop(self):
+        self._request(1)
+        return self._stash.pop(0)
+
+    def stop(self):
+        self._gen = None
+        self._stash = []
+
+
 def from_file(filename, fmt=None):
     """Load a ProgramTrack trajectory from a file.  This function
     supports two formats. The modern format is a pickle file. The


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Rewrote the `_run_track` function to upload lines by time instead of free points in the ACU.

## Description
<!--- Describe your changes in detail -->
The `_run_track` function in the ACU agent has been refactored to upload ever `MIN_STACK_ADVANCE_TIME` (or the `last_upload_length`) worth of points. The filling of `upload_lines` is also written to always fill to `2 * MIN_STACK_ADVANCE_TIME` worth of points. 

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
The current ACU _run_track function uploads points when the number of free points in the ACU runs below the minimum number of points based on the step_time of the generator. This causes the minimum number of uploaded points to be too small if the step_time ever increases during point generation (like during two_leg turnarounds). Here I've rewritten the uploading to be completed via time since last upload and to always upload at least 2 times the `MINIMUM_STACK_ADVANCE_TIME` worth of points. This should hopefully keep the minimum number of uploaded points at or above `MINIMUM_STACK_ADVANCE_TIME` worth of points at all times.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
Needs to be tested on a real ACU.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
