### PR TITLE
pysmurf-controller: Update sodetlib version to v0.6.7

### DIFF
--- a/docker/pysmurf_controller/Dockerfile
+++ b/docker/pysmurf_controller/Dockerfile
@@ -4,7 +4,7 @@ FROM simonsobs/so_smurf_base:v0.0.9
 # sodetlib Install
 #################################################################
 WORKDIR /
-RUN git clone --branch v0.6.6 --depth 1 https://github.com/simonsobs/sodetlib.git
+RUN git clone --branch v0.6.7 --depth 1 https://github.com/simonsobs/sodetlib.git
 # allow versioneer to determine sodetlib version safely
 USER cryo
 RUN git config --global --add safe.directory /sodetlib


### PR DESCRIPTION
Updates sodetlib repo release tag to v0.6.7, which publishes a change to retry amplifier biasing. This is often needed during `uxm_relock` after hammering.