### PR TITLE
hwp-supervisor: Add option to disable shutdown

### DIFF
--- a/socs/agents/hwp_supervisor/agent.py
+++ b/socs/agents/hwp_supervisor/agent.py
@@ -1682,6 +1682,8 @@ class HWPSupervisor:
             session.data['actions'] = {
                 'pmx': self.hwp_state.pmx_action,
                 'gripper': self.hwp_state.gripper_action,
+                'shutdown_mode': self.shutdown_mode,
+                'shutdown_enabled': self.shutdown_enabled,
             }
 
             action = self.hwp_state.pmx_action
@@ -2168,7 +2170,7 @@ class HWPSupervisor:
         if params['enable'] is not None:
             self.shutdown_enabled = params['enable']
 
-        return True, 'Params updated.'
+        return True, f'Shutdown parameters updated: {self.shutdown_enabled}'
 
     def cancel_shutdown(self, session, params):
         """cancel_shutdown()

--- a/socs/agents/hwp_supervisor/agent.py
+++ b/socs/agents/hwp_supervisor/agent.py
@@ -1521,6 +1521,7 @@ class HWPSupervisor:
         self.shutdown_no_data_timeout = args.shutdown_no_data_timeout
         self.shutdown_delay = args.shutdown_delay
         self.shutdown_mode = False
+        self.shutdown_enabled = not args.disable_shutdown
 
         self.agent.register_feed('actions', record=True)
 
@@ -1686,13 +1687,14 @@ class HWPSupervisor:
             action = self.hwp_state.pmx_action
             if action == 'ok':
                 last_okay_time = time.time()
-            elif action == 'no_data' and self.shutdown_no_data_timeout >= 0:
+            elif self.shutdown_enabled and action == 'no_data' \
+                    and self.shutdown_no_data_timeout >= 0:
                 if (time.time() - last_okay_time) > \
                         self.shutdown_no_data_timeout + self.shutdown_delay:
                     if not self.shutdown_mode:
                         self.agent.start('disable_driver_board', params={})
                         self.shutdown_mode = True
-            elif action == 'stop':
+            elif self.shutdown_enabled and action == 'stop':
                 if (time.time() - last_okay_time) > self.shutdown_delay:
                     if not self.shutdown_mode:
                         self.agent.start('disable_driver_board', params={})
@@ -2150,6 +2152,24 @@ class HWPSupervisor:
         action.sleep_until_complete(session=session)
         return action.success, f"Completed with state: {action.cur_state_info.state}"
 
+    @ocs_agent.param('enable', type=bool, default=None)
+    def update_shutdown(self, session, params):
+        """update_shutdown(enable=None)
+
+        **Task** - Update HWP shutdown parameters.
+
+        All arguments are optional.
+
+        Args:
+          enable (bool): If True, enable HWP shutdown checks.
+          If False, disable HWP shutdown non-temporarily.
+
+        """
+        if params['enable'] is not None:
+            self.shutdown_enabled = params['enable']
+
+        return True, 'Params updated.'
+
     def cancel_shutdown(self, session, params):
         """cancel_shutdown()
         **Task** - Cancels shutdown mode
@@ -2291,6 +2311,10 @@ def make_parser(parser=None):
         help="Voltage to use when braking the HWP",
     )
     pgroup.add_argument(
+        '--disable-shutdown', action='store_true',
+        help="Disable shutdown before startup.",
+    )
+    pgroup.add_argument(
         '--shutdown-no-data-timeout', type=float, default=15 * 60,
         help="Time(sec) after which a 'no_data' action should trigger a shutdown"
     )
@@ -2326,6 +2350,7 @@ def main(args=None):
     agent.register_task('disable_driver_board', hwp.disable_driver_board)
     agent.register_task('power_cycle_gripper', hwp.power_cycle_gripper)
     agent.register_task('abort_action', hwp.abort_action)
+    agent.register_task('update_shutdown', hwp.update_shutdown)
     agent.register_task('cancel_shutdown', hwp.cancel_shutdown)
 
     runner.run(agent, auto_reconnect=True)

--- a/socs/agents/hwp_supervisor/agent.py
+++ b/socs/agents/hwp_supervisor/agent.py
@@ -2170,7 +2170,7 @@ class HWPSupervisor:
         """
         if params['enable'] is not None:
             self.shutdown_enabled = params['enable']
-            self.log(f'Shutdown {"enabled" if self.shutdown_enabled else "disabled"}')
+            self.log.info(f'Shutdown {"enabled" if self.shutdown_enabled else "disabled"}')
 
         return True, 'Params updated.'
 

--- a/socs/agents/hwp_supervisor/agent.py
+++ b/socs/agents/hwp_supervisor/agent.py
@@ -2203,11 +2203,13 @@ class HWPSupervisor:
 
         **Task** - Update HWP shutdown parameters.
 
-        All arguments are optional.
-
-        Args:
-          enable (bool): If True, enable HWP shutdown checks.
-          If False, disable HWP shutdown non-temporarily.
+        Args
+        -------
+        enable : bool
+            If True, enable HWP shutdown checks. If False, disables the
+            shutdown checks until re-enabled or the agent is restarted.
+            This will not revert the shutdown mode to normal if the agent is
+            already in the shutdown mode. Use cancel_shutdown to do so.
 
         """
         if params['enable'] is not None:

--- a/socs/agents/hwp_supervisor/agent.py
+++ b/socs/agents/hwp_supervisor/agent.py
@@ -1654,6 +1654,8 @@ class HWPSupervisor:
                 'actions': {
                     'pmx': 'ok'  # 'ok', 'stop', or 'no_data'
                     'gripper': 'ok'  # 'ok', 'stop', or 'no_data'
+                    'shutdown_mode': False,
+                    'shutdown_enabled': True,
                 }}
         """
         pm = Pacemaker(1. / self.sleep_time)
@@ -1667,6 +1669,8 @@ class HWPSupervisor:
             'actions': {
                 'pmx': 'no_data',
                 'gripper': 'no_data',
+                'shutdown_mode': self.shutdown_mode,
+                'shutdown_enabled': self.shutdown_enabled,
             }
         }
 

--- a/socs/agents/hwp_supervisor/agent.py
+++ b/socs/agents/hwp_supervisor/agent.py
@@ -1709,6 +1709,7 @@ class HWPSupervisor:
                     'pmx_action': self.hwp_state.pmx_action,
                     'gripper_action': self.hwp_state.gripper_action,
                     'shutdown_mode': int(self.shutdown_mode),
+                    'shutdown_enabled': int(self.shutdown_enabled),
                 },
             }
             self.agent.publish_to_feed('actions', data)
@@ -2169,8 +2170,9 @@ class HWPSupervisor:
         """
         if params['enable'] is not None:
             self.shutdown_enabled = params['enable']
+            self.log(f'Shutdown {"enabled" if self.shutdown_enabled else "disabled"}')
 
-        return True, f'Shutdown parameters updated: {self.shutdown_enabled}'
+        return True, 'Params updated.'
 
     def cancel_shutdown(self, session, params):
         """cancel_shutdown()


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Added a option to disable shutdown on startup
Added a task to disable and re-enable shutdown non-temporarily.

## Motivation and Context
Having these option is helpful for hwp expert to operate in irregular state.
For example, sometimes lakeshore or ups could have communication issue and we cannot monitor YBCO temperature or ups state, but hwp could be safe to operate.

## How Has This Been Tested?
Tested at satp3 on June 9th 2026.
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
