### PR TITLE
ACU: use new persistent http connection in soaculib

### DIFF
--- a/socs/agents/acu/agent.py
+++ b/socs/agents/acu/agent.py
@@ -287,7 +287,7 @@ class ACUAgent:
         tclient._HTTP11ClientFactory.noisy = False
 
         self.acu_control = aculib.AcuControl(
-            acu_config, backend=RetwistedHttpBackend(persistent=False))
+            acu_config, backend=RetwistedHttpBackend(persistent=True))
         self.acu_read = aculib.AcuControl(
             acu_config, backend=TwistedHttpBackend(persistent=True), readonly=True)
 


### PR DESCRIPTION
## Description

Makes ACU agent use new backend.  This backend should be more stable as it opens a single http command connection to ACU and holds onto it.

Requires soaculib v0.4.3 or later; older versions will fail on startup, due to persistent=True argument.

<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

There is some evidence, in recent ACU communication failures, that rapid commanding (which would previously have required multiple connections) is causing the issues.  There was also some evidence that making such requests inside a twisted thread was causing some errors to not get caught properly.  The exact culprit was not found (i.e. why the thread locked up instead of calling back an error).  But in any case the new solution is what we wanted to, originally, and should be easier to debug if it shows similar comms issues.

## How Has This Been Tested?

I have run this at site on SATP3 and it works well.  So far the lockups that cause lots of trouble before have not been observed.  It's too early to say this fixed them, however.

I've also tested on simulator, where this backend works much better, as new connection overhead really seems to slow down simulator communications.

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
