### PR TITLE
hwp-gripper: Add option to disable spin check

### DIFF
--- a/socs/agents/hwp_gripper/agent.py
+++ b/socs/agents/hwp_gripper/agent.py
@@ -730,7 +730,7 @@ class HWPGripperAgent:
             duration = params['disable_temporarily']
             self.spin_check_disable_until = time.time() + duration
             self.log.info(f'Spin check disabled temporarily for {duration:.0f} seconds '
-                          f'(until {self.check_disable_until}).')
+                          f'(until {self.spin_check_disable_until}).')
 
         return True, 'Params updated.'
 

--- a/socs/agents/hwp_gripper/agent.py
+++ b/socs/agents/hwp_gripper/agent.py
@@ -40,7 +40,7 @@ class HWPGripperAgent:
         self.supervisor_id = args.supervisor_id
         self.freq_tol = args.freq_tol
         self.spin_check_enabled = True
-        self.spin_check_disable_until = 0
+        self.spin_check_disable_until = 0.
 
         self.client: Optional[cli.GripperClient] = None
 
@@ -881,7 +881,9 @@ class HWPGripperAgent:
                 >>> response.session
                 {'time': 1649085992.719602,
                  'gripper_action': 'ok',
-                 'shutdown_mode': 0}
+                 'shutdown_mode': 0,
+                 'spin_check_enabled': 1,
+                 'spin_check_disable_until': 1649086292.719602}
         """
         last_ok_time = time.time()
 

--- a/socs/agents/hwp_gripper/agent.py
+++ b/socs/agents/hwp_gripper/agent.py
@@ -725,8 +725,12 @@ class HWPGripperAgent:
         """
         if params['enable'] is not None:
             self.spin_check_enabled = params['enable']
+            self.log.info(f'Spin check {"enabled" if self.spin_check_enabled else "disabled"}.')
         if params['disable_temporarily'] is not None:
-            self.spin_check_disable_until = time.time() + params['disable_temporarily']
+            duration = params['disable_temporarily']
+            self.spin_check_disable_until = time.time() + duration
+            self.log.info(f'Spin check disabled temporarily for {duration:.0f} seconds '
+                          f'(until {self.check_disable_until}).')
 
         return True, 'Params updated.'
 
@@ -921,6 +925,8 @@ class HWPGripperAgent:
                 'data': {
                     'gripper_action': action,
                     'shutdown_mode': int(self.shutdown_mode),
+                    'spin_check_enabled': int(self.spin_check_enabled),
+                    'spin_check_disable_until': self.spin_check_disable_until,
                 },
                 'block_name': 'gripper_action',
                 'timestamp': time.time()
@@ -929,7 +935,9 @@ class HWPGripperAgent:
             self.agent.publish_to_feed('gripper_action', data)
             session.data = {
                 'gripper_action': action,
-                'shutdown_mode': int(self.shutdown_mode),
+                'shutdown_mode': self.shutdown_mode,
+                'spin_check_enabled': self.spin_check_enabled,
+                'spin_check_disable_until': self.spin_check_disable_until,
                 'time': time.time()
             }
 

--- a/socs/agents/hwp_gripper/agent.py
+++ b/socs/agents/hwp_gripper/agent.py
@@ -709,9 +709,9 @@ class HWPGripperAgent:
         return True, 'Cancelled shutdown mode'
 
     @ocs_agent.param('enable', type=bool, default=None)
-    @ocs_agent.param('disable_temporarily', type=float, default=None)
+    @ocs_agent.param('disable_duration', type=float, default=None)
     def update_spin_check(self, session, params=None):
-        """update_spin_check(enable=None)
+        """update_spin_check(enable=None, disable_duration=None)
 
         **Task** - Update HWP spin check parameters.
 
@@ -719,15 +719,15 @@ class HWPGripperAgent:
 
         Args:
           enable (bool): If True, enable HWP spin checks.
