### PR TITLE
pysmurf-monitor: Enable metadata feed buffer

### DIFF
--- a/socs/agents/pysmurf_monitor/agent.py
+++ b/socs/agents/pysmurf_monitor/agent.py
@@ -150,7 +150,7 @@ class PysmurfMonitor(DatagramProtocol):
             feed_name = f'{stream_id}_meta'
 
             if feed_name not in self.agent.feeds:
-                self.agent.register_feed(feed_name, record=True, buffer_time=0)
+                self.agent.register_feed(feed_name, record=True, buffer_time=1)
 
             feed_data = {'block_name': field_name,
                          'timestamp': data['time'],


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
This PR enables the feed buffer for the pysmurf-monitor metadata feed(s).

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
This prevents the feed from publishing immediately, instead publishing 1/sec, which should reduce the load on the crossbar server. This is publishing around 150-200/sec in practice otherwise.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
I've tested this change while publishing as fast as I possibly can from a single thread on my laptop. The crossbar server CPU usage drops from essentially full (100%) usage to <1%.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
