### PR TITLE
hwp-supervisor: Make freq tolerance configurable

### DIFF
--- a/socs/agents/hwp_supervisor/agent.py
+++ b/socs/agents/hwp_supervisor/agent.py
@@ -820,8 +820,15 @@ class ControlState:
         """
         Waits until the HWP has slowed before shutting off PMX
 
+        Attributes
+        -----------
+        freq_tol : float
+            Tolerance of frequency to consider hwp is stopped.
+        freq_tol_duration : float
+            Duration in seconds that the frequency must be within the tolerance
         min_freq : float
             Frequency (Hz) below which the PMX should be shut off.
+            Defaults to 0.5.
         """
         freq_tol: float
         freq_tol_duration: float

--- a/socs/agents/hwp_supervisor/agent.py
+++ b/socs/agents/hwp_supervisor/agent.py
@@ -823,8 +823,9 @@ class ControlState:
         min_freq : float
             Frequency (Hz) below which the PMX should be shut off.
         """
-        min_freq: float
-        prev_freq: float = None
+        freq_tol: float
+        freq_tol_duration: float
+        min_freq: float = 0.5
 
     @dataclass
     class PmxOff:
@@ -1349,15 +1350,15 @@ class ControlStateMachine:
 
                 time.sleep(10)
                 self.action.set_state(ControlState.WaitForBrake(
-                    min_freq=0.5,
-                    prev_freq=hwp_state.enc_freq,
+                    freq_tol=state.freq_tol,
+                    freq_tol_duration=state.freq_tol_duration,
                 ))
 
             elif isinstance(state, ControlState.WaitForBrake):
                 f0 = query_pid_state()['current_freq']
                 time.sleep(5)
                 f1 = query_pid_state()['current_freq']
-                if f0 < 0.5 or (f1 > f0):
+                if f0 < state.min_freq or (f1 > f0):
                     self.log.info("Turning off PMX and putting PCU in stop mode")
                     self.run_and_validate(clients.pmx.set_off)
                     self.run_and_validate(
@@ -1366,8 +1367,8 @@ class ControlStateMachine:
                     )
                     self.action.set_state(ControlState.WaitForTargetFreq(
                         target_freq=0,
-                        freq_tol=0.05,
-                        freq_tol_duration=30,
+                        freq_tol=state.freq_tol,
+                        freq_tol_duration=state.freq_tol_duration,
                     ))
                     return
 
@@ -1501,6 +1502,14 @@ class HWPSupervisor:
         self.driver_power_cycle_wait_time = args.driver_power_cycle_wait_time
         self.gripper_power_agent_type = args.gripper_power_agent_type
         self.gripper_iboot_outlets = args.gripper_iboot_outlets
+
+        self.spin_up_freq_tol = args.spin_up_freq_tol
+        self.spin_up_freq_tol_duration = args.spin_up_freq_tol_duration
+        self.spin_down_freq_tol = args.spin_down_freq_tol
+        self.spin_down_freq_tol_duration = args.spin_down_freq_tol_duration
+        self.brake_freq_tol = args.brake_freq_tol
+        self.brake_freq_tol_duration = args.brake_freq_tol_duration
+        self.brake_voltage = args.brake_voltage
 
         self.shutdown_no_data_timeout = args.shutdown_no_data_timeout
         self.shutdown_delay = args.shutdown_delay
@@ -1760,8 +1769,8 @@ class HWPSupervisor:
         return True, 'Stopping spin control process'
 
     @ocs_agent.param('target_freq', type=float)
-    @ocs_agent.param('freq_tol', type=float, default=0.05)
-    @ocs_agent.param('freq_tol_duration', type=float, default=10)
+    @ocs_agent.param('freq_tol', type=float, default=None)
+    @ocs_agent.param('freq_tol_duration', type=float, default=None)
     def pid_to_freq(self, session, params):
         """pid_to_freq(target_freq=2.0, freq_tol=0.05, freq_tol_duration=10)
 