-            If False, disable HWP spin checks non-temporarily.
-          disable_temporarily (float):  If set, disable
+            If False, disable HWP spin checks until re-enabled or the agent is restarted.
+          disable_duration (float): A time in seconds. If set, disable
             HWP spin check for this number of seconds.
         """
         if params['enable'] is not None:
             self.spin_check_enabled = params['enable']
             self.log.info(f'Spin check {"enabled" if self.spin_check_enabled else "disabled"}.')
-        if params['disable_temporarily'] is not None:
-            duration = params['disable_temporarily']
+        if params['disable_duration'] is not None:
+            duration = params['disable_duration']
             self.spin_check_disable_until = time.time() + duration
             self.log.info(f'Spin check disabled temporarily for {duration:.0f} seconds '
                           f'(until {self.spin_check_disable_until}).')

--- a/socs/agents/hwp_gripper/agent.py
+++ b/socs/agents/hwp_gripper/agent.py
@@ -38,6 +38,9 @@ class HWPGripperAgent:
 
         self.shutdown_mode = False
         self.supervisor_id = args.supervisor_id
+        self.freq_tol = args.freq_tol
+        self.spin_check_enabled = True
+        self.spin_check_disable_until = 0
 
         self.client: Optional[cli.GripperClient] = None
 
@@ -99,7 +102,11 @@ class HWPGripperAgent:
         return res['data']['hwp_state']['pid_current_freq']
 
     def _check_stopped(self):
-        return self._get_hwp_freq() < 0.1
+        if self.spin_check_enabled and (time.time() > self.spin_check_disable_until):
+            return self._get_hwp_freq() < self.freq_tol
+        else:
+            self.log.info("Spin check is disabled.")
+            return True
 
     def init_connection(self, session, params):
         """init_connection()
@@ -211,7 +218,7 @@ class HWPGripperAgent:
                          "MOVE in Gripper.MOVE() completed successfully"]}
         """
 
-        if self._get_hwp_freq() > 0.1:
+        if not self._check_stopped():
             self.log.warn("Not moving actuators while HWP is spinning")
             return False, "HWP is spinning, not moving actuators"
 
@@ -447,7 +454,7 @@ class HWPGripperAgent:
                                     ..
                  {'result': True, 'log': [.., .., etc]}]
         """
-        if self._get_hwp_freq() > 0.1:
+        if not self._check_stopped():
             return False, "Not gripping HWP because HWP is spinning"
 
         result, session.data = self._grip_hwp(check_shutdown=True)
@@ -701,6 +708,28 @@ class HWPGripperAgent:
         self.shutdown_mode = False
         return True, 'Cancelled shutdown mode'
 
+    @ocs_agent.param('enable', type=bool, default=None)
+    @ocs_agent.param('disable_temporarily', type=float, default=None)
+    def update_spin_check(self, session, params=None):
+        """update_spin_check(enable=None)
+
+        **Task** - Update HWP spin check parameters.
+
+        All arguments are optional.
+
+        Args:
+          enable (bool): If True, enable HWP spin checks.
+            If False, disable HWP spin checks non-temporarily.
+          disable_temporarily (float):  If set, disable
+            HWP spin check for this number of seconds.
+        """
+        if params['enable'] is not None:
+            self.spin_check_enabled = params['enable']
+        if params['disable_temporarily'] is not None:
+            self.spin_check_disable_until = time.time() + params['disable_temporarily']
+
+        return True, 'Params updated.'
+
     def restart(self, session, params=None):
         """restart()
 
@@ -931,6 +960,8 @@ def make_parser(parser=None):
                              'limit switches (mm). This needs to be multiple of 0.1')
     pgroup.add_argument('--supervisor-id', type=str,
                         help='Instance ID for HWP Supervisor agent')
+    pgroup.add_argument('--freq-tol', type=float, default=0.1,
+                        help='Tolerance of frequency to consider hwp is stopped in Hz')
     pgroup.add_argument('--no-data-warn-time', type=float, default=60,
                         help='Time (seconds) since last supervisor-ok signal to '
                              'wait before issuing a warning')
@@ -972,6 +1003,7 @@ def main(args=None):
     agent.register_task('ungrip', gripper_agent.ungrip)
     agent.register_task('cancel_shutdown', gripper_agent.cancel_shutdown)
     agent.register_task('restart', gripper_agent.restart)
+    agent.register_task('update_spin_check', gripper_agent.update_spin_check)
 
     runner.run(agent, auto_reconnect=True)
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Added a task to disable spin check temporarily and non-temporarily.
Made frequency tolerance for spin check configurable.

## Motivation and Context
THis is helpful for hwp expert to operate gripper in irregular state.
Currently hwp-pid controller must be working for gripper hwp using agent.

## How Has This Been Tested?
Tested at satp3 on June 9th.
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
