### PR TITLE
Pin setuptools-scm version in ocs-pysmurf-agent build

### DIFF
--- a/docker/pysmurf_controller/Dockerfile
+++ b/docker/pysmurf_controller/Dockerfile
@@ -13,6 +13,8 @@ WORKDIR /sodetlib
 RUN pip3 install -U pip
 RUN pip3 install -e .
 RUN pip3 install -r requirements.txt
+# Pin version until base image is on a more modern Python version
+RUN pip3 install setuptools-scm==9.2.2
 
 ENV OCS_CONFIG_DIR=/config
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
This pins the `setuptools-scm` version in the pysmurf controller Docker image build to a working version.

On the more modern Python version in the new rogue 6 testing images this works fine without the pin. So we'll pin this until we're officially on that build.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
The [new v10.2.0 release](https://github.com/pypa/setuptools-scm/releases/tag/setuptools-scm-v10.2.0) of `setuptools-scm` re-enabled support for Python 3.8 and 3.9, but that broke our builds.

Without the pin `socs` fails to install:
```
$ docker build -t pysmurf-controller:test .
[+] Building 4.7s (11/12)                                                                                                                                                                            docker:default
 => [internal] load build definition from Dockerfile                                                                                                                                                           0.0s
 => => transferring dockerfile: 779B                                                                                                                                                                           0.0s
 => [internal] load metadata for docker.io/simonsobs/so_smurf_base:v0.0.9                                                                                                                                      0.0s
 => [internal] load .dockerignore                                                                                                                                                                              0.0s
 => => transferring context: 2B                                                                                                                                                                                0.0s
 => [ 1/10] FROM docker.io/simonsobs/so_smurf_base:v0.0.9                                                                                                                                                      0.0s
 => CACHED [ 2/10] RUN git clone --branch v0.6.7 --depth 1 https://github.com/simonsobs/sodetlib.git                                                                                                           0.0s
 => CACHED [ 3/10] RUN git config --global --add safe.directory /sodetlib                                                                                                                                      0.0s
 => CACHED [ 4/10] WORKDIR /sodetlib                                                                                                                                                                           0.0s
 => CACHED [ 5/10] RUN pip3 install -U pip                                                                                                                                                                     0.0s
 => CACHED [ 6/10] RUN pip3 install -e .                                                                                                                                                                       0.0s
 => CACHED [ 7/10] RUN pip3 install -r requirements.txt                                                                                                                                                        0.0s
 => ERROR [ 8/10] RUN python3 -m pip install git+https://github.com/simonsobs/socs.git@main                                                                                                                    4.6s
------
 > [ 8/10] RUN python3 -m pip install git+https://github.com/simonsobs/socs.git@main:
0.394 Collecting git+https://github.com/simonsobs/socs.git@main
0.394   Cloning https://github.com/simonsobs/socs.git (to revision main) to /tmp/pip-req-build-omq5l6p8
0.410   Running command git clone --filter=blob:none --quiet https://github.com/simonsobs/socs.git /tmp/pip-req-build-omq5l6p8
1.732   Resolved https://github.com/simonsobs/socs.git to commit f3bb97692ecfdbef9a2150b715f78e56839edd25
1.742   Installing build dependencies: started
3.563   Installing build dependencies: finished with status 'done'
3.564   Getting requirements to build wheel: started
3.623   Getting requirements to build wheel: finished with status 'done'
3.624   Preparing metadata (pyproject.toml): started
3.849   Preparing metadata (pyproject.toml): finished with status 'done'
4.032 Collecting autobahn[serialization] (from socs==0.6.2.post1.dev5+gf3bb97692)
4.140   Downloading autobahn-23.1.2.tar.gz (480 kB)
4.313   Preparing metadata (setup.py): started
4.558   Preparing metadata (setup.py): finished with status 'error'
4.562   error: subprocess-exited-with-error
4.562
4.562   × python setup.py egg_info did not run successfully.
4.562   │ exit code: 1
4.562   ╰─> [24 lines of output]
4.562       Traceback (most recent call last):
4.562         File "<string>", line 2, in <module>
4.562         File "<pip-setuptools-caller>", line 34, in <module>
4.562         File "/tmp/pip-install-gxvedzq4/autobahn_790d70a6da6644c78603e9d97bf4ad4e/setup.py", line 253, in <module>
4.562           setup(
4.562         File "/usr/lib/python3/dist-packages/setuptools/__init__.py", line 143, in setup
4.562           _install_setup_requires(attrs)
4.562         File "/usr/lib/python3/dist-packages/setuptools/__init__.py", line 131, in _install_setup_requires
4.562           dist = distutils.core.Distribution(dict(
4.562         File "/usr/lib/python3/dist-packages/setuptools/dist.py", line 447, in __init__
4.562           _Distribution.__init__(self, {
4.562         File "/usr/lib/python3.8/distutils/dist.py", line 292, in __init__
4.562           self.finalize_options()
4.562         File "/usr/lib/python3/dist-packages/setuptools/dist.py", line 740, in finalize_options
4.562           ep.load()(self)
4.562         File "/usr/lib/python3/dist-packages/pkg_resources/__init__.py", line 2445, in load
4.562           return self.resolve()
4.562         File "/usr/lib/python3/dist-packages/pkg_resources/__init__.py", line 2451, in resolve
4.562           module = __import__(self.module_name, fromlist=['__name__'], level=0)
4.562         File "/usr/local/lib/python3.8/dist-packages/setuptools_scm/_integration/setuptools.py", line 24, in <module>
4.562           from .version_inference import GetVersionInferenceConfig
4.562         File "/usr/local/lib/python3.8/dist-packages/setuptools_scm/_integration/version_inference.py", line 17, in <module>
4.562           from setuptools import sic as setuptools_sic
4.562       ImportError: cannot import name 'sic' from 'setuptools' (/usr/lib/python3/dist-packages/setuptools/__init__.py)
4.562       [end of output]
4.562
4.562   note: This error originates from a subprocess, and is likely not a problem with pip.
4.564 error: metadata-generation-failed
4.564
4.564 × Encountered error while generating package metadata.
4.564 ╰─> See above for output.
4.564
4.564 note: This is an issue with the package mentioned above, not pip.
4.564 hint: See above for details.
------
Dockerfile:22
--------------------
  20 |
  21 |     # SOCS installation
  22 | >>> RUN python3 -m pip install git+https://github.com/simonsobs/socs.git@main
  23 |
  24 |     RUN python3 -m pip install dumb-init
--------------------
ERROR: failed to build: failed to solve: process "/bin/sh -c python3 -m pip install git+https://github.com/simonsobs/socs.git@main" did not complete successfully: exit code: 1
```

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
The image has been built successfully locally.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
