### PR TITLE
tpg366: Make acq process robust to network disruptions

### DIFF
--- a/docs/agents/pfeiffer.rst
+++ b/docs/agents/pfeiffer.rst
@@ -79,3 +79,9 @@ Below is an example client to start data acquisition::
     If ``['--mode', 'acq']`` is specified in the ocs configuration file,
     acquisition will begin automatically upon agent startup, so there may be no
     need to run this client.
+
+Supporting APIs
+---------------
+
+.. autoclass:: socs.agents.pfeiffer_tpg366.drivers.TPG366
+    :members:

--- a/socs/agents/pfeiffer_tpg366/agent.py
+++ b/socs/agents/pfeiffer_tpg366/agent.py
@@ -106,7 +106,6 @@ class PfeifferAgent:
         """
         if self.take_data:
             self.take_data = False
-            self.gauge.close()
             return True, 'requested to stop taking data.'
         else:
             return False, 'acq is not currently running'

--- a/socs/agents/pfeiffer_tpg366/agent.py
+++ b/socs/agents/pfeiffer_tpg366/agent.py
@@ -76,6 +76,16 @@ class PfeifferAgent:
                     session.degraded = True
                     time.sleep(1)  # wait between reconnection attempts
                     continue
+                # When reconnecting after a network outage it's likely we'll
+                # get some junk that can't be processed by
+                # self.gauge.read_pressure_all(), but doesn't show as a
+                # ConnectionError. This will just skip that one time and resume
+                # data collecting.
+                except Exception as e:
+                    self.log.error(f"Caught unexpected error: {e}")
+                    session.degraded = True
+                    time.sleep(1)  # wait between reconnection attempts
+                    continue
 
                 # Loop through all the channels on the device
                 for channel in range(len(pressure_array)):

--- a/socs/agents/pfeiffer_tpg366/agent.py
+++ b/socs/agents/pfeiffer_tpg366/agent.py
@@ -8,7 +8,7 @@ import txaio
 from ocs import ocs_agent, site_config
 from ocs.ocs_twisted import TimeoutLock
 
-from socs.agents.pfeiffer_tpg366.drivers import Pfeiffer
+from socs.agents.pfeiffer_tpg366.drivers import TPG366
 
 # For logging
 txaio.use_twisted()
@@ -23,7 +23,7 @@ class PfeifferAgent:
         self.lock = TimeoutLock()
         self.f_sample = f_sample
         self.take_data = False
-        self.gauge = Pfeiffer(ip_address, int(port))
+        self.gauge = TPG366(ip_address, int(port))
         agg_params = {'frame_length': 60, }
         self.agent.register_feed('pressures',
                                  record=True,

--- a/socs/agents/pfeiffer_tpg366/agent.py
+++ b/socs/agents/pfeiffer_tpg366/agent.py
@@ -66,7 +66,17 @@ class PfeifferAgent:
                 # Useful for debugging, but should separate to a task to cut
                 # down on queries in the main acq() loop.
                 # self.gauge.channel_power()
-                pressure_array = self.gauge.read_pressure_all()
+                try:
+                    pressure_array = self.gauge.read_pressure_all()
+                    if session.degraded:
+                        self.log.info("Connection re-established.")
+                        session.degraded = False
+                except ConnectionError:
+                    self.log.error("Failed to get data from device. Check network connection.")
+                    session.degraded = True
+                    time.sleep(1)  # wait between reconnection attempts
+                    continue
+
                 # Loop through all the channels on the device
                 for channel in range(len(pressure_array)):
                     data['data']["pressure_ch" + str(channel + 1)] = pressure_array[channel]

--- a/socs/agents/pfeiffer_tpg366/agent.py
+++ b/socs/agents/pfeiffer_tpg366/agent.py
@@ -1,123 +1,17 @@
-# Script to log and readout pfeiffer TPG 366 gauge contoller
-# via Ethernet connection
-# Zhilei Xu, Tanay Bhandarkar
+# Original script by Zhilei Xu and Tanay Bhandarkar.
 
 import argparse
 import os
-import socket
 import time
 
-import numpy as np
 import txaio
 from ocs import ocs_agent, site_config
 from ocs.ocs_twisted import TimeoutLock
 
+from socs.agents.pfeiffer_tpg366.drivers import Pfeiffer
+
 # For logging
 txaio.use_twisted()
-
-BUFF_SIZE = 128
-ENQ = '\x05'
-
-
-class Pfeiffer:
-    """CLASS to control and retrieve data from the pfeiffer tpg366
-    pressure gauge controller
-
-
-    Args:
-        ip_address: IP address of the deivce
-        porti (int): 8000 (fixed for the device)
-
-    Attributes:
-       read_pressure reads the pressure from one channel (given as an argument)
-       read_pressure_all reads pressures from the six channels
-       close closes the socket
-    """
-
-    def __init__(self, ip_address, port, timeout=10,
-                 f_sample=1.):
-        self.ip_address = ip_address
-        self.port = port
-        self.comm = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
-        self.comm.connect((self.ip_address, self.port))
-        self.comm.settimeout(timeout)
-        self.log = txaio.make_logger()
-
-    def channel_power(self):
-        """
-        Function to check the power status of all channels.
-
-        Args:
-            None
-
-        Returns:
-            List of channel states.
-
-        """
-        msg = 'SEN\r\n'
-        self.comm.send(msg.encode())
-        self.comm.recv(BUFF_SIZE).decode()
-        self.comm.send(ENQ.encode())
-        read_str = self.comm.recv(BUFF_SIZE).decode()
-        power_str = read_str.split('\r')
-        power_states = np.array(power_str[0].split(','), dtype=int)
-        if any(chan == 1 for chan in power_states):
-            channel_states = [index + 1 for index, state in enumerate(power_states) if state == 1]
-            self.log.debug("The following channels are off: {}".format(channel_states))
-        return channel_states
-
-    def read_pressure(self, ch_no):
-        """
-        Function to measure the pressure of one given channel
-        ch_no is the chanel to be measured (e.g. 1-6)
-        returns the measured pressure as a float
-
-        Args:
-            ch_no: The channel to be measured (1-6)
-
-        Returns:
-            pressure as a float
-        """
-        msg = 'PR%d\r\n' % ch_no
-        self.comm.send(msg.encode())
-        self.comm.recv(BUFF_SIZE).decode()
-        self.comm.send(ENQ.encode())
-        read_str = self.comm.recv(BUFF_SIZE).decode()
-        pressure_str = read_str.split(',')[-1].split('\r')[0]
-        pressure = float(pressure_str)
-        return pressure
-
-    def read_pressure_all(self):
-        """measure the pressure of all channel
-        Return an array of 6 pressure values as a float array
-
-        Args:
-            None
-
-        Returns:
-            6 element array corresponding to each channels
-            pressure reading, as floats
-        """
-        msg = 'PRX\r\n'
-        self.comm.send(msg.encode())
-        # Could use this to catch exemptions, for troubleshooting
-        self.comm.recv(BUFF_SIZE).decode()
-        self.comm.send(ENQ.encode())
-        read_str = self.comm.recv(BUFF_SIZE).decode()
-        pressure_str = read_str.split('\r')[0]
-        gauge_states = pressure_str.split(',')[::2]
-        gauge_states = np.array(gauge_states, dtype=int)
-        pressures = pressure_str.split(',')[1::2]
-        pressures = [float(p) for p in pressures]
-        if any(state != 0 for state in gauge_states):
-            index = np.where(gauge_states != 0)
-            for j in index[0]:
-                pressures[j] = 0.
-        return pressures
-
-    def close(self):
-        """Close the socket of the connection"""
-        self.comm.close()
 
 
 class PfeifferAgent:

--- a/socs/agents/pfeiffer_tpg366/drivers.py
+++ b/socs/agents/pfeiffer_tpg366/drivers.py
@@ -4,7 +4,7 @@ import numpy as np
 
 from socs.tcp import TCPInterface
 
-BUFF_SIZE = 128
+BUFF_SIZE = 4096
 ENQ = '\x05'
 
 

--- a/socs/agents/pfeiffer_tpg366/drivers.py
+++ b/socs/agents/pfeiffer_tpg366/drivers.py
@@ -1,0 +1,107 @@
+# Original script by Zhilei Xu and Tanay Bhandarkar.
+
+import socket
+
+import numpy as np
+
+BUFF_SIZE = 128
+ENQ = '\x05'
+
+
+class Pfeiffer:
+    """CLASS to control and retrieve data from the pfeiffer tpg366
+    pressure gauge controller
+
+
+    Args:
+        ip_address: IP address of the deivce
+        porti (int): 8000 (fixed for the device)
+
+    Attributes:
+       read_pressure reads the pressure from one channel (given as an argument)
+       read_pressure_all reads pressures from the six channels
+       close closes the socket
+    """
+
+    def __init__(self, ip_address, port, timeout=10,
+                 f_sample=1.):
+        self.ip_address = ip_address
+        self.port = port
+        self.comm = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+        self.comm.connect((self.ip_address, self.port))
+        self.comm.settimeout(timeout)
+
+    def channel_power(self):
+        """
+        Function to check the power status of all channels.
+
+        Args:
+            None
+
+        Returns:
+            List of channel states.
+
+        """
+        msg = 'SEN\r\n'
+        self.comm.send(msg.encode())
+        self.comm.recv(BUFF_SIZE).decode()
+        self.comm.send(ENQ.encode())
+        read_str = self.comm.recv(BUFF_SIZE).decode()
+        power_str = read_str.split('\r')
+        power_states = np.array(power_str[0].split(','), dtype=int)
+        if any(chan == 1 for chan in power_states):
+            channel_states = [index + 1 for index, state in enumerate(power_states) if state == 1]
+        return channel_states
+
+    def read_pressure(self, ch_no):
+        """
+        Function to measure the pressure of one given channel
+        ch_no is the chanel to be measured (e.g. 1-6)
+        returns the measured pressure as a float
+
+        Args:
+            ch_no: The channel to be measured (1-6)
+
+        Returns:
+            pressure as a float
+        """
+        msg = 'PR%d\r\n' % ch_no
+        self.comm.send(msg.encode())
+        self.comm.recv(BUFF_SIZE).decode()
+        self.comm.send(ENQ.encode())
+        read_str = self.comm.recv(BUFF_SIZE).decode()
+        pressure_str = read_str.split(',')[-1].split('\r')[0]
+        pressure = float(pressure_str)
+        return pressure
+
+    def read_pressure_all(self):
+        """measure the pressure of all channel
+        Return an array of 6 pressure values as a float array
+
+        Args:
+            None
+
+        Returns:
+            6 element array corresponding to each channels
+            pressure reading, as floats
+        """
+        msg = 'PRX\r\n'
+        self.comm.send(msg.encode())
+        # Could use this to catch exemptions, for troubleshooting
+        self.comm.recv(BUFF_SIZE).decode()
+        self.comm.send(ENQ.encode())
+        read_str = self.comm.recv(BUFF_SIZE).decode()
+        pressure_str = read_str.split('\r')[0]
+        gauge_states = pressure_str.split(',')[::2]
+        gauge_states = np.array(gauge_states, dtype=int)
+        pressures = pressure_str.split(',')[1::2]
+        pressures = [float(p) for p in pressures]
+        if any(state != 0 for state in gauge_states):
+            index = np.where(gauge_states != 0)
+            for j in index[0]:
+                pressures[j] = 0.
+        return pressures
+
+    def close(self):
+        """Close the socket of the connection"""
+        self.comm.close()

--- a/socs/agents/pfeiffer_tpg366/drivers.py
+++ b/socs/agents/pfeiffer_tpg366/drivers.py
@@ -1,35 +1,38 @@
 # Original script by Zhilei Xu and Tanay Bhandarkar.
 
-import socket
-
 import numpy as np
+
+from socs.tcp import TCPInterface
 
 BUFF_SIZE = 128
 ENQ = '\x05'
 
 
-class Pfeiffer:
-    """CLASS to control and retrieve data from the pfeiffer tpg366
-    pressure gauge controller
+class TPG366(TCPInterface):
+    """Interface class for connecting to the Pfeiffer TPG366 maxigauge
+    controller.
 
 
-    Args:
-        ip_address: IP address of the deivce
-        porti (int): 8000 (fixed for the device)
+    Parameters
+    ----------
+    ip_address : str
+        IP address of the device.
+    port : int
+        Associated port for TCP communication. Default is 8000.
+    timeout : float
+        Duration in seconds that operations wait before giving up. Default is
+        10 seconds.
 
-    Attributes:
-       read_pressure reads the pressure from one channel (given as an argument)
-       read_pressure_all reads pressures from the six channels
-       close closes the socket
+    Attributes
+    ----------
+    comm : socket.socket
+        Socket object that forms the connection to the compressor.
+
     """
 
