### PR TITLE
fls: Avoid publishing nan photocurrent value

### DIFF
--- a/socs/agents/fls/agent.py
+++ b/socs/agents/fls/agent.py
@@ -161,6 +161,9 @@ class FLSAgent:
                  'scan_direction': 1,
                  'integration_time': 299.3421
                  'timestamp': 1771277799.562098}
+
+            In cases where the DLC Smart reads an invalid value for photocurrent, the
+            photocurrent will be recorded as 999999.
         """
         with self.lock.acquire_timeout(0, job='acq') as acquired:
             if not acquired:

--- a/socs/agents/fls/drivers.py
+++ b/socs/agents/fls/drivers.py
@@ -233,10 +233,10 @@ class DLCSmart(TCPInterface):
         self.param_set("lockin:integration-time", int_time)
 
     def check_scan_params(self):
-        smode = self.param_ref("frequency:scan-mode-fast")
-        if 'fast' in smode:
+        fast = self.param_ref("frequency:scan-mode-fast")
+        if 'fast' in fast:
             fast = 'fast'
-        elif 'precise' in smode:
+        elif 'precise' in fast:
             fast = 'precise'
         smin = self.param_ref("frequency:frequency-min")
         smax = self.param_ref("frequency:frequency-max")

--- a/socs/agents/fls/drivers.py
+++ b/socs/agents/fls/drivers.py
@@ -233,7 +233,11 @@ class DLCSmart(TCPInterface):
         self.param_set("lockin:integration-time", int_time)
 
     def check_scan_params(self):
-        fast = self.param_ref("frequency:scan-mode-fast")
+        smode = self.param_ref("frequency:scan-mode-fast")
+        if 'fast' in smode:
+            fast = 'fast'
+        elif 'precise' in smode:
+            fast = 'precise'
         smin = self.param_ref("frequency:frequency-min")
         smax = self.param_ref("frequency:frequency-max")
         sstep = self.param_ref("frequency:frequency-step")
@@ -290,7 +294,7 @@ class DLCSmart(TCPInterface):
         if '#t' in photocurrent:
             photocurrent = photocurrent.strip('( #t)')
         else:
-            photocurrent = 'nan'
+            photocurrent = 999999.
 
         # Set and actual frequency
         set_frequency = self.param_ref("frequency:frequency-set")

--- a/socs/agents/fls/drivers.py
+++ b/socs/agents/fls/drivers.py
@@ -234,10 +234,6 @@ class DLCSmart(TCPInterface):
 
     def check_scan_params(self):
         fast = self.param_ref("frequency:scan-mode-fast")
-        if 'fast' in fast:
-            fast = 'fast'
-        elif 'precise' in fast:
-            fast = 'precise'
         smin = self.param_ref("frequency:frequency-min")
         smax = self.param_ref("frequency:frequency-max")
         sstep = self.param_ref("frequency:frequency-step")


### PR DESCRIPTION
- drivers: In sampling, changed 'nan' value for photocurrent to a non-nan float (999999.)
- drivers: In check_scan_params, changed handling of scan mode to remove excess '/'
- agent: Updated acq docstring in agent to reflect change to photocurrent handling

## Description
This is a bug fix for the FLS Agent acq process.

## Motivation and Context
The Influx agent was crashing due to the FLS Agent publishing a 'nan' value in its acq process.
We will handle the invalid data case by publishing an unrealistic non-nan float. Additional update
to publish a cleaner string for scan mode (remove an excess '/') when possible.

## How Has This Been Tested?
Currently untested.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