@@ -1775,9 +1784,11 @@ class HWPSupervisor:
             looking at the cryostat from the sky.
         freq_tol : float
             Frequency threshold (Hz) for determining when the HWP is at the target frequency.
+            Defaults to ``spin_up_freq_tol`` from config.
         freq_tol_duration : float
             Duration (seconds) for which the HWP must be within ``freq_tol`` of the
             ``target_freq`` to be considered successful.
+            Defaults to ``spin_up_freq_tol_duration`` from config.
 
         Notes
         --------
@@ -1793,6 +1804,17 @@ class HWPSupervisor:
                 'success': True}
             }
         """
+        freq_tol = (
+            params["freq_tol"]
+            if params["freq_tol"] is not None
+            else self.spin_up_freq_tol
+        )
+        freq_tol_duration = (
+            params["freq_tol_duration"]
+            if params["freq_tol_duration"] is not None
+            else self.spin_up_freq_tol_duration
+        )
+
         if params['target_freq'] >= 0:
             d = '1' if self.forward_is_cw else '0'
         else:
@@ -1800,8 +1822,8 @@ class HWPSupervisor:
 
         state = ControlState.PIDToFreq(
             target_freq=np.abs(params['target_freq']),
-            freq_tol=params['freq_tol'],
-            freq_tol_duration=params['freq_tol_duration'],
+            freq_tol=freq_tol,
+            freq_tol_duration=freq_tol_duration,
             direction=d
         )
         action = self.control_state_machine.request_new_action(state)
@@ -1850,9 +1872,9 @@ class HWPSupervisor:
         action.sleep_until_complete(session=session)
         return action.success, f"Completed with state: {action.cur_state_info.state}"
 
-    @ocs_agent.param('freq_tol', type=float, default=0.05)
-    @ocs_agent.param('freq_tol_duration', type=float, default=10)
-    @ocs_agent.param('brake_voltage', type=float, default=10.)
+    @ocs_agent.param('freq_tol', type=float, default=None)
+    @ocs_agent.param('freq_tol_duration', type=float, default=None)
+    @ocs_agent.param('brake_voltage', type=float, default=None)
     def brake(self, session, params):
         """brake(freq_tol=0.05, freq_tol_duration=10, brake_voltage=10)
 
@@ -1862,11 +1884,14 @@ class HWPSupervisor:
         -------
         freq_tol : float
             Frequency tolerance (Hz) for determining when the HWP is at the target frequency.
+            Defaults to ``brake_freq_tol`` from config.
         freq_tol_duration : float
             Duration (seconds) for which the HWP must be within ``freq_tol`` of the
             ``target_freq`` to be considered successful.
+            Defaults to ``brake_freq_tol_duration`` from config.
         brake_voltage: float
             Voltage to use when braking the HWP.
+            Defaults to ``brake_voltage`` from config.
 
         Notes
         --------
@@ -1882,18 +1907,34 @@ class HWPSupervisor:
                 'success': True}
             }
         """
+        freq_tol = (
+            params["freq_tol"]
+            if params["freq_tol"] is not None
+            else self.brake_freq_tol
+        )
+        freq_tol_duration = (
+            params["freq_tol_duration"]
+            if params["freq_tol_duration"] is not None
+            else self.brake_freq_tol_duration
+        )
+        brake_voltage = (
+            params["brake_voltage"]
+            if params["brake_voltage"] is not None
+            else self.brake_voltage
+        )
+
         state = ControlState.Brake(
-            freq_tol=params['freq_tol'],
-            freq_tol_duration=params['freq_tol_duration'],
-            brake_voltage=params['brake_voltage'],
+            freq_tol=freq_tol,
+            freq_tol_duration=freq_tol_duration,
+            brake_voltage=brake_voltage,
         )
         action = self.control_state_machine.request_new_action(state)
         action.sleep_until_complete(session=session)
         return action.success, f"Completed with state: {action.cur_state_info.state}"
 
     @ocs_agent.param('wait_stop', type=bool, default=False)
-    @ocs_agent.param('freq_tol', type=float, default=0.05)
-    @ocs_agent.param('freq_tol_duration', type=float, default=30)
+    @ocs_agent.param('freq_tol', type=float, default=None)
+    @ocs_agent.param('freq_tol_duration', type=float, default=None)
     def pmx_off(self, session, params):
         """pmx_off(wait_stop=False, freq_tol=0.05, freq_tol_duration=30)
 