-    def __init__(self, ip_address, port, timeout=10,
-                 f_sample=1.):
-        self.ip_address = ip_address
-        self.port = port
-        self.comm = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
-        self.comm.connect((self.ip_address, self.port))
-        self.comm.settimeout(timeout)
+    def __init__(self, ip_address, port=8000, timeout=10):
+        # Setup the TCP Interface
+        super().__init__(ip_address, port, timeout)
 
     def channel_power(self):
         """
@@ -43,10 +46,10 @@ class Pfeiffer:
 
         """
         msg = 'SEN\r\n'
-        self.comm.send(msg.encode())
-        self.comm.recv(BUFF_SIZE).decode()
-        self.comm.send(ENQ.encode())
-        read_str = self.comm.recv(BUFF_SIZE).decode()
+        self.send(msg.encode())
+        self.recv(bufsize=BUFF_SIZE).decode()
+        self.send(ENQ.encode())
+        read_str = self.recv(bufsize=BUFF_SIZE).decode()
         power_str = read_str.split('\r')
         power_states = np.array(power_str[0].split(','), dtype=int)
         if any(chan == 1 for chan in power_states):
@@ -66,10 +69,10 @@ class Pfeiffer:
             pressure as a float
         """
         msg = 'PR%d\r\n' % ch_no
-        self.comm.send(msg.encode())
-        self.comm.recv(BUFF_SIZE).decode()
-        self.comm.send(ENQ.encode())
-        read_str = self.comm.recv(BUFF_SIZE).decode()
+        self.send(msg.encode())
+        self.recv(bufsize=BUFF_SIZE).decode()
+        self.send(ENQ.encode())
+        read_str = self.recv(bufsize=BUFF_SIZE).decode()
         pressure_str = read_str.split(',')[-1].split('\r')[0]
         pressure = float(pressure_str)
         return pressure
@@ -86,11 +89,11 @@ class Pfeiffer:
             pressure reading, as floats
         """
         msg = 'PRX\r\n'
