### PR TITLE
wiregrid_tiltsensor: Catch TypeError and retry get_angle

### DIFF
--- a/socs/agents/wiregrid_tiltsensor/agent.py
+++ b/socs/agents/wiregrid_tiltsensor/agent.py
@@ -114,7 +114,7 @@ class WiregridTiltSensorAgent:
                 try:
                     msg, angles = self.tiltsensor.get_angle()
                     self.log.debug(f'self.tiltsensor.get_angle(): {msg}')
-                except (ValueError, RuntimeError) as e:
+                except (ValueError, RuntimeError, TypeError) as e:
                     self.log.warn(e)
                     msg = 'Failed to get angle. -> Reconnect to the sensor'
                     self.log.warn(msg)


### PR DESCRIPTION

<!--- Provide a general summary of your changes in the Title above -->

## Description
Add `TypeError` to the list of errors to reconnect to the tilt sensor in the exception in `wiregrid_tiltsensor/agent.py`.

## Motivation and Context
When the angle is out of range for the tilt sensor, a TypeError occurs in `get_angle()`. 
This error continues even if the angle is within the range. So I implemented the reconnection to the tilt sensor for the TypeError to fix the error.

Resolves #1042.

## How Has This Been Tested?
No

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.