### PR TITLE
acu: Fix upload-on-change and go_to logic bugs

### DIFF
--- a/socs/agents/acu/agent.py
+++ b/socs/agents/acu/agent.py
@@ -1296,7 +1296,7 @@ class ACUAgent:
         # (SATP), but in "cold" cases where siren needs to sound, this
         # can be as long as 12 seconds.  For the LAT, can take an
         # extra couple seconds if there were faults to clear.
-        MAX_STARTUP_TIME = 15.
+        MAX_STARTUP_TIME = 20.
 
         # How long does it take to sound the warning horn?  It takes
         # 10 seconds.  Don't wait longer than this.
@@ -1306,6 +1306,12 @@ class ACUAgent:
         # brakes released, except in case that warning horn is
         # sounding?  3 seconds should be enough.
         WARNING_HORN_DETECT = 3.
+
+        # How long after mode change should we wait before signaling
+        # to caller that we have passed the "init" stage?  Without
+        # this check, we can get charged double warning horn penalty
+        # for 2-axis moves on LAT.
+        MIN_INIT_PHASE = 1.
 
         # Velocity to assume when computing maximum time a move should
         # take (to bail out in unforeseen circumstances).  There are
@@ -1492,6 +1498,11 @@ class ACUAgent:
                     elif time_since_start > WARNING_HORN_DETECT and not warning_horn:
                         warning_horn = True
                         self.log.info('Warning horn is probably sounding.')
+                    elif state_feedback['state'] == 'init' and time_since_start > MIN_INIT_PHASE:
+                        # This is to prevent az and el warning horns
+                        # from each incurring a 10s delay...
+                        state_feedback['state'] = 'wait'
+
                 elif still and motion_expected:
                     self.log.error(f'Motion did not start within {MAX_STARTUP_TIME:.1f} s.')
                     state = state.FAIL

--- a/socs/agents/acu/agent.py
+++ b/socs/agents/acu/agent.py
@@ -121,8 +121,14 @@ MONITOR_STRUCTURE = [
     ('ACU_emergency', 'ACU_emergency', None, None),
     ('ACU_corotator', 'corotator', None, None),
     ('ACU_shutter', 'shutter', None, None),
-    ('ACU_tilt', 'tilt_slow', 'changed', 0.5),
+
+    # Deprecated: tilt_slow and tilt_fast. Removed after soaculib 0.4.3
+    ('ACU_tilt_old', 'tilt_slow', 'changed', 0.5),
     (None, 'tilt_fast', None, None),
+
+    # New tiltmeter dataset.
+    ('ACU_tilt', 'tiltmeter', 'tick', None),
+
     ('ACU_sun_avoidance', 'sun_avoidance', None, 1.),
     ('ACU_corrections', 'corrections', None, 10.),
     ('ACU_hvac_data', 'hvac_data', None, 10.),
@@ -911,7 +917,7 @@ class ACUAgent:
                 new_blocks[block_name] = {
                     'timestamp': self.data['status']['summary']['ctime'],
                     'block_name': block_name,
-                    'data': self.data['status'][data_key],
+                    'data': {} | self.data['status'][data_key],
                 }
 
             # Only keep blocks that have changed or have new data.


### PR DESCRIPTION

## Description

First fix is to the LAT tiltmeter readout.  Due to a bug, this was writing out to influx but not to HK data stream.  In fact this affected any stream marked to "update on change".  This will increase the time precision of slowly-changing ACU fields (such as error bits), in the HK output.

Also took this opportunity to redefine tiltmeter data fields; see https://github.com/simonsobs/soaculib/pull/45.  These agent changes are backwards compatible with existing soaculib.  But once this is approved, we should merge the soaculib one before merging this, so new soaculib goes in the docker image.

Second fix is to more rapidly set Preset mode, on two axes, even if warning horn seems to be sounding.  It seems that on LAT the warning horn is independent for az and el axes, and without this fix those horns will sound serially instead of at the same time.

Also increased MAX_STARTUP_TIME to 20s, since LAT can be really slow to get going sometimes, it seems...

## Motivation and Context

Tiltmeter readout has been odd for a while but the data themselves didn't seem worth keeping so it was not prioritized.  But an ACU fix must have improved that datastream, and now we want to start recording those data better.  (Older data can be extracted from influxdb if needed.)

The warning horn issue was discovered in looking at https://github.com/simonsobs/socs/issues/1057 closely.

This PR resolves https://github.com/simonsobs/socs/issues/1057

## How Has This Been Tested?

Tested with simulator; but the change in state machine means we need to test on a real system too.  Will leave as draft until that test is done.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