-        self.comm.send(msg.encode())
+        self.send(msg.encode())
         # Could use this to catch exemptions, for troubleshooting
-        self.comm.recv(BUFF_SIZE).decode()
-        self.comm.send(ENQ.encode())
-        read_str = self.comm.recv(BUFF_SIZE).decode()
+        self.recv(bufsize=BUFF_SIZE).decode()
+        self.send(ENQ.encode())
+        read_str = self.recv(bufsize=BUFF_SIZE).decode()
         pressure_str = read_str.split('\r')[0]
         gauge_states = pressure_str.split(',')[::2]
         gauge_states = np.array(gauge_states, dtype=int)
@@ -101,7 +104,3 @@ class Pfeiffer:
             for j in index[0]:
                 pressures[j] = 0.
         return pressures
-
-    def close(self):
-        """Close the socket of the connection"""
-        self.comm.close()

--- a/socs/agents/pfeiffer_tpg366/drivers.py
+++ b/socs/agents/pfeiffer_tpg366/drivers.py
@@ -34,6 +34,14 @@ class TPG366(TCPInterface):
         # Setup the TCP Interface
         super().__init__(ip_address, port, timeout)
 
+        # On boot the TPG366 starts in 'continuous transmission' mode. This
+        # sends a single 'ENQ', which stops transmission.
+        try:
+            self._send_enquiry()
+            print('Startup ENQ response:', self.recv())
+        except ConnectionError as e:
+            print(f'Encountered error connecting to device: {e}')
+
     def _send_mnemonic(self, mnemonic):
         """Send a mnemonic.
 

--- a/socs/agents/pfeiffer_tpg366/drivers.py
+++ b/socs/agents/pfeiffer_tpg366/drivers.py
@@ -63,12 +63,11 @@ class TPG366(TCPInterface):
 
     def channel_power(self):
         """
