### PR TITLE
wg-actuator: Increase initial movement distance to 10 mm

### DIFF
--- a/socs/agents/wiregrid_actuator/agent.py
+++ b/socs/agents/wiregrid_actuator/agent.py
@@ -176,7 +176,7 @@ class WiregridActuatorAgent:
                 return False, msg
 
         # Initial slow & small moving
-        ret, msg, LSonoff = move_func(5, speedrate=0.2)
+        ret, msg, LSonoff = move_func(10, speedrate=0.2)
         # Check the status of the initial moving
         if not ret:
             msg = '_insert_eject()[{}]: ERROR!: in the initail moving | {} '\


### PR DESCRIPTION

Increase the initial movement distance from 5 to 10 mm to avoid failure after the initial movement due to the limit switch not turning off after the movement.

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Increase the initial movement distance from 5 to 10 mm in `wiregrid_actuator`.
## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
I did not test it. But it is a very small change, which should not have any issues.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
