### PR TITLE
Remove pysmurf-slac as direct dependency

### DIFF
--- a/docs/agents/pysmurf-controller.rst
+++ b/docs/agents/pysmurf-controller.rst
@@ -21,7 +21,6 @@ Dependencies
 
 The pysmurf controller requires the following packages:
 
-    - `pysmurf <https://github.com/slaclab/pysmurf>`_
     - `sodetlib <https://github.com/simonsobs/sodetlib>`_
     - `sotodlib <https://github.com/simonsobs/sotodlib>`_
 
@@ -29,7 +28,6 @@ These can be installed via pip:
 
 .. code-block:: bash
 
-    $ python -m pip install 'pysmurf-slac @ git+https://github.com/slaclab/pysmurf.git@main'
     $ python -m pip install 'sodetlib @ git+https://github.com/simonsobs/sodetlib.git@master'
     $ python -m pip install 'sotodlib @ git+https://github.com/simonsobs/sotodlib.git@master'
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -92,7 +92,6 @@ pfeiffer = [
 # Pysmurf Controller Agent
 pysmurf = [
     "pyepics",
-    # "pysmurf-slac @ git+https://github.com/slaclab/pysmurf.git@main",
     # "sodetlib @ git+https://github.com/simonsobs/sodetlib.git@master",
     # "sotodlib @ git+https://github.com/simonsobs/sotodlib.git@master",
 ]

--- a/requirements.txt
+++ b/requirements.txt
@@ -42,7 +42,6 @@ pfeiffer-vacuum-protocol==0.4
 
 # pysmurf controller
 pyepics
-pysmurf-slac @ git+https://github.com/slaclab/pysmurf.git@main
 sodetlib @ git+https://github.com/simonsobs/sodetlib.git@master
 # pin to just before 3.8 support dropped
 sotodlib @ git+https://github.com/simonsobs/sotodlib.git@5d613d5915b1716c401abecb5446088bce5fc1a4


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
This PR removes `pysmurf-slac` as a direct dependency in `socs`.

We need https://github.com/simonsobs/sodetlib/pull/510 to be merged before this, so that we don't upgrade to the Rogue 6 version of pysmurf.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
We've been slowly moving in this direction once we got `pysmurf` onto PyPI. I was waiting for things to settle out in the Rogue 6 install. 

pysmurf [recently set a version requirement](https://github.com/slaclab/pysmurf/pull/1010) of Python >= 3.10 [1], so we need to install a compatible version from PyPI. (Pinning the required version in https://github.com/simonsobs/sodetlib/pull/510.)

The base Docker images install `pysmurf` already, and the dependency really lies in `sodetlib`, so we'll rely on those installing it properly, rather than also list it here.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
Built in the CI. Not tested with any system yet.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