-        Function to check the power status of all channels.
+        Check the power state of all channels.
 
-        Args:
-            None
-
-        Returns:
+        Returns
+        -------
+        list
             List of channel states.
 
         """
@@ -81,16 +80,18 @@ class TPG366(TCPInterface):
         return channel_states
 
     def read_pressure(self, ch_no):
-        """
-        Function to measure the pressure of one given channel
-        ch_no is the chanel to be measured (e.g. 1-6)
-        returns the measured pressure as a float
+        """Measure the pressure of one given channel.
 
-        Args:
-            ch_no: The channel to be measured (1-6)
+        Parameters
+        ----------
+        ch_no : int
+            The channel to be measured (1-6).
 
-        Returns:
-            pressure as a float
+        Returns
+        -------
+        float
+            Channel pressure.
+
         """
         msg = 'PR%d\r\n' % ch_no
         read_str = self.send_and_recv(msg)
@@ -99,15 +100,14 @@ class TPG366(TCPInterface):
         return pressure
 
     def read_pressure_all(self):
-        """measure the pressure of all channel
-        Return an array of 6 pressure values as a float array
+        """Measure the pressure of all channels.
 
-        Args:
-            None
+        Returns
+        -------
+        np.array
+            Six element array corresponding to each channels pressure reading,
+            as floats.
 