@@ -1905,8 +1946,10 @@ class HWPSupervisor:
             Whether to wait until hwp stops.
         freq_tol : float
             Tolerance of frequency to consider hwp is stopped.
+            Defaults to ``spin_down_freq_tol`` from config.
         freq_tol_duration : float
             Duration in seconds that the frequency must be within the tolerance
+            Defaults to ``spin_down_freq_tol_duration`` from config.
 
         Notes
         --------
@@ -1922,10 +1965,21 @@ class HWPSupervisor:
                 'success': True}
             }
         """
+        freq_tol = (
+            params["freq_tol"]
+            if params["freq_tol"] is not None
+            else self.spin_down_freq_tol
+        )
+        freq_tol_duration = (
+            params["freq_tol_duration"]
+            if params["freq_tol_duration"] is not None
+            else self.spin_down_freq_tol_duration
+        )
+
         state = ControlState.PmxOff(
             wait_stop=params['wait_stop'],
-            freq_tol=params['freq_tol'],
-            freq_tol_duration=params['freq_tol_duration'],
+            freq_tol=freq_tol,
+            freq_tol_duration=freq_tol_duration,
         )
         action = self.control_state_machine.request_new_action(state)
         action.sleep_until_complete(session=session)
@@ -2200,6 +2254,34 @@ def make_parser(parser=None):
         '--forward-dir', choices=['cw', 'ccw'], default='cw',
         help="Whether the PID 'forward' direction is cw or ccw. "
              "cw or ccw is defined when hwp is viewed from the sky side."
+    )
+    pgroup.add_argument(
+        '--spin-up-freq-tol', type=float, default=0.05,
+        help="Frequency tolerance (Hz) for pid_to_freq task",
+    )
+    pgroup.add_argument(
+        '--spin-up-freq-tol-duration', type=float, default=10.0,
+        help="Frequency tolerance duration (sec) for pid_to_freq task",
+    )
+    pgroup.add_argument(
+        '--spin-down-freq-tol', type=float, default=0.05,
+        help="Frequency tolerance (Hz) for pmx_off task",
+    )
+    pgroup.add_argument(
+        '--spin-down-freq-tol-duration', type=float, default=30.0,
+        help="Frequency tolerance duration (sec) for pmx_off task",
+    )
+    pgroup.add_argument(
+        '--brake-freq-tol', type=float, default=0.05,
+        help="Frequency tolerance (Hz) for brake task",
+    )
+    pgroup.add_argument(
+        '--brake-freq-tol-duration', type=float, default=10.0,
+        help="Frequency tolerance duration (sec) for brake task",
+    )
+    pgroup.add_argument(
+        '--brake-voltage', type=float, default=10.0,
+        help="Voltage to use when braking the HWP",
     )
     pgroup.add_argument(
         '--shutdown-no-data-timeout', type=float, default=15 * 60,


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Make tolerance of hwp-supervisor tasks configurable.

Note: prev_freq of WaitForBrake was not used and deleted.

## Motivation and Context
satp2 had issue that hwp keep spins at very low rate 0.06-0.08 Hz when brake (obs_1776949383_satp2_1111111).
To avoid this issue, we would like to slightly increase the freq_tol of brake task (and pmx_off task) of satp2.  sorunlib.hwp.spin_down calls disable_driver_board after sorunlib.hwp.stop so it should ensure that hwp stops.
https://github.com/simonsobs/sorunlib/blob/033a4df897ba373921803543dd94decbd69e9832/src/sorunlib/hwp.py#L97

## How Has This Been Tested?
Not yet -> Tested at satp2 on May 11th 2026.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
