### PR TITLE
acu: Add minimum stoptime check to PointProvider.stop()

### DIFF
--- a/socs/agents/acu/drivers.py
+++ b/socs/agents/acu/drivers.py
@@ -179,7 +179,12 @@ class PointProvider:
         if free_form:
             # For the stop, stop_time = v0 / max_acceleration
             v0 = final_point.az_vel
-            stoptime = abs(v0) / stop_accel
+
+            # Ensure we always generate at least 5 stop points.
+            # Otherwise if v0 is very small we can generate as little as one point.
+            # Attempting to generate only one point will silently break the _gen_trajectory
+            # function in turnarounds.py and produce unintended results.
+            stoptime = max(0.5, abs(v0) / stop_accel)
 
             # We need to generate a smooth stop based from the last point uploaded.
             # Grab the data from the final point to form a smooth stop from it.


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Forces the stoptime of a generated free_form stop to be 0.5 seconds.

## Description
<!--- Describe your changes in detail -->
Added a check that ensures free_form stop times are always at least 0.5 seconds. This ensures we're always generating at least 5 points for any stop.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
We were seeing some weird intermittent crashes on the SATP1 when running two_leg turnaround scans. These scans would fail on scan stop without any ACU az_position_errors or summary faults being thrown. The failure mode was an error thrown in the ACU agent `_run_track` function when the platform didn't stop within 20 seconds. In reality, the ACU WAS properly stopped, but it never consumed the final point in its track. The agent checks if the number of free_upload_positions == 10,000 to check if the ACU is "done". This meant the agent never saw the platform as "done moving".

I think this was an edge case between the `gen_free_form_stop` function and stopping inside of a turnaround as these failures were rare (~once a week) and seemed to occur after we uploaded a number of turnaround points. I simmed what stops were being generated during turnarounds and it turns out generating a free form stop with a v0 very close to 0 was causing an error because of this line : `stoptime = abs(v0) / az_accel`. 

This line meant that the `stoptime` for v0 ~0 was also near 0. This meant the `_gen_trajectory` function was attempting to generate as little as one point. This caused the PointTracks generated by the `gen_free_form_stop` function to be possible nonsensical. Because v0 ~ 0, I think the ACU was basically already stopped (so it didn't throw any az errors or summary faults) and then refused to follow the last point generated by the stop. So no ACU errors were thrown but the scan never "finished". 

By setting a minimum stop time, we're now forcing the functions to generate at least 5 points. This fixes the `_gen_trajectory` function which now outputs normal trajectories to follow, even when v0 ~ 0.

Here is a PointTrack generated in a turnaround before:
```
[TrackPoint(timestamp=np.float64(28.100000000000023), az=np.float64(-37.46041847972498), el=0, az_vel=np.float64(-4909.312662733779), el_vel=0.0, az_flag=2, el_flag=0, group_flag=1)]
```
and after the change with `stoptime = max(0.5, abs(v0) / stop_accel)`:

```
[TrackPoint(timestamp=np.float64(28.100000000000023), az=np.float64(41.28008422092286), el=0, az_vel=np.float64(0.0016718125000016108), el_vel=0.0, az_flag=2, el_flag=0, group_flag=1),
 TrackPoint(timestamp=np.float64(28.20000000000002), az=np.float64(41.28023127114258), el=0, az_vel=np.float64(0.0012112690429699176), el_vel=0.0, az_flag=2, el_flag=0, group_flag=1),
 TrackPoint(timestamp=np.float64(28.300000000000022), az=np.float64(41.28032000100098), el=0, az_vel=np.float64(0.0005633281250005434), el_vel=0.0, az_flag=2, el_flag=0, group_flag=1),
 TrackPoint(timestamp=np.float64(28.40000000000002), az=np.float64(41.28035041049805), el=0, az_vel=np.float64(0.00010278466796884937), el_vel=0.0, az_flag=2, el_flag=0, group_flag=1),
 TrackPoint(timestamp=np.float64(28.50000000000002), az=np.float64(41.28035316467286), el=0, az_vel=np.float64(0.0), el_vel=0.0, az_flag=2, el_flag=0, group_flag=1)]
```

Now we're no longer generating points with possibly unexactable az velocities.

Another side effect is this fixes a _very_ rare edge case when `v0 == 0`. The current code will actually cause a `LinAlgError` for generating a singular matrix deep in the linear algebra of `_gen_trajectory`. This change will no longer cause this (though it will generate 5 exactly duplicate points with v0 = 0... which is probably ok). 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
I've simmed these changes with some sim scan code but this has not been tested on platform. This will be a difficult edge case to test for specifically as its hard to end scans right in turnarounds, but it can be tested to make sure it doesn't immediately crash from typos at least. 

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