-        Returns:
-            6 element array corresponding to each channels
-            pressure reading, as floats
         """
         msg = 'PRX\r\n'
         read_str = self.send_and_recv(msg)

--- a/socs/agents/pfeiffer_tpg366/drivers.py
+++ b/socs/agents/pfeiffer_tpg366/drivers.py
@@ -57,7 +57,17 @@ class TPG366(TCPInterface):
 
         """
         self.send(mnemonic.encode())
-        resp = self.recv(bufsize=BUFF_SIZE)  # don't decode, might just be ACK
+        resp = self.recv(bufsize=BUFF_SIZE)  # don't decode, expecting ACK
+        # print('Raw response:', resp)  # useful debug print
+
+        # if COM was on we'll get a long string, check just the last message
+        ack = resp.splitlines()[-1].strip()
+
+        if ack != b'\x06':
+            print('WARN: Did not receive ACK. Attempting to drain buffer.')
+            print('Buffer contents:', self.recv())
+            print('Resending command:', mnemonic.encode())
+            self._send_mnemonic(mnemonic)
         return resp
 
     def _send_enquiry(self):

--- a/socs/agents/pfeiffer_tpg366/drivers.py
+++ b/socs/agents/pfeiffer_tpg366/drivers.py
@@ -34,6 +34,33 @@ class TPG366(TCPInterface):
         # Setup the TCP Interface
         super().__init__(ip_address, port, timeout)
 
+    def send_and_recv(self, message):
+        """Send message and request transmission of queried data from device.
+
+        The flow control for querying the TPG366 involves first sending a
+        message to set the measuring mode, receiving positive feedback from the
+        device, then sending a request for transmission from the device,
+        followed finally by receiving the measurement data.
+
+        This method combines these four steps into one.
+
+        Parameters
+        ----------
+        message : str
+            Mnemonic command code message with parameters.
+
+        Returns
+        -------
+        Decoded response from the device.
+
+        """
+        self.send(message.encode())
+        self.recv(bufsize=BUFF_SIZE).decode()
+        self.send(ENQ.encode())
+        read_str = self.recv(bufsize=BUFF_SIZE).decode()
+
+        return read_str
+
     def channel_power(self):
         """
         Function to check the power status of all channels.
@@ -46,10 +73,7 @@ class TPG366(TCPInterface):
 
         """
         msg = 'SEN\r\n'
-        self.send(msg.encode())
-        self.recv(bufsize=BUFF_SIZE).decode()
-        self.send(ENQ.encode())
-        read_str = self.recv(bufsize=BUFF_SIZE).decode()
+        read_str = self.send_and_recv(msg)
         power_str = read_str.split('\r')
         power_states = np.array(power_str[0].split(','), dtype=int)
         if any(chan == 1 for chan in power_states):
@@ -69,10 +93,7 @@ class TPG366(TCPInterface):
             pressure as a float
         """
         msg = 'PR%d\r\n' % ch_no
-        self.send(msg.encode())
-        self.recv(bufsize=BUFF_SIZE).decode()
-        self.send(ENQ.encode())
-        read_str = self.recv(bufsize=BUFF_SIZE).decode()
+        read_str = self.send_and_recv(msg)
         pressure_str = read_str.split(',')[-1].split('\r')[0]
         pressure = float(pressure_str)
         return pressure
@@ -89,11 +110,7 @@ class TPG366(TCPInterface):
             pressure reading, as floats
         """
         msg = 'PRX\r\n'
-        self.send(msg.encode())
-        # Could use this to catch exemptions, for troubleshooting
-        self.recv(bufsize=BUFF_SIZE).decode()
-        self.send(ENQ.encode())
-        read_str = self.recv(bufsize=BUFF_SIZE).decode()
+        read_str = self.send_and_recv(msg)
         pressure_str = read_str.split('\r')[0]
         gauge_states = pressure_str.split(',')[::2]
         gauge_states = np.array(gauge_states, dtype=int)

