### PR TITLE
Create additional user/group for suprsync agent

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -14,6 +14,10 @@ RUN useradd -d /home/cryo -M cryo -u 1000 && \
     mkdir /home/cryo && \
     chown cryo:smurf /home/cryo
 
+# Set up user/group for suprsync agent database permission compatability
+RUN groupadd group1002 -g 1002 && \
+    useradd -m user1010 -u 1010 -g 1002
+
 # Install packages
 # suprsync agent - rsync
 # labjack agent - wget, libusb-1.0-0-dev, udev


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
This PR creates a new user/group (`user1010/group1002`) for user with suprsync.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
The suprsync agent needs to interact with an sqlite database that is bind mounted in from the host filesystem, and it needs to SSH to other machines. For SSH to work properly the user needs a home directory.

This change allows the suprsync agent at site to be run with `user: "1010:1002"` to run as the created user and map permissions from the host system into the container correctly.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

This has not been tested with the suprsync agent, just by building the image locally and inspecting the user within a running container:
```
$ docker run -it --rm --entrypoint=/bin/bash socs:user
root@42a04144036a:/# su user1010
$ id
uid=1010(user1010) gid=1002(group1002) groups=1002(group1002)
$ cd
$ pwd
/home/user1010
$ ls -lthra
total 20K
-rw-r--r-- 1 user1010 group1002  807 Jan  6  2022 .profile
-rw-r--r-- 1 user1010 group1002 3.7K Jan  6  2022 .bashrc
-rw-r--r-- 1 user1010 group1002  220 Jan  6  2022 .bash_logout
drwxr-xr-x 1 root     root      4.0K May 26 14:55 ..
drwxr-x--- 2 user1010 group1002 4.0K May 26 14:55 .
```

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
