### PR TITLE
PysmurfController: fix uxm_setup arg bug and default to modify_attens…

### DIFF
--- a/socs/agents/pysmurf_controller/agent.py
+++ b/socs/agents/pysmurf_controller/agent.py
@@ -486,7 +486,7 @@ class PysmurfController:
 
     @ocs_agent.param('bands', default=None)
     @ocs_agent.param('kwargs', default=None)
-    @ocs_agent.param('run_in_main_procsess', default=False)
+    @ocs_agent.param('run_in_main_process', default=False)
     def uxm_setup(self, session, params):
         """uxm_setup(bands=None, kwargs=None, run_in_main_process=False)
 
@@ -505,6 +505,12 @@ class PysmurfController:
         <https://simons1.princeton.edu/docs/sodetlib/operations/setup.html#first-time-setup>`_
         for more information on the sodetlib setup procedure and allowed
         keyword arguments.
+
+        Note that (possibly) in contrast to sodetlib's uxm_setup function, the
+        following defaults are passed through, by this function:
+
+        - ``modify_attens=False``
+
 
         Args
         -----
@@ -542,9 +548,15 @@ class PysmurfController:
                    'band_medians': List of median white noise for each band
                 }
             }
+
         """
-        if params['kwargs'] is None:
-            params['kwargs'] = {}
+        # Defaults -- overrides some undesireable behaviors of
+        # sodetlib/pysmurf.  If these are changed, update docstring.
+        kwargs = {
+            'modify_attens': False,
+        }
+        if params['kwargs'] is not None:
+            kwargs.update(params['kwargs'])
 
         with self.lock.acquire_timeout(0, job='uxm_setup') as acquired:
             if not acquired:
@@ -552,7 +564,7 @@ class PysmurfController:
 
             cfg = RunCfg(
                 func_name='run_uxm_setup',
-                kwargs={'bands': params['bands'], 'kwargs': params['kwargs']},
+                kwargs={'bands': params['bands'], 'kwargs': kwargs},
                 run_in_main_process=params['run_in_main_process'],
             )
             result = run_smurf_func(cfg)


### PR DESCRIPTION
## Description

In uxm_setup:

1. Typo bugfix.  Probably was broken.
2. Set a default value for modify_attens.  This is rarely needed.


## Motivation and Context

Running uxm_setup through OCS is desirable because then we can more easily enforce that PysmurfMonitor is running.  That's beyond the scope of this PR but here we at least help make it possible to do so.

Resolves #1098.

## How Has This Been Tested?

Untested, but unlikely to make anything worse than it was before.  And there's some chance it will work.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