--- a/socs/agents/pfeiffer_tpg366/drivers.py
+++ b/socs/agents/pfeiffer_tpg366/drivers.py
@@ -34,13 +34,35 @@ class TPG366(TCPInterface):
         # Setup the TCP Interface
         super().__init__(ip_address, port, timeout)
 
+    def _send_mnemonic(self, mnemonic):
+        """Send a mnemonic.
+
+        Parameters
+        ----------
+        mnemonic : str
+            Unencoded mnemonic string, with terminating characters, i.e. 'PRX\r'.
+
+        Returns
+        -------
+        Enocded response from the device. Typically an ACK, unless the device
+        is in a strange state.
+
+        """
+        self.send(mnemonic.encode())
+        resp = self.recv(bufsize=BUFF_SIZE)  # don't decode, might just be ACK
+        return resp
+
+    def _send_enquiry(self):
+        self.send(ENQ.encode())
+
     def send_and_recv(self, message):
         """Send message and request transmission of queried data from device.
 
         The flow control for querying the TPG366 involves first sending a
-        message to set the measuring mode, receiving positive feedback from the
-        device, then sending a request for transmission from the device,
-        followed finally by receiving the measurement data.
+        message (referred to in the TPG366 manual as a mnemonic) to set the
+        measuring mode, receiving positive feedback from the device, then
+        sending a request for transmission from the device, followed finally by
+        receiving the measurement data.
 
         This method combines these four steps into one.
 
@@ -54,9 +76,8 @@ class TPG366(TCPInterface):
         Decoded response from the device.
 
         """
-        self.send(message.encode())
-        self.recv(bufsize=BUFF_SIZE).decode()
-        self.send(ENQ.encode())
+        self._send_mnemonic(message)
+        self._send_enquiry()
         read_str = self.recv(bufsize=BUFF_SIZE).decode()
 
         return read_str


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description
<!--- Describe your changes in detail -->
This PR adds error handling to the Pfeiffer TPG366 agent. I separated the driver class out to its own module, renamed it to something more specific (since we have other Pfeiffer devices), and made it a subclass of `TCPInterface` to enable error handling.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Resolves #1000.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
This has been tested in the following scenarios:

- [x] Test error handling when the device is offline during agent startup
- [x] Test error handling with acq running when network connection is interrupted
- [x] Test error handling with acq running when the device is power cycled

From power off:
```
2026-05-22T17:35:58-0400 startup-op: launching acq
2026-05-22T17:35:58-0400 start called for acq
2026-05-22T17:35:58-0400 acq:0 Status is now "starting".
2026-05-22T17:35:58-0400 acq:0 Status is now "running".
2026-05-22T17:35:58-0400 Connection not established.
2026-05-22T17:35:58-0400 Resetting the connection to the device.
2026-05-22T17:36:08-0400 Connection not established within 10 seconds.
2026-05-22T17:36:08-0400 Failed to get data from device. Check network connection.
2026-05-22T17:36:09-0400 Connection not established.
2026-05-22T17:36:09-0400 Resetting the connection to the device.
2026-05-22T17:36:13-0400 Connection re-established.
```

Through network disconnect:
```
2026-05-22T17:32:31-0400 startup-op: launching acq
2026-05-22T17:32:31-0400 start called for acq
2026-05-22T17:32:31-0400 acq:0 Status is now "starting".
2026-05-22T17:32:31-0400 acq:0 Status is now "running".
2026-05-22T17:32:52-0400 Failed to get data from device. Check network connection.
2026-05-22T17:33:03-0400 Failed to get data from device. Check network connection.
2026-05-22T17:33:08-0400 Caught unexpected error: invalid literal for int() with base 10: '\x06'
2026-05-22T17:33:09-0400 WARN: Did not receive ACK. Attempting to drain buffer.
2026-05-22T17:33:09-0400 Buffer contents: b'\x06\r\n'
2026-05-22T17:33:09-0400 Resending command: b'PRX\r\n'
2026-05-22T17:33:09-0400 Connection re-established.
```

Through power cycle:
```
2026-05-22T17:33:54-0400 Failed to get data from device. Check network connection.
2026-05-22T17:34:05-0400 Failed to get data from device. Check network connection.
2026-05-22T17:34:10-0400 Connection error: [Errno 104] Connection reset by peer
2026-05-22T17:34:10-0400 Failed to get data from device. Check network connection.
2026-05-22T17:34:11-0400 Connection error: [Errno 32] Broken pipe
2026-05-22T17:34:11-0400 Resetting the connection to the device.
2026-05-22T17:34:11-0400 Connection re-established.
```

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
