### PR TITLE
tcp: Add optional reset when an error is raised on recv

### DIFF
--- a/docs/developer/interfaces/tcp.rst
+++ b/docs/developer/interfaces/tcp.rst
@@ -15,6 +15,8 @@ A few important things to know about the behavior of the interface class:
   ``self.comm`` will be ``None``.
 * The connection will be reset when ``send()`` is called if this happens.
   An exception will be raised if it still cannot connect.
+* The connection will be reset when an error is encountered when sending
+  and optionally reset when receiving.
 * The interface is built to mimic ``socket.send()`` and ``socket.recv()``, but
   uses ``socket.sendall()`` in its implementation, so all bytes in the included
   message are sent to the socket.

--- a/docs/developer/interfaces/tcp.rst
+++ b/docs/developer/interfaces/tcp.rst
@@ -15,6 +15,8 @@ A few important things to know about the behavior of the interface class:
   ``self.comm`` will be ``None``.
 * The connection will be reset when ``send()`` is called if this happens.
   An exception will be raised if it still cannot connect.
+* The connection will be reset when an error is encountered when either sending
+  or receiving.
 * The interface is built to mimic ``socket.send()`` and ``socket.recv()``, but
   uses ``socket.sendall()`` in its implementation, so all bytes in the included
   message are sent to the socket.

--- a/socs/tcp.py
+++ b/socs/tcp.py
@@ -52,6 +52,9 @@ class TCPInterface:
 
     def _reset(self):
         print("Resetting the connection to the device.")
+        if self.comm:
+            self.comm.close()
+            self.comm = None
         self.comm = self._connect((self.ip_address, self.port))
 
     def send(self, msg):

--- a/socs/tcp.py
+++ b/socs/tcp.py
@@ -147,15 +147,22 @@ class TCPInterface:
             Raised if the socket is not ready to read from.
 
         """
-        self._check_ready()
+        try:
+            self._check_ready()
+        except ConnectionError as e:
+            print(e)
+            self._reset()
+            raise ConnectionError
         try:
             data = self.comm.recv(bufsize)
         except OSError as e:
             print(f"Connection error: {e}")
+            self._reset()
             raise ConnectionError
         except Exception as e:
             print(f"Caught unexpected {type(e).__name__} during recv:")
             print(f"  {e}")
+            self._reset()
             raise ConnectionError
         return data
 

--- a/socs/tcp.py
+++ b/socs/tcp.py
@@ -126,7 +126,7 @@ class TCPInterface:
         if not sel.select(self.timeout):
             raise ConnectionError("Socket not ready to read. Possible timeout.")
 
-    def recv(self, bufsize=4096):
+    def recv(self, bufsize=4096, reset_on_error=False):
         """Receive response from the device.
 
         This method will check if the socket is ready to be read from before
@@ -137,6 +137,11 @@ class TCPInterface:
         ----------
         bufsize : int
             Amount of data to be recieved in bytes. Defaults to 4096.
+        reset_on_error : bool
+            Flag to set whether to recreate the socket connection on error.
+            This can be useful to effectively clear the network buffer, but
+            some devices don't handle multiple rapid connections well.
+            Defaults to False.
 
         Returns
         -------
@@ -150,15 +155,27 @@ class TCPInterface:
             Raised if the socket is not ready to read from.
 
         """
-        self._check_ready()
+        if reset_on_error:
+            try:
+                self._check_ready()
+            except ConnectionError as e:
+                print(e)
+                self._reset()
+                raise ConnectionError
+        else:
+            self._check_ready()
         try:
             data = self.comm.recv(bufsize)
         except OSError as e:
             print(f"Connection error: {e}")
+            if reset_on_error:
+                self._reset()
             raise ConnectionError
         except Exception as e:
             print(f"Caught unexpected {type(e).__name__} during recv:")
             print(f"  {e}")
+            if reset_on_error:
+                self._reset()
             raise ConnectionError
         return data
 

--- a/socs/tcp.py
+++ b/socs/tcp.py
@@ -39,7 +39,7 @@ class TCPInterface:
         try:
             sock.connect(address)
         except TimeoutError:
-            print(f"Connection not established within {self.timeout}.")
+            print(f"Connection not established within {self.timeout} seconds.")
             return
         except OSError as e:
             print(f"Unable to connect. {e}")


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
This PR adds an optional 'reset on error' flag to the `recv()` method in the `TCPInterface` class. This enables recreating the socket connection when an error is encountered when receiving. This is what happens when an error is encountered on `send`.

This also explicitly closes the socket if it's still open during a reset.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
While testing using this class on the Lakeshore372 agent I found that I would receive stale messages from before a disconnection, crashing the agent in other unpredictable ways.

Resetting on error in `recv` avoids these stale messages by establishing a new session.

I hadn't seen this behavior when testing other devices, but it's common for most agents to send the same command over and over in `acq`, which makes it difficult to see stale messages.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
This has been run with a yet to be PR'd version of the Lakeshore372 agent and tested by disconnecting the Ethernet cable to the 372, as well as by power cycling the 372.

These logs contain both a disconnection and a power cycle:
```
2026-05-19T16:32:35-0400 acq:1 Status is now "running".
2026-05-19T16:32:35-0400 Starting data acquisition for observatory.LSA23JD
2026-05-19T16:32:56-0400 Socket not ready to read. Possible timeout.
2026-05-19T16:32:56-0400 Resetting the connection to the device.
2026-05-19T16:33:06-0400 Connection not established within 10 seconds.
2026-05-19T16:33:06-0400 Failed to get data from LS372. Check network connection.
2026-05-19T16:33:07-0400 Connection not established.
2026-05-19T16:33:07-0400 Resetting the connection to the device.
2026-05-19T16:33:17-0400 Connection not established within 10 seconds.
2026-05-19T16:33:17-0400 Failed to get data from LS372. Check network connection.
2026-05-19T16:33:18-0400 Connection not established.
2026-05-19T16:33:18-0400 Resetting the connection to the device.
2026-05-19T16:33:28-0400 Connection re-established.
2026-05-19T16:34:33-0400 Socket not ready to read. Possible timeout.
2026-05-19T16:34:33-0400 Resetting the connection to the device.
2026-05-19T16:34:43-0400 Connection not established within 10 seconds.
2026-05-19T16:34:43-0400 Failed to get data from LS372. Check network connection.
2026-05-19T16:34:44-0400 Connection not established.
2026-05-19T16:34:44-0400 Resetting the connection to the device.
2026-05-19T16:34:54-0400 Connection not established within 10 seconds.
2026-05-19T16:34:54-0400 Failed to get data from LS372. Check network connection.
2026-05-19T16:34:55-0400 Connection not established.
2026-05-19T16:34:55-0400 Resetting the connection to the device.
2026-05-19T16:35:05-0400 Connection not established within 10 seconds.
2026-05-19T16:35:05-0400 Failed to get data from LS372. Check network connection.
2026-05-19T16:35:06-0400 Connection not established.
2026-05-19T16:35:06-0400 Resetting the connection to the device.
2026-05-19T16:35:11-0400 Connection re-established.
```

I ended up making it optional because some devices did not like multiple rapid connections in my testing.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
